### PR TITLE
Guard assigning BLAS and LAPACK to the Trilinos build if MKL is found

### DIFF
--- a/tpl/CMakeLists.txt
+++ b/tpl/CMakeLists.txt
@@ -4,7 +4,7 @@
 # \author    J. Bakosi
 # \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
 # \brief     Build quinoa third-party Libraries
-# \date      Mon 28 Nov 2016 09:40:11 AM MST
+# \date      Fri 02 Dec 2016 07:45:06 AM MST
 #
 ################################################################################
 
@@ -510,12 +510,13 @@ if (MKL_FOUND)
   if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(TRILINOS_MKL "-DTPL_ENABLE_MKL=ON;-DMKL_LIBRARY_DIRS=$ENV{MKLROOT}/lib;-DMKL_INCLUDE_DIRS=$ENV{MKLROOT}/include;-DTPL_BLAS_LIBRARIES=${MKL_LIBS};-DTPL_LAPACK_LIBRARIES=${MKL_LIBS}")
   endif()
-endif()
-if(NOT blas)
-  set(TRILINOS_BLAS -DTPL_BLAS_LIBRARIES=${BLAS_LIBRARIES})
-endif()
-if(NOT lapack)
-  set(TRILINOS_LAPACK -DTPL_LAPACK_LIBRARIES=${LAPACK_LIBRARIES})
+else()
+  if(BLAS_FOUND)
+    set(TRILINOS_BLAS -DTPL_BLAS_LIBRARIES=${BLAS_LIBRARIES})
+  endif()
+  if(LAPACKE_FOUND)
+    set(TRILINOS_LAPACK -DTPL_LAPACK_LIBRARIES=${LAPACK_LIBRARIES})
+  endif()
 endif()
 ExternalProject_Add(
   trilinos


### PR DESCRIPTION
Otherwise if both MKL and BLAS/LAPACK are given trilinos gets confused.

When building trilinos and when MKL is available, the cmake arguments
`-DTPL_BLAS_LIBRARIES` and `-DTPL_LAPACK_LIBRARIES` confuse the trilinos build,
probably because there are the same arguments coming from the fact that MKL is
found -- this is just above the additions of 1c527a1.

This is an attempt to fix that by guarding the setting of `TRILINOS_BLAS` and `TRILINOS_LAPACK` in the `else`-part of `MKL_FOUND`. This fix works on my CI machines but I can't test gentoo yet.

Christoph: can you test this?