### PR TITLE
Resolved Issue #55

### DIFF
--- a/src/Base/ExceptionMPI.h
+++ b/src/Base/ExceptionMPI.h
@@ -47,6 +47,7 @@ namespace tk {
 //!    executed on multiple MPI ranks. Within asynchrounous Charm++ chares, the
 //!    simpler ErrChk macro suffices.
 //! \author J. Bakosi
+#ifdef QUINOA_CONFIG_MPI_ENABLED
 #define ErrChkMPI(expr, ...) \
 { \
   int err = (expr) ? 0 : 1; \
@@ -54,6 +55,13 @@ namespace tk {
   MPI_Allreduce( &err, &globalerr, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD ); \
   if ( globalerr ) Throw( __VA_ARGS__); \
 }
+#else
+#define ErrChkMPI(expr, ...)\
+{\
+  int QUINOA_ErrChkMPI_err = (expr) ? 0 : 1; \
+  if ( QUINOA_ErrChkMPI_err ) Throw( __VA_ARGS__); \
+}
+#endif
 
 } // tk::
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,11 @@ get_mpi_compilers()
 set(COMPILER ${UNDERLYING_CXX_COMPILER})
 set(MPI_COMPILER ${MPI_CXX_COMPILER})
 
+# If we have met the mandatory MPI dependency, add a definition
+if(${MPI_CXX_FOUND})
+  add_definitions(-DQUINOA_CONFIG_MPI_ENABLED)
+endif(${MPI_CXX_FOUND})
+
 # Mac OS X specifics
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 


### PR DESCRIPTION
Removed MPI Dependency from MPI Error Checker in the event that mandatory MPI dependency is not satisfied