### PR TITLE
fix endian.h collision with glibc

### DIFF
--- a/src/Base/QEndian.h
+++ b/src/Base/QEndian.h
@@ -1,6 +1,6 @@
 // *****************************************************************************
 /*!
-  \file      src/Control/Endian.h
+  \file      src/Base/QEndian.h
   \author    J. Bakosi
   \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
   \brief     Swap endianness
@@ -8,8 +8,8 @@
              http://stackoverflow.com/a/3522853.
 */
 // *****************************************************************************
-#ifndef Endian_h
-#define Endian_h
+#ifndef QEndian_h
+#define QEndian_h
 
 #include <climits>
 
@@ -62,4 +62,4 @@ double swap_endian( double u ) {
 
 } // ::tk
 
-#endif // Endian_h
+#endif // QEndian_h

--- a/src/IO/GmshMeshReader.C
+++ b/src/IO/GmshMeshReader.C
@@ -19,7 +19,7 @@
 #include <vector>
 #include <iostream>     // NOT NEEDED
 
-#include "Endian.h"
+#include "QEndian.h"
 #include "UnsMesh.h"
 #include "GmshMeshReader.h"
 #include "Reorder.h"


### PR DESCRIPTION
glibc comes with an endian.h as well. And on case insensitve file-
systems this might ge picked up, so rename ours.