### PR TITLE
Re-enable clang builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,6 @@ matrix:
   - env: DISTRO=alpine SONARQUBE=ON COVERAGE=ON RUNNER_ARGS="-mca plm isolated"
     compiler: clang
 
-matrix:
-  allow_failures:
-  - compiler: clang
-
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Thanks, @junghans, for putting in the clang path! (Let's merge this to `master`, then will merge to `develop` as well.)