### PR TITLE
Duplicate linksys signal fix

### DIFF
--- a/src/LinSys/LinSysMerger.h
+++ b/src/LinSys/LinSysMerger.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/LinSys/LinSysMerger.h
-  \author    J. Bakosi
+  \author    Los Alamos National Laboratory
   \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
   \brief     Charm++ chare linear system merger group to solve a linear system
   \details   Charm++ chare linear system merger group used to collect and
@@ -218,7 +218,7 @@ extern CkReduction::reducerType DiagMerger;
 //!   group's elements are used to collect information from all chare objects
 //!   that happen to be on a given PE. See also the Charm++ interface file
 //!   linsysmerger.ci.
-//! \author J. Bakosi
+//! \author Los Alamos National Laboratory
 template< class HostProxy, class WorkerProxy, class AuxSolver  >
 class LinSysMerger : public CBase_LinSysMerger< HostProxy,
                                                 WorkerProxy,

--- a/src/LinSys/LinSysMerger.h
+++ b/src/LinSys/LinSysMerger.h
@@ -1003,7 +1003,8 @@ class LinSysMerger : public CBase_LinSysMerger< HostProxy,
               r[i] = 0.0;
         }
       }
-      rhsbc_complete(); rhsbc_complete();
+      rhsbc_complete_rhs();
+      rhsbc_complete_aux();
     }
 
     //! Build Hypre data for our portion of the solution vector

--- a/src/LinSys/linsysmerger.ci
+++ b/src/LinSys/linsysmerger.ci
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/LinSys/linsysmerger.ci
-  \author    J. Bakosi
+  \author    Los Alamos National Laboratory
   \copyright 2012-2015, Jozsef Bakosi, 2016, Los Alamos National Security, LLC.
   \brief     Charm++ module interface file for merging a linear system
   \details   Charm++ module interface file for merging a linear system. See more
@@ -200,7 +200,7 @@ module linsysmerger {
       entry void wait4lhs() {
         when lhsbc_complete() serial "hyprelhs" { hyprelhs(); } };
       entry void wait4rhs() {
-        when rhsbc_complete() serial "hyprerhs" { hyprerhs(); } };
+        when rhsbc_complete_rhs() serial "hyprerhs" { hyprerhs(); } };
 
       entry void wait4hypresol() {
         when hypresol_complete(), hyprerow_complete() serial "sol" { sol(); } };
@@ -220,7 +220,7 @@ module linsysmerger {
         when asmsol_complete(), asmlhs_complete(), asmrhs_complete()
           serial "solve" { solve(); } };
       entry void wait4aux() {
-        when rhsbc_complete(), auxlhs_complete(), auxrhs_complete()
+        when rhsbc_complete_aux(), auxlhs_complete(), auxrhs_complete()
           serial "aux" { auxsolve(); } };
 
       entry void wait4solve() {
@@ -231,7 +231,8 @@ module linsysmerger {
       entry void row_complete();
       entry void bc_complete();
       entry void lhsbc_complete();
-      entry void rhsbc_complete();
+      entry void rhsbc_complete_rhs();
+      entry void rhsbc_complete_aux();
       entry void hyprerow_complete();
       entry void lhs_complete();
       entry void rhs_complete();


### PR DESCRIPTION
Requesting Code Review and approval of merge of bugfix in LinksysMerger to develop branch. Please follow standard code review practices as there is a good chance I missed something and I don't want to introduce a different error.

During analysis of LinksysMerger it was noticed that the same signal was called twice, sequentially. Upon further analysis it was clear that this was due to multiple when() statements dependent on the signal. I have yet to check the Charm++ model to see if this is undefined behavior, but it is at least ambiguous and decreases code clarity. I changed the duplicate rhsbc_complete() signals to be unique for each when() statement.