### PR TITLE
Corrected Copyright in Files Post License Transfer

### DIFF
--- a/cmake/BuildShared.cmake
+++ b/cmake/BuildShared.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/BuildShared.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Set default value for building shared libs if none was specified
 #
 ################################################################################

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/BuildType.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Set a default build type if none was specified
 #
 ################################################################################

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/CodeCoverage.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Setup target for code coverage analysis
 #
 ################################################################################

--- a/cmake/ConfigureDataLayout.cmake
+++ b/cmake/ConfigureDataLayout.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/ConfigureDataLayout.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Configure data layouts
 #
 ################################################################################

--- a/cmake/CppCheck.cmake
+++ b/cmake/CppCheck.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/CppCheck.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Setup target for code coverage analysis
 #
 ################################################################################

--- a/cmake/DetectCXXversion.cmake
+++ b/cmake/DetectCXXversion.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/DetectCXXversion.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Detect C++ compiler major, minor, and patch version
 #
 ################################################################################

--- a/cmake/DetectCodeCoverage.cmake
+++ b/cmake/DetectCodeCoverage.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/DetectCodeCoverage.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Detect prerequesites for code coverage analysis
 #
 ################################################################################

--- a/cmake/DetectOS.cmake
+++ b/cmake/DetectOS.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/DetectOS.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Detect operating system
 #
 ################################################################################

--- a/cmake/DisallowInSourceBuilds.cmake
+++ b/cmake/DisallowInSourceBuilds.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/DisallowInSourceBuilds.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Cmake code to disallow in-source builds
 #
 ################################################################################

--- a/cmake/FindAEC.cmake
+++ b/cmake/FindAEC.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindAEC.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the Adaptive Entropy Coding library
 #
 ################################################################################

--- a/cmake/FindGmsh.cmake
+++ b/cmake/FindGmsh.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindGmsh.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find Gmsh
 #
 ################################################################################

--- a/cmake/FindHypre.cmake
+++ b/cmake/FindHypre.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindHypre.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the Hypre library from LLNL
 #
 ################################################################################

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindLAPACKE.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the C-interface to LAPACK as well as LAPACK/BLAS
 #
 ################################################################################

--- a/cmake/FindLibCXX.cmake
+++ b/cmake/FindLibCXX.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindLibCXX.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find libc++
 #
 ################################################################################

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindLMKL.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the Math Kernel Library from Intel
 #
 ################################################################################

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindLNetCDF.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find NetCDF
 #
 ################################################################################

--- a/cmake/FindNumDiff.cmake
+++ b/cmake/FindNumDiff.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindNumDiff.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find NumDiff
 #
 ################################################################################

--- a/cmake/FindPEGTL.cmake
+++ b/cmake/FindPEGTL.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindPEGTL.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find PEGTL
 #
 ################################################################################

--- a/cmake/FindPStreams.cmake
+++ b/cmake/FindPStreams.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindLPstreams.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the Pstreams library
 #
 ################################################################################

--- a/cmake/FindPugixml.cmake
+++ b/cmake/FindPugixml.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindPugixml.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the pugixml library
 #
 ################################################################################

--- a/cmake/FindRNGSSE2.cmake
+++ b/cmake/FindRNGSSE2.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindRNGSSE2.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the RNGSSE2 library
 #
 ################################################################################

--- a/cmake/FindRandom123.cmake
+++ b/cmake/FindRandom123.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindRandom123.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find Random123
 #
 ################################################################################

--- a/cmake/FindRoot.cmake
+++ b/cmake/FindRoot.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindRoot.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the Root library from CERN
 #
 ################################################################################

--- a/cmake/FindTestU01.cmake
+++ b/cmake/FindTestU01.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/FindTestU01.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the TestU01 library
 #
 ################################################################################

--- a/cmake/MPICompilers.cmake
+++ b/cmake/MPICompilers.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/MPICompilers.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the MPI wrappers
 #
 ################################################################################

--- a/cmake/TPLs.cmake
+++ b/cmake/TPLs.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/TPLs.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find the third-party libraries required to build Quinoa
 #
 ################################################################################

--- a/cmake/add_regression_test.cmake
+++ b/cmake/add_regression_test.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/add_regression_test.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Function used to add a regression test to the ctest test suite
 #
 ################################################################################

--- a/cmake/charm.cmake
+++ b/cmake/charm.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/charm.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Function used to setup a Charm++ module
 #
 ################################################################################

--- a/cmake/get_compiler_flags.cmake
+++ b/cmake/get_compiler_flags.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/get_compiler_flags.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Cmake code to get compiler flags
 #
 ################################################################################

--- a/cmake/libstdcxx.cmake
+++ b/cmake/libstdcxx.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/libstdcxx.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Find libc++ and offer to switch between libc++ and libstdc++
 #
 ################################################################################

--- a/cmake/test_runner.cmake
+++ b/cmake/test_runner.cmake
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      cmake/test_runner.cmake
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Regression test runner using the cmake scripting language
 #
 ################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 ################################################################################
 #
 # \file      src/CMakeLists.txt
-# \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+# \copyright 2016-2017, Los Alamos National Security, LLC.
 # \brief     Build quinoa
 #
 ################################################################################

--- a/src/Control/Keywords.h
+++ b/src/Control/Keywords.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/Keywords.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Definition of all keywords
   \details   This file contains the definition of all keywords, including those
     of command-line argument parsers as well as input, i.e., control, file

--- a/src/Control/Tags.h
+++ b/src/Control/Tags.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/Tags.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Tags
   \details   Tags are unique types, used for metaprogramming.
 */

--- a/src/Control/UnitTest/CmdLine/Grammar.h
+++ b/src/Control/UnitTest/CmdLine/Grammar.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/UnitTest/CmdLine/Grammar.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     UnitTest's command line grammar definition
   \details   Grammar definition for parsing the command line. We use the Parsing
   Expression Grammar Template Library (PEGTL) to create the grammar and the

--- a/src/Control/UnitTest/Types.h
+++ b/src/Control/UnitTest/Types.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/UnitTest/Types.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Types for UnitTest's parsers
   \details   Types for UnitTest's parsers. This file defines the components of
     the tagged tuple that stores heteroegeneous objects in a hierarchical way.

--- a/src/Control/Walker/Components.h
+++ b/src/Control/Walker/Components.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/Walker/Components.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Storage for number of components
   \details   Storage for number of components. This is part of the input deck
      stack and is thus populated during the control file parsing.

--- a/src/Control/Walker/InputDeck/InputDeck.h
+++ b/src/Control/Walker/InputDeck/InputDeck.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Control/Walker/InputDeck/InputDeck.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Walker's input deck
   \details   Walker's input deck
 */

--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/IO/ExodusIIMeshReader.C
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     ExodusII mesh reader
   \details   ExodusII mesh reader class definition. Currently, this is a bare
      minimum functionality to interface with the ExodusII reader. It only reads

--- a/src/IO/ExodusIIMeshReader.h
+++ b/src/IO/ExodusIIMeshReader.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/IO/ExodusIIMeshReader.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     ExodusII mesh reader
   \details   ExodusII mesh reader class declaration.
 */

--- a/src/IO/MeshFactory.C
+++ b/src/IO/MeshFactory.C
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/IO/MeshFactory.C
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Unstructured mesh reader and writer factory
   \details   Unstructured mesh reader and writer factory.
 */

--- a/src/IO/PDFWriter.C
+++ b/src/IO/PDFWriter.C
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/IO/PDFWriter.C
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Univariate PDF writer
   \brief     PDF writer class definition
   \details   This file defines a PDF writer class that facilitates outputing

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Inciter/Partitioner.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Charm++ chare partitioner group used to perform mesh partitioning
   \details   Charm++ chare partitioner group used to perform mesh partitioning.
     The implementation uses the Charm++ runtime system and is fully

--- a/src/Inciter/partitioner.ci
+++ b/src/Inciter/partitioner.ci
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Inciter/partitioner.ci
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Charm++ module interface file for the chare partitioner group
   \details   Charm++ module interface file for the chare partitioner group used
              to perform mesh partitioning.

--- a/src/LinSys/LinSysMerger.C
+++ b/src/LinSys/LinSysMerger.C
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/LinSys/LinSysMerger.C
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Linear system merger
   \details   Linear system merger.
 */

--- a/src/LinSys/LinSysMerger.h
+++ b/src/LinSys/LinSysMerger.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/LinSys/LinSysMerger.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Charm++ chare linear system merger group to solve a linear system
   \details   Charm++ chare linear system merger group used to collect and
     assemble the left hand side matrix (lhs), the right hand side (rhs) vector,

--- a/src/LinSys/linsysmerger.ci
+++ b/src/LinSys/linsysmerger.ci
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/LinSys/linsysmerger.ci
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Charm++ module interface file for merging a linear system
   \details   Charm++ module interface file for merging a linear system. See more
      in src/LinSys/LinSysMerger.h.

--- a/src/PDE/PDE.h
+++ b/src/PDE/PDE.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/PDE/PDE.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Partial differential equation
   \details   This file defines a generic partial differential equation class.
     The class uses runtime polymorphism without client-side inheritance:

--- a/src/PDE/PDEStack.C
+++ b/src/PDE/PDEStack.C
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/PDE/PDEStack.C
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Stack of partial differential equations
   \details   This file defines class PDEStack, which implements various
     functionality related to registering and instantiating partial differential

--- a/src/PDE/PDEStack.h
+++ b/src/PDE/PDEStack.h
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/PDE/PDEStack.h
-  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \copyright 2016-2017, Los Alamos National Security, LLC.
   \brief     Stack of differential equations
   \details   This file declares class PDEStack, which implements various
     functionality related to registering and instantiating partial differential


### PR DESCRIPTION
Following discussions, corrected copyright in files to address status relative to when the license of the code transferred. Files created after the transfer date were never under the previous license and have been updated accordingly.

I do suggest we remove copyright from all non-license files to save ourselves time on copyright range changes in the future, but that is a problem for a different discussion and is less of an immediate concern.

List of affected files generated via 
`git log --diff-filter=A --name-status --oneline  c63ca7ae816fc52f6796a5cf4f0dbe365619f1ff..928819e304edcb379f2884da73b0b239b494d3a0`

Not guaranteed to have gotten every file (another reason to remove copyrights altogether), but haven't found any that were created post-transfer that still exist and don't have an updated copyright line.