### PR TITLE
Various fixes related to getting the TC linux builds back in business

### DIFF
--- a/regression/meshconv/gmsh_output/gmsh.ndiff.cfg
+++ b/regression/meshconv/gmsh_output/gmsh.ndiff.cfg
@@ -1,3 +1,3 @@
 #rows   cols    constraints
 1-2     *       skip
-11      *       skip
+11-12   *       skip

--- a/src/Base/Get_Tuple.h
+++ b/src/Base/Get_Tuple.h
@@ -18,8 +18,7 @@ namespace tk {
 
 #if not defined (_LIBCPP_STD_VER) || (_LIBCPP_STD_VER <= 11)
 
-namespace detail
-{
+namespace detail {
 
 template <class T, std::size_t N, class... Args>
 struct get_number_of_element_from_tuple_by_type_impl {

--- a/src/Base/Get_Tuple.h
+++ b/src/Base/Get_Tuple.h
@@ -16,11 +16,7 @@
 
 namespace tk {
 
-#if _LIBCPP_STD_VER > 11
-
-using std::get;
-
-#else
+#if not defined (_LIBCPP_STD_VER) || (_LIBCPP_STD_VER <= 11)
 
 namespace detail
 {
@@ -54,6 +50,10 @@ T& get(std::tuple<Args...>& t) {
   return std::get<detail::
     get_number_of_element_from_tuple_by_type_impl<T, 0, Args...>::value>(t);
 }
+
+#else
+
+using std::get;
 
 #endif
 

--- a/src/Base/Get_Tuple.h
+++ b/src/Base/Get_Tuple.h
@@ -1,0 +1,62 @@
+// *****************************************************************************
+/*!
+  \file      src/Base/Get_Tuple.h
+  \copyright 2012-2015, J. Bakosi, 2016-2017, Los Alamos National Security, LLC.
+  \brief     Define std::get<T>(std::tuple) until C++14
+  \details   Define std::get<T>(std::tuple) until C++14. When we switch to
+    C++14, this can go away. The code below is from
+    https://stackoverflow.com/a/16707966.
+*/
+// *****************************************************************************
+#ifndef Get_Tuple_h
+#define Get_Tuple_h
+
+#include <type_traits>
+#include <tuple>
+
+namespace tk {
+
+#if _LIBCPP_STD_VER > 11
+
+using std::get;
+
+#else
+
+namespace detail
+{
+
+template <class T, std::size_t N, class... Args>
+struct get_number_of_element_from_tuple_by_type_impl {
+  static constexpr auto value = N;
+};
+
+template <class T, std::size_t N, class... Args>
+struct get_number_of_element_from_tuple_by_type_impl<T, N, T, Args...> {
+  static constexpr auto value = N;
+};
+
+template <class T, std::size_t N, class U, class... Args>
+struct get_number_of_element_from_tuple_by_type_impl<T, N, U, Args...> {
+  static constexpr auto value =
+    get_number_of_element_from_tuple_by_type_impl<T, N + 1, Args...>::value;
+};
+
+} // detail::
+
+template <class T, class... Args>
+T get(const std::tuple<Args...>& t) {
+  return std::get<detail::
+    get_number_of_element_from_tuple_by_type_impl<T, 0, Args...>::value>(t);
+}
+
+template <class T, class... Args>
+T& get(std::tuple<Args...>& t) {
+  return std::get<detail::
+    get_number_of_element_from_tuple_by_type_impl<T, 0, Args...>::value>(t);
+}
+
+#endif
+
+} // tk::
+
+#endif // Get_Tuple_h

--- a/src/Base/Variant.h
+++ b/src/Base/Variant.h
@@ -37,6 +37,8 @@
 #include "NoWarning/variant.h"
 #include "NoWarning/for_each.h"
 
+#include "Get_Tuple.h"
+
 namespace tk {
 
 template< typename... Types >
@@ -82,7 +84,7 @@ class Variant {
       Variant* const host;
       getval( Variant* const h ) : host(h) {}
       template< typename P > void operator()( const P& p ) const {
-        std::get< P >( host->tuple ) = p;
+        tk::get< P >( host->tuple ) = p;
       }
     };
 
@@ -92,7 +94,7 @@ class Variant {
       int cnt;
       setval( Variant* const h ) : host(h), cnt(0) {}
       template< typename U > void operator()( U ) {
-        if (host->idx == cnt++) host->variant = std::get< U >( host->tuple );
+        if (host->idx == cnt++) host->variant = tk::get< U >( host->tuple );
       }
     };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -258,7 +258,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")  # intel-specific settings
   endif()
 
   # Use the C++14 standard (CMAKE_CXX_STANDARD does not set this for intel)
-  add_compiler_flag("-std=c++14")
+  add_compiler_flag("-std=c++11")
 
   # Compiler flags for intel
   add_compiler_flag("-w3")       # enable diagnostics: remarks, warnings, errors
@@ -324,7 +324,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")  # pgi-specific settings
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray")  # cray-specific settings
 
   # Use the C++14 standard (CMAKE_CXX_STANDARD does not set this for cray)
-  add_compiler_flag("-hstd=c++14")
+  add_compiler_flag("-hstd=c++11")
 
   # Compiler flags for cray
   # enable errors, warnings, cautions, notes, comments

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ execute_process(
 string(REGEX REPLACE "[\r\n]" "" BUILD_DATE "${BUILD_DATE}")
 
 # Set the requirement for the C++ standard
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "Required language standard: C++${CMAKE_CXX_STANDARD}")

--- a/src/NoWarning/beta_distribution.h
+++ b/src/NoWarning/beta_distribution.h
@@ -16,6 +16,8 @@
   #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
   #pragma clang diagnostic ignored "-Wfloat-equal"
   #pragma clang diagnostic ignored "-Wreserved-id-macro"
+  #pragma clang diagnostic ignored "-Wsign-conversion"
+  #pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #elif defined(STRICT_GNUC)
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wfloat-equal"


### PR DESCRIPTION
Various minor fixes related to getting the TeamCity linux builds back up and passing again.

Background: At first I tried to go with requiring C++14, but that ended up not a great choice, because the system-wide gcc/g++ on the TC build agents is v4.8.5 which does not yet support `std::get<T>(std::tuple)`. Attempted to build a custom gcc + libstdc++ on the build agents lead to all sorts of problems as gcc/libstdc++ is very adamant on using the system-wide libstdc++.

Instead, this PR reverts the C++14 requirement back to C++11 and puts in some C++ code  in Base/Get_Tuple.h conditional on the libc++ version: if C++14 is enabled, it takes the standard `std::get` implementation, if not it uses the new code. libstdc++ will always use the latter as it is pretty convoluted and hard to detect if it has this feature.

In the meantime, some of the packages in the TC linux build agents have been updated and thus some more fixes, mostly ignoring warnings from libraries, were needed.