### PR TITLE
Do not overwrite CMAKE_INSTALL_RPATH

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,8 +467,6 @@ set(CMAKE_SKIP_BUILD_RPATH false)
 # (use later on when installing)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH false)
 
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
 # Add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
@@ -477,7 +475,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
      "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
 if("${isSystemDir}" STREQUAL "-1")
-   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${CMAKE_INSTALL_PREFIX}/lib")
 endif("${isSystemDir}" STREQUAL "-1")
 
 # add a target to generate API documentation with Doxygen


### PR DESCRIPTION
This allows incrementally adding to `RPATH`, as is done by, e.g., `FindMKL.cmake`, see also https://github.com/quinoacomputing/cmake-modules/commit/d9e3472dc196503927bd8fa0c028bac04e573fd1.