### PR TITLE
Fix build dependency: unittest on BCs charm module

### DIFF
--- a/src/UnitTest/CMakeLists.txt
+++ b/src/UnitTest/CMakeLists.txt
@@ -24,7 +24,7 @@ addCharmModule( "testarray" "UnitTest" )
 add_dependencies("UnitTest" "unittestCharmModule")
 
 # Add extra dependencies of UnitTest on those CharmModules that are required for
-# testing Inciter/Scheme.
+# testing Inciter.
 add_dependencies("UnitTest" "matcgCharmModule")
 add_dependencies("UnitTest" "diagcgCharmModule")
 add_dependencies("UnitTest" "distfctCharmModule")
@@ -32,6 +32,7 @@ add_dependencies("UnitTest" "dgCharmModule")
 add_dependencies("UnitTest" "discretizationCharmModule")
 add_dependencies("UnitTest" "solverCharmModule")
 add_dependencies("UnitTest" "transporterCharmModule")
+add_dependencies("UnitTest" "boundaryconditionsCharmModule")
 
 # Add extra dependency of TUTSuite on charm modules testing advanced array
 # element placement using maps. This is required since TUTSuite spawns chare


### PR DESCRIPTION
Thanks @adityakpandare for finding the problem.

Additional detail:

Basically, cmake attempts to generate all dependencies required to build a target, such as `unittest`, or any executable or shared library we build automatically. This is great, however, with Charm++-generated `decl.h` and `def.h` files we have to add these dependencies manually because cmake does not understand that new dependencies are introduced based on these and the `.ci` files. This is fine if A simply depends on B, but when A depends on B which depends on C, then we also have to add that A depends on C, which is not always obvious (cmake cannot see this). So we have to do a bunch of `add_dependencies()` cmake function calls (beside the existing `addCharmModule()` calls, which sets up the direct "A depends on B" dependency but cannot do the "A depends on C" one) to various places in the build system. A particularly awful place for this (i.e., many manual add_dependencies() calls) is the unit test suite which @adityakpandare  just bumped into.
