### PR TITLE
Remove hard-coded number of args from Scheme

### DIFF
--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -1221,7 +1221,7 @@ Partitioner::createDiscWorkers()
     typename decltype(m_chedgenodes)::mapped_type edno;
     if (!m_chedgenodes.empty()) edno = tk::cref_find( m_chedgenodes, cid );
     // Create worker array element
-    m_scheme.discInsert< tag::elem >( cid, m_host, m_bc,
+    m_scheme.discInsert( cid, m_host, m_bc,
       tk::cref_find(m_chinpoel,cid), msum, tk::cref_find(m_chfilenodes,cid),
       edno, m_nchare, m_nbfac, m_bface, m_triinpoel, CkMyPe() );
   }
@@ -1268,7 +1268,7 @@ Partitioner::createWorkers()
     // Make sure (bound) base is already created and accessible
     Assert( m_scheme.get()[cid].ckLocal() != nullptr, "About to pass nullptr" );
     // Create worker array element
-    m_scheme.insert< tag::elem >( cid, m_scheme.get(), m_solver, CkMyPe() );
+    m_scheme.insert( cid, m_scheme.get(), m_solver, CkMyPe() );
   }
 }
 

--- a/src/Inciter/Scheme.h
+++ b/src/Inciter/Scheme.h
@@ -216,22 +216,7 @@ class Scheme : public SchemeBase {
     //! \details This function calls the insert member function of a chare array
     //!   element discproxy and thus equivalent to discproxy[x].insert(...),
     //!   using the last argument as default.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 11, int >::type = 0 >
-    void discInsert( const CkArrayIndex1D& x, Args&&... args ) {
-      discproxy[x].insert( fctproxy, std::forward<Args>(args)..., nullptr );
-    }
-    //////  discproxy[x].insert(...,CkEntryOptions)
-    //! Function to call the insert entry method of an element discproxy (p2p)
-    //! \param[in] x Chare array element index
-    //! \param[in] args Arguments to member function (entry method) to be called
-    //! \details This function calls the insert member function of a chare array
-    //!   element discproxy and thus equivalent to discproxy[x].insert(...),
-    //!   specifying a non-default last argument.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 1,
-      typename std::enable_if< sizeof...(Args) == 12, int >::type = 0 >
+    template< typename... Args >
     void discInsert( const CkArrayIndex1D& x, Args&&... args ) {
       discproxy[x].insert( fctproxy, std::forward<Args>(args)... );
     }
@@ -270,55 +255,10 @@ class Scheme : public SchemeBase {
     //! \details This function calls the setup member function of a chare array
     //!   proxy and thus equivalent to proxy.setup(...), using the last argument
     //!   as default.
-    template< class Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::bcast >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 1, int >::type = 0 >
-    void setup( Args&&... args ) {
-      boost::apply_visitor( call_setup<Args...,std::nullptr_t>(
-        std::forward< Args >( args )..., nullptr ), proxy );
-    }
-    //////  proxy.setup(...,CkEntryOptions)
-    //! function to call the setup entry method of an array proxy (broadcast)
-    //! \param[in] args arguments to member function (entry method) to be called
-    //! \details this function calls the setup member function of a chare array
-    //!   proxy and thus equivalent to proxy.setup(...), specifying a
-    //!   non-default last argument.
-    template< class Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::bcast >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 2, int >::type = 0 >
+    template< typename... Args >
     void setup( Args&&... args ) {
       boost::apply_visitor( call_setup<Args...>( std::forward<Args>(args)... ),
                             proxy );
-    }
-    //////  proxy[x].setup(...)
-    //! Function to call the setup entry method of an element proxy (p2p)
-    //! \param[in] x Chare array element index
-    //! \param[in] args Arguments to member function (entry method) to be called
-    //! \details This function calls the setup member function of a chare array
-    //!   element proxy and thus equivalent to proxy[x].setup(...), using the
-    //!   last argument as default.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 1, int >::type = 0 >
-    void setup( const CkArrayIndex1D& x, Args&&... args ) {
-      auto e = tk::element< ProxyElem >( proxy, x );
-      boost::apply_visitor( call_setup<Args...,std::nullptr_t>(
-        std::forward<Args>(args)...,nullptr), e );
-    }
-    //////  proxy[x].setup(...,CkEntryOptions)
-    //! Function to call the setup entry method of an element proxy (p2p)
-    //! \param[in] x Chare array element index
-    //! \param[in] args Arguments to member function (entry method) to be called
-    //! \details This function calls the setup member function of a chare array
-    //!   element proxy and thus equivalent to proxy[x].setup(...), specifying a
-    //!   non-default last argument.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 2, int >::type = 0 >
-    void setup( const CkArrayIndex1D& x, Args&&... args ) {
-      auto e = tk::element< ProxyElem >( proxy, x );
-      boost::apply_visitor( call_setup<Args...>( std::forward<Args>(args)... ),
-                            e );
     }
 
     //////  proxy.dt(...)
@@ -382,24 +322,7 @@ class Scheme : public SchemeBase {
     //! \details This function calls the insert member function of a chare array
     //!   element proxy and thus equivalent to proxy[x].insert(...), using the
     //!   last argument as default.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 0,
-      typename std::enable_if< sizeof...(Args) == 3, int >::type = 0 >
-    void insert( const CkArrayIndex1D& x, Args&&... args ) {
-      auto e = tk::element< ProxyElem >( proxy, x );
-      boost::apply_visitor( call_insert<Args...,std::nullptr_t>(
-        std::forward<Args>(args)...,nullptr), e );
-    }
-    //////  proxy[x].insert(...,CkEntryOptions)
-    //! Function to call the insert entry method of an element proxy (p2p)
-    //! \param[in] x Chare array element index
-    //! \param[in] args Arguments to member function (entry method) to be called
-    //! \details This function calls the insert member function of a chare array
-    //!   element proxy and thus equivalent to proxy[x].insert(...), specifying
-    //!   a non-default last argument.
-    template< typename Op, typename... Args, typename std::enable_if<
-      std::is_same< Op, tag::elem >::value, int >::type = 1,
-      typename std::enable_if< sizeof...(Args) == 4, int >::type = 0 >
+    template< typename... Args >
     void insert( const CkArrayIndex1D& x, Args&&... args ) {
       auto e = tk::element< ProxyElem >( proxy, x );
       boost::apply_visitor( call_insert<Args...>( std::forward<Args>(args)... ),

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -615,7 +615,7 @@ Transporter::stat()
      "\n      it             t            dt        ETE        ETA   out\n"
        " ---------------------------------------------------------------\n" );
 
-  m_scheme.setup< tag::bcast >( m_V );
+  m_scheme.setup( m_V );
 }
 
 void


### PR DESCRIPTION
This removes some overloads from `Scheme`. This makes it less general, but only removes overloads that have not been used. As a result, this code is more readable, less error prone, and more generic for the overloads that stay.

In particular, the removed overloads remove our ability to pass the optional `CkEntryOptions` Charm++ argument to the wrapped entry methods, but we don't use them right now. If/when we need to add the `CkEntryOptions` argument, we can just either add back the overload(s) (if we really want both) or simply add back the CkEntryOptions argument (without it being optional). Until then, we are left with more readable code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/194)
<!-- Reviewable:end -->
