### PR TITLE
Face and element geometry data computation.

### DIFF
--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -42,9 +42,13 @@ DG::DG( const CProxy_Discretization& disc,
   // Signal the runtime system that the workers have been created
   solver.ckLocalBranch()->created();
 
-  // Compute face geometry
   auto d = Disc();
+
+  // Compute face geometry
   m_geoFace = tk::genGeoFaceTri(fd.Ntfac(), fd.Inpofa(), d->Coord());
+
+  // Compute element geometry
+  m_geoElem = tk::genGeoElemTet(d->Inpoel(), d->Coord());
 }
 
 void

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -41,7 +41,10 @@ DG::DG( const CProxy_Discretization& disc,
 {
   // Signal the runtime system that the workers have been created
   solver.ckLocalBranch()->created();
-  IGNORE( fd );
+
+  // Compute face geometry
+  auto d = Disc();
+  m_geoFace = tk::genGeoFaceTri(fd.Ntfac(), fd.Inpofa(), d->Coord());
 }
 
 void

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -59,6 +59,7 @@ class DG : public CBase_DG {
       p | m_disc;
       p | m_vol;
       p | m_geoFace;
+      p | m_geoElem;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -73,6 +74,8 @@ class DG : public CBase_DG {
     tk::real m_vol;
     //! Face geometry
     tk::Fields m_geoFace;
+    //! Element geometry
+    tk::Fields m_geoElem;
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -20,6 +20,7 @@
 
 #include "NoWarning/dg.decl.h"
 #include "FaceData.h"
+#include "DerivedData.h"
 
 namespace inciter {
 
@@ -57,6 +58,7 @@ class DG : public CBase_DG {
       CBase_DG::pup(p);
       p | m_disc;
       p | m_vol;
+      p | m_geoFace;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -69,6 +71,8 @@ class DG : public CBase_DG {
     CProxy_Discretization m_disc;
     //! Total mesh volume
     tk::real m_vol;
+    //! Face geometry
+    tk::Fields m_geoFace;
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {

--- a/src/Mesh/DerivedData.C
+++ b/src/Mesh/DerivedData.C
@@ -20,6 +20,7 @@
 #include "Exception.h"                  // for Assert
 #include "DerivedData.h"
 #include "ContainerUtil.h"
+#include "Vector.h"
 
 namespace tk {
 
@@ -1414,58 +1415,31 @@ genGeoElemTet( const std::vector< std::size_t >& inpoel,
 
   tk::Fields geoElem( nelem, 4 );
 
+  const auto& x = coord[0];
+  const auto& y = coord[1];
+  const auto& z = coord[2];
+
   for(std::size_t e=0; e<nelem; ++e)
   {
-    std::size_t ip1, ip2, ip3, ip4;
-    tk::real xp1, yp1, zp1,
-             xp2, yp2, zp2,
-             xp3, yp3, zp3,
-             xp4, yp4, zp4,
-             x34, y34, z34,
-             xy34, xz34, yz34,
-             vole;
-
     // get volume
-    ip1 = inpoel[nnpe*e];
-    ip2 = inpoel[nnpe*e + 1];
-    ip3 = inpoel[nnpe*e + 2];
-    ip4 = inpoel[nnpe*e + 3];
+    const auto A = inpoel[nnpe*e+0];
+    const auto B = inpoel[nnpe*e+1];
+    const auto C = inpoel[nnpe*e+2];
+    const auto D = inpoel[nnpe*e+3];
+    std::array< tk::real, 3 > ba{{ x[B]-x[A], y[B]-y[A], z[B]-z[A] }},
+                              ca{{ x[C]-x[A], y[C]-y[A], z[C]-z[A] }},
+                              da{{ x[D]-x[A], y[D]-y[A], z[D]-z[A] }};
 
-    xp1 = coord[0][ip1];
-    yp1 = coord[1][ip1];
-    zp1 = coord[2][ip1];
+    const auto vole = tk::triple( ba, ca, da ) / 6.0;
 
-    xp2 = coord[0][ip2];
-    yp2 = coord[1][ip2];
-    zp2 = coord[2][ip2];
-
-    xp3 = coord[0][ip3];
-    yp3 = coord[1][ip3];
-    zp3 = coord[2][ip3];
-
-    xp4 = coord[0][ip4];
-    yp4 = coord[1][ip4];
-    zp4 = coord[2][ip4];
-
-    x34 = xp3 - xp4;
-    y34 = yp3 - yp4;
-    z34 = zp3 - zp4;
-
-    xy34 = xp3*yp4 - yp3*xp4;
-    yz34 = yp3*zp4 - zp3*yp4;
-    xz34 = xp3*zp4 - zp3*xp4;
-
-    vole = (  xp1 * ( yp2*z34 - zp2*y34 + yz34 )
-            - yp1 * ( xp2*z34 - zp2*x34 + xz34 )
-            + zp1 * ( xp2*y34 - yp2*x34 + xy34 )
-            - ( xp2*yz34 - yp2*xz34 + zp2*xy34 ) ) / 6.0;
+    Assert( vole > 0, "Element Jacobian non-positive" );
 
     geoElem(e,0,0) = vole;
 
     // get centroid
-    geoElem(e,1,0) = (xp1+xp2+xp3+xp4)/4.0;
-    geoElem(e,2,0) = (yp1+yp2+yp3+yp4)/4.0;
-    geoElem(e,3,0) = (zp1+zp2+zp3+zp4)/4.0;
+    geoElem(e,1,0) = (x[A]+x[B]+x[C]+x[D])/4.0;
+    geoElem(e,2,0) = (y[A]+y[B]+y[C]+y[D])/4.0;
+    geoElem(e,3,0) = (z[A]+z[B]+z[C]+z[D])/4.0;
   }
 
   return geoElem;

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -121,6 +121,11 @@ tk::Fields
 genGeoFaceTri( std::size_t ntfac,
                const std::vector< std::size_t >& inpofa,
                const tk::UnsMesh::Coords& coord );
+
+//! Generate derived data structure, element geometry
+tk::Fields
+genGeoElemTet( const std::vector< std::size_t >& inpoel,
+               const tk::UnsMesh::Coords& coord );
 } // tk::
 
 #endif // DerivedData_h

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -14,6 +14,9 @@
 #include <map>
 #include <utility>
 #include <cstddef>
+#include "Types.h"
+#include "Fields.h"
+#include "UnsMesh.h"
 
 namespace tk {
 
@@ -112,6 +115,12 @@ genBelemTet( std::size_t nbfac,
               const std::vector< std::size_t >& inpofa,
               const std::pair< std::vector< std::size_t >,
                                std::vector< std::size_t > >& esup );
+
+//! Generate derived data structure, face geometry
+tk::Fields
+genGeoFaceTri( std::size_t ntfac,
+               const std::vector< std::size_t >& inpofa,
+               const tk::UnsMesh::Coords& coord );
 } // tk::
 
 #endif // DerivedData_h

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -3345,6 +3345,70 @@ void DerivedData_object::test< 68 >() {
   }
 }
 
+//! Generate and test face-geometry vector for a single tetrahedron
+template<> template<>
+void DerivedData_object::test< 69 >() {
+  set_test_name( "Face-geometries (genGeoFaceTri) for a tetrahedron" );
+
+  // total number of faces
+  std::size_t ntfac(4);
+
+  // coordinates of tetrahedron vertices
+  tk::UnsMesh::Coords coord {{ {1.0, 0.0, 0.0, 0.0},
+                               {0.0, 0.0, 1.0, 0.0},
+                               {0.0, 0.0, 0.0, 1.0} }};
+
+  // face-node connectivity
+  std::vector< std::size_t > inpofa { 0, 1, 2,
+                                      0, 3, 1,
+                                      1, 3, 2,
+                                      2, 3, 0 };
+
+  // get face-geometries
+  auto geoFace = tk::genGeoFaceTri( ntfac, inpofa, coord );
+
+  // correct face-areas
+  std::vector< tk::real > correct_farea { 0.5, 0.5, 0.5, 0.8660254037844389 };
+
+  // correct face-normals
+  std::array< std::vector< tk::real >, 3 > correct_fnorm {{
+                                       { 0.0,  0.0, -1.0, 1.0/sqrt(3.0)},
+                                       { 0.0, -1.0,  0.0, 1.0/sqrt(3.0)},
+                                       {-1.0,  0.0,  0.0, 1.0/sqrt(3.0)},
+                                       }};
+
+  // correct face-centroids
+  tk::UnsMesh::Coords correct_fcent {{ {1.0/3.0, 1.0/3.0, 0.0,     1.0/3.0},
+                                       {1.0/3.0, 0.0,     1.0/3.0, 1.0/3.0},
+                                       {0.0,     1.0/3.0, 1.0/3.0, 1.0/3.0} }};
+
+  tk::real prec = std::numeric_limits< tk::real >::epsilon();
+
+  for(std::size_t f=0 ; f<ntfac; ++f)
+  {
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-area",
+                    geoFace(f,0,0), correct_farea[f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-nx",
+                    geoFace(f,1,0), correct_fnorm[0][f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-ny",
+                    geoFace(f,2,0), correct_fnorm[1][f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-nz",
+                    geoFace(f,3,0), correct_fnorm[2][f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-cx",
+                    geoFace(f,4,0), correct_fcent[0][f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-cy",
+                    geoFace(f,5,0), correct_fcent[1][f], prec);
+
+    ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-cz",
+                    geoFace(f,6,0), correct_fcent[2][f], prec);
+  }
+}
+
 #if defined(STRICT_GNUC)
   #pragma GCC diagnostic pop
 #endif

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -3420,7 +3420,7 @@ void DerivedData_object::test< 70 >() {
                                {0.0, 0.0, 0.0, 1.0} }};
 
   // element-node connectivity
-  std::vector< std::size_t > inpoel { 0, 1, 2, 3 };
+  std::vector< std::size_t > inpoel { 0, 3, 2, 1 };
 
   // get element-geometries
   auto geoElem = tk::genGeoElemTet( inpoel, coord );

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -3348,7 +3348,7 @@ void DerivedData_object::test< 68 >() {
 //! Generate and test face-geometry vector for a single tetrahedron
 template<> template<>
 void DerivedData_object::test< 69 >() {
-  set_test_name( "Face-geometries (genGeoFaceTri) for a tetrahedron" );
+  set_test_name( "Face-geometry (genGeoFaceTri) for a tetrahedron" );
 
   // total number of faces
   std::size_t ntfac(4);
@@ -3407,6 +3407,45 @@ void DerivedData_object::test< 69 >() {
     ensure_equals("incorrect entry " + std::to_string(f) + " in geoFace-cz",
                     geoFace(f,6,0), correct_fcent[2][f], prec);
   }
+}
+
+//! Generate and test element-geometry vector for a single tetrahedron
+template<> template<>
+void DerivedData_object::test< 70 >() {
+  set_test_name( "Element-geometry (genGeoElemTet) for a tetrahedron" );
+
+  // coordinates of tetrahedron vertices
+  tk::UnsMesh::Coords coord {{ {1.0, 0.0, 0.0, 0.0},
+                               {0.0, 0.0, 1.0, 0.0},
+                               {0.0, 0.0, 0.0, 1.0} }};
+
+  // element-node connectivity
+  std::vector< std::size_t > inpoel { 0, 1, 2, 3 };
+
+  // get element-geometries
+  auto geoElem = tk::genGeoElemTet( inpoel, coord );
+
+  // correct element-volume
+  tk::real correct_vole { 1.0/6.0 };
+
+  // correct element-centroid
+  tk::UnsMesh::Coords correct_ecent {{ {1.0/4.0},
+                                       {1.0/4.0},
+                                       {1.0/4.0} }};
+
+  tk::real prec = std::numeric_limits< tk::real >::epsilon();
+
+  ensure_equals("incorrect entry in geoElem-vol",
+                  geoElem(0,0,0), correct_vole, prec);
+
+  ensure_equals("incorrect entry in geoElem-cx",
+                  geoElem(0,1,0), correct_ecent[0][0], prec);
+
+  ensure_equals("incorrect entry in geoElem-cy",
+                  geoElem(0,2,0), correct_ecent[1][0], prec);
+
+  ensure_equals("incorrect entry in geoElem-cz",
+                  geoElem(0,3,0), correct_ecent[2][0], prec);
 }
 
 #if defined(STRICT_GNUC)


### PR DESCRIPTION
This commit calculates and tests the face geometry array geoFace which
contains area, unit-normal components and centroid coordinates. Since
this information is required only when DG discretization is used, the
call to function genGeoFaceTri() is in DG.C. This commit also includes 
calculations of volume and centroids of tetrahedra in the function 
genGeoElemTet(), also called from the DG class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/200)
<!-- Reviewable:end -->
