### PR TITLE
Only read side sets if DG, hide error handling

### DIFF
--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -388,6 +388,8 @@ ExodusIIMeshReader::readFaces( std::size_t nbfac,
 //!   also called triangle-elements in the EXO2 file, and their connectivity.
 // *****************************************************************************
 {
+  ErrChk( nbfac > 0, "Number of boundary faces must be larger than zero" );
+
   std::size_t nnpf(3);
 
   // Read triangle boundary-face connectivity

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -210,7 +210,7 @@ Transporter::createPartitioner()
   // Read side sets for boundary faces
   m_print.diag( "Reading side set faces" );
   std::map< int, std::vector< std::size_t > > bface;
-  auto nbfac = er.readSidesetFaces( bface );
+  std::size_t nbfac = 0;
 
   std::vector< std::size_t > triinpoel;
   const auto scheme = g_inputdeck.get< tag::selected, tag::scheme >();

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -215,13 +215,10 @@ Transporter::createPartitioner()
   std::vector< std::size_t > triinpoel;
   const auto scheme = g_inputdeck.get< tag::selected, tag::scheme >();
 
-  if (nbfac<1 && scheme == ctr::SchemeType::DG)
-  {
-    Throw( "Boundary faces not specified using side-sets in ExodusII input file" );
-  }
-  else if (nbfac>0)
-  {
-    // Read triangle boundary-face connectivity 
+  // Read triangle boundary-face connectivity
+  if (scheme == ctr::SchemeType::DG) {
+    m_print.diag( "Reading side set faces" );
+    nbfac = er.readSidesetFaces( bface );
     er.readFaces( nbfac, triinpoel );
   }
 

--- a/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
+++ b/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
@@ -1588,6 +1588,24 @@ void ExodusIIMeshReader_object::test< 5 >() {
   }
 }
 
+//! Attempt to read side-set (boundary) connectivity, feeding garbage
+template<> template<>
+void ExodusIIMeshReader_object::test< 6 >() {
+  set_test_name( "boundary-face conn read throws on garbage" );
+
+  // Attempt to read boundary face-node connectivity passing nbfac=0
+  try {
+    std::vector< std::size_t > triinpoel;
+    std::string infile( REGRESSION_DIR "/meshconv/gmsh_output/box_24_ss1.exo" );
+    tk::ExodusIIMeshReader er( infile );
+    er.readFaces( 0, triinpoel );
+    fail( "should throw exception" );
+  }
+  catch ( tk::Exception& ) {
+    // exception thrown, test ok
+  }
+}
+
 } // tut::
 
 #endif // test_ExodusIIMeshReader_h


### PR DESCRIPTION
This avoids reading the side set face connectivity unless `DG` is configured by the user. Also hide error handling inside reader, simplifying client code (tested by new unit test).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/202)
<!-- Reviewable:end -->
