### PR TITLE
 Mapping to Exodus-global node-IDs and splitting the bface map to chunks.

### DIFF
--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -416,6 +416,10 @@ ExodusIIMeshReader::readNodemap()
 // *****************************************************************************
 //  Read local to global node-ID map from ExodusII file
 //! \return node_map Vector mapping the local Exodus node-IDs to global node-IDs
+//! \details The node-map is required to get the "Exodus-global" node-IDs from
+//!   the "Exodus-internal" node-IDs, which are returned from the exodus APIs.
+//!   The node-IDs in the exodus file are referred to as the "Exodus-global"
+//!   node-IDs or "fileIDs" in Quinoa.
 // *****************************************************************************
 {
   // Read triangle boundary-face connectivity

--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -379,10 +379,13 @@ ExodusIIMeshReader::readElements( const std::array< std::size_t, 2 >& ext,
 
 void
 ExodusIIMeshReader::readFaces( std::size_t nbfac,
+                               const std::vector< std::size_t >& node_map,
                                std::vector< std::size_t >& conn )
 // *****************************************************************************
 //  Read face connectivity of a number of boundary faces from ExodusII file
 //! \param[in] nbfac Number of boundary faces
+//! \param[in] node_map Vector mapping the local Exodus node-IDs to global
+//!            node-IDs
 //! \param[inout] conn Connectivity vector to push to
 //! \details This function reads-in the total number of boundary faces 
 //!   also called triangle-elements in the EXO2 file, and their connectivity.
@@ -394,15 +397,7 @@ ExodusIIMeshReader::readFaces( std::size_t nbfac,
 
   // Read triangle boundary-face connectivity
   std::vector< std::size_t > l_triinpoel;
-  auto nnode = readElemBlockIDs();
   readElements( {{0,nbfac-1}}, tk::ExoElemType::TRI, l_triinpoel );
-
-  // Create array to store node-number map
-  std::vector< int > node_map( nnode );
-
-  // Read in the node number map to map the above nodes to the global node-IDs
-  ErrChk( ex_get_id_map( m_inFile, EX_NODE_MAP, node_map.data() ) == 0,
-          "Failed to read node map length from ExodusII file: " );
 
   std::size_t count(0);
   // Use node_map to get the global-IDs of the face-node connectivity
@@ -411,9 +406,36 @@ ExodusIIMeshReader::readFaces( std::size_t nbfac,
     count = f*nnpf;
     for (std::size_t i=0; i<nnpf; ++i)
     {
-      conn.push_back( static_cast< std::size_t >(node_map[ l_triinpoel[count+i] ]-1) );
+      conn.push_back( node_map[ l_triinpoel[count+i] ] );
     }
   }
+}
+
+std::vector< std::size_t >
+ExodusIIMeshReader::readNodemap()
+// *****************************************************************************
+//  Read local to global node-ID map from ExodusII file
+//! \return node_map Vector mapping the local Exodus node-IDs to global node-IDs
+// *****************************************************************************
+{
+  // Read triangle boundary-face connectivity
+  auto nnode = readElemBlockIDs();
+
+  // Create array to store node-number map
+  std::vector< int > node_map( nnode );
+
+  // Read in the node number map to map the above nodes to the global node-IDs
+  ErrChk( ex_get_id_map( m_inFile, EX_NODE_MAP, node_map.data() ) == 0,
+          "Failed to read node map length from ExodusII file: " );
+
+  std::vector< std::size_t > node_map1( nnode );
+
+  for (std::size_t i=0; i<nnode; ++i)
+  {
+          node_map1[i] = static_cast< std::size_t >(node_map[i]-1);
+  }
+
+  return node_map1;
 }
 
 std::map< int, std::vector< std::size_t > >

--- a/src/IO/ExodusIIMeshReader.h
+++ b/src/IO/ExodusIIMeshReader.h
@@ -90,7 +90,11 @@ class ExodusIIMeshReader {
 
     //! Read face connectivity of a number boundary faces from file
     void readFaces( std::size_t nbfac,
+                    const std::vector< std::size_t >& nodemap,
                     std::vector< std::size_t >& conn );
+
+    //! Read local to global node-ID map
+    std::vector< std::size_t > readNodemap();
 
     //! Read node list of all side sets from ExodusII file
     std::map< int, std::vector< std::size_t > > readSidesets();

--- a/src/Inciter/FaceData.C
+++ b/src/Inciter/FaceData.C
@@ -71,7 +71,7 @@ FaceData::FaceData(
     m_ntfac = tk::genNtfac( 4, m_nbfac, m_esuel );
     m_inpofa = tk::genInpofaTet( m_ntfac, m_nbfac, inpoel, m_triinpoel,
                                  m_esuel );
-    m_belem =  tk::genBelemTet( m_nbfac, m_inpofa, esup );
+    m_belem =  tk::genBelemTet( m_nbfac, m_inpofa, nodemap, gid, esup );
     m_esuf = tk::genEsuf( 4, m_ntfac, m_nbfac, m_belem, m_esuel );
 
     Assert( m_belem.size() == m_nbfac,

--- a/src/Inciter/FaceData.C
+++ b/src/Inciter/FaceData.C
@@ -23,16 +23,17 @@ using inciter::FaceData;
 FaceData::FaceData(
   const std::vector< std::size_t >& conn,
   std::size_t nbfac_complete,
-  const std::map< int, std::vector< std::size_t > >& bface,
-  const std::vector< std::size_t >& triinpoel_complete ) : m_bface( bface )
+  const std::map< int, std::vector< std::size_t > >& bface_complete,
+  const std::vector< std::size_t >& triinpoel_complete,
+  const std::vector< std::size_t >& nodemap )// : m_bface( bface )
 // *****************************************************************************
 //  Constructor
 //! \param[in] conn Vector of mesh element connectivity owned (global IDs)
 //!   mesh chunk we operate on
 //! \param[in] nbfac_complete Total number of boundary-faces (triangles) in 
 //!   the entire mesh
-//! \param[in] bface Map of boundary-face lists mapped to corresponding 
-//!   side set ids
+//! \param[in] bface_complete Map of boundary-face lists mapped to corresponding 
+//!   side set ids for the entire mesh
 //! \param[in] triinpoel_complete Interconnectivity of points and 
 //!   boundary-face in the entire mesh
 //! \details This class is created per chare-worker in 
@@ -46,8 +47,19 @@ FaceData::FaceData(
 
     auto el = tk::global2local( conn );   // fills inpoel, m_gid, m_lid
     auto inpoel = std::get< 0 >( el );
+
+    auto l_inpoel = inpoel;
+
+    for (std::size_t e=0; e<inpoel.size()/4; ++e)
+    {
+            inpoel[4*e]   = nodemap[l_inpoel[4*e]];
+            inpoel[4*e+1] = nodemap[l_inpoel[4*e+1]];
+            inpoel[4*e+2] = nodemap[l_inpoel[4*e+2]];
+            inpoel[4*e+3] = nodemap[l_inpoel[4*e+3]];
+    }
+
     m_nbfac = tk::genNbfacTet( nbfac_complete, inpoel, triinpoel_complete,
-                               m_triinpoel );
+                               bface_complete, m_triinpoel, m_bface );
     m_esuel = tk::genEsuelTet( inpoel,tk::genEsup(inpoel,4) );
     m_ntfac = tk::genNtfac( 4, m_nbfac, m_esuel );
     m_inpofa = tk::genInpofaTet( m_ntfac, m_nbfac, inpoel, m_triinpoel,

--- a/src/Inciter/FaceData.C
+++ b/src/Inciter/FaceData.C
@@ -25,7 +25,7 @@ FaceData::FaceData(
   std::size_t nbfac_complete,
   const std::map< int, std::vector< std::size_t > >& bface_complete,
   const std::vector< std::size_t >& triinpoel_complete,
-  const std::vector< std::size_t >& nodemap )// : m_bface( bface )
+  const std::vector< std::size_t >& nodemap )
 // *****************************************************************************
 //  Constructor
 //! \param[in] conn Vector of mesh element connectivity owned (global IDs)

--- a/src/Inciter/FaceData.h
+++ b/src/Inciter/FaceData.h
@@ -26,7 +26,8 @@ class FaceData
         const std::vector< std::size_t >& conn,
         std::size_t nbfac_complete,
         const std::map< int, std::vector< std::size_t > >& bface,
-        const std::vector< std::size_t >& triinpoel_complete );
+        const std::vector< std::size_t >& triinpoel_complete,
+        const std::vector< std::size_t >& nodemap );
 
     /** @name Accessors
       * */

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -81,7 +81,10 @@ Partitioner::Partitioner(
 //! \param[in] bc Boundary conditions group proxy
 //! \param[in] scheme Discretization scheme
 //! \param[in] nbfac Total number of boundary faces
-//! \param[out] bface Face lists mapped to side set ids
+//! \param[in] bface Face lists mapped to side set ids
+//! \param[in] triinpoel Interconnectivity of points and boundary-face
+//! \param[in] nodemap Vector mapping the local Exodus node-IDs to global Exodus
+//!            node-IDs
 // *****************************************************************************
 {
   tk::ExodusIIMeshReader

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -34,7 +34,8 @@ Partitioner::Partitioner(
   const Scheme& scheme,
   std::size_t nbfac,
   const std::map< int, std::vector< std::size_t > >& bface,
-  const std::vector< std::size_t >& triinpoel ) :
+  const std::vector< std::size_t >& triinpoel,
+  const std::vector< std::size_t >& nodemap ) :
   m_cb( cb[0], cb[1], cb[2], cb[3], cb[4], cb[5], cb[6] ),
   m_host( host ),
   m_solver( solver ),
@@ -70,7 +71,8 @@ Partitioner::Partitioner(
   m_msumed(),
   m_nbfac( nbfac ),
   m_bface( bface ),
-  m_triinpoel( triinpoel )
+  m_triinpoel( triinpoel ),
+  m_nodemap( nodemap )
 // *****************************************************************************
 //  Constructor
 //! \param[in] cb Charm++ callbacks
@@ -1266,7 +1268,7 @@ Partitioner::createWorkers()
     Assert( m_scheme.get()[cid].ckLocal() != nullptr, "About to pass nullptr" );
 
     // Face data class
-    FaceData fd(tk::cref_find(m_chinpoel,cid), m_nbfac, m_bface, m_triinpoel);
+    FaceData fd(tk::cref_find(m_chinpoel,cid), m_nbfac, m_bface, m_triinpoel, m_nodemap);
 
     // Create worker array element
     m_scheme.insert< tag::elem >( cid, m_scheme.get(), m_solver, fd, CkMyPe() );

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -333,6 +333,10 @@ class Partitioner : public CBase_Partitioner {
     //! \brief Boundary face-node connectivity.
     std::vector< std::size_t > m_triinpoel;
     //! \brief Local-global node-ID map.
+    //! \details The node-map is required to get the "Exodus-global" node-IDs
+    //!   from the "Exodus-internal" node-IDs, which are returned from the exodus
+    //!   APIs. The node-IDs in the exodus file are referred to as the 
+    //!   "Exodus-global" node-IDs or "fileIDs" in Quinoa.
     std::vector< std::size_t > m_nodemap;
 
     //! Read our contiguously-numbered chunk of the mesh graph from file

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -122,7 +122,8 @@ class Partitioner : public CBase_Partitioner {
                  const Scheme& scheme,
                  std::size_t nbfac,
                  const std::map< int, std::vector< std::size_t > >& bface,
-                 const std::vector< std::size_t >& triinpoel );
+                 const std::vector< std::size_t >& triinpoel,
+                 const std::vector< std::size_t >& nodemap );
 
     //! Partition the computational mesh
     void partition( int nchare );
@@ -331,6 +332,8 @@ class Partitioner : public CBase_Partitioner {
     std::map< int, std::vector< std::size_t > > m_bface;
     //! \brief Boundary face-node connectivity.
     std::vector< std::size_t > m_triinpoel;
+    //! \brief Local-global node-ID map.
+    std::vector< std::size_t > m_nodemap;
 
     //! Read our contiguously-numbered chunk of the mesh graph from file
     void readGraph( tk::ExodusIIMeshReader& er );

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -215,11 +215,14 @@ Transporter::createPartitioner()
   std::vector< std::size_t > triinpoel;
   const auto scheme = g_inputdeck.get< tag::selected, tag::scheme >();
 
+  // Read local to global node-ID map from file
+  auto nodemap = er.readNodemap();
+
   // Read triangle boundary-face connectivity
   if (scheme == ctr::SchemeType::DG) {
     m_print.diag( "Reading side set faces" );
     nbfac = er.readSidesetFaces( bface );
-    er.readFaces( nbfac, triinpoel );
+    er.readFaces( nbfac, nodemap, triinpoel );
   }
 
   // Verify that side sets to which boundary conditions are assigned by user
@@ -252,7 +255,7 @@ Transporter::createPartitioner()
   // Create mesh partitioner Charm++ chare group
   m_partitioner =
     CProxy_Partitioner::ckNew( cbp, thisProxy, m_solver, m_bc, m_scheme,
-                               nbfac, bface, triinpoel );
+                               nbfac, bface, triinpoel, nodemap );
 }
 
 void

--- a/src/Inciter/partitioner.ci
+++ b/src/Inciter/partitioner.ci
@@ -28,7 +28,8 @@ module partitioner {
         const Scheme& scheme,
         std::size_t nbfac,
         const std::map< int, std::vector< std::size_t > >& bface,
-        const std::vector< std::size_t >& triinpoel );
+        const std::vector< std::size_t >& triinpoel,
+        const std::vector< std::size_t >& nodemap );
       entry void partition( int nchare );
       entry void add( int frompe,
             const std::unordered_map< int, std::vector< std::size_t > >& elem );

--- a/src/Mesh/DerivedData.C
+++ b/src/Mesh/DerivedData.C
@@ -811,7 +811,7 @@ genNbfacTet( std::size_t tnbfac,
              const std::vector< std::size_t >& triinpoel_complete,
              const std::map< int, std::vector< std::size_t > >& bface_complete,
              std::vector< std::size_t >& triinpoel,
-             std::map< int, std::vector< std::size_t > > bface )
+             std::map< int, std::vector< std::size_t > >& bface )
 // *****************************************************************************
 //  Generate the number of boundary-faces and the triangle boundary-face
 //  connectivity for a chunk of a full mesh.

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -115,6 +115,8 @@ genInpofaTet( std::size_t ntfac,
 std::vector< std::size_t >
 genBelemTet( std::size_t nbfac,
               const std::vector< std::size_t >& inpofa,
+              const std::vector< std::size_t >& nodemap,
+              const std::vector< std::size_t >& gid,
               const std::pair< std::vector< std::size_t >,
                                std::vector< std::size_t > >& esup );
 

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -85,7 +85,9 @@ std::size_t
 genNbfacTet( std::size_t tnbfac,
              const std::vector< std::size_t >& inpoel,
              const std::vector< std::size_t >& triinpoel_complete,
-             std::vector< std::size_t >& triinpoel );
+             const std::map< int, std::vector< std::size_t > >& bface_complete,
+             std::vector< std::size_t >& triinpoel,
+             std::map< int, std::vector< std::size_t > > bface );
 
 //! Generate derived data structure, total number of faces
 std::size_t

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -87,7 +87,7 @@ genNbfacTet( std::size_t tnbfac,
              const std::vector< std::size_t >& triinpoel_complete,
              const std::map< int, std::vector< std::size_t > >& bface_complete,
              std::vector< std::size_t >& triinpoel,
-             std::map< int, std::vector< std::size_t > > bface );
+             std::map< int, std::vector< std::size_t > >& bface );
 
 //! Generate derived data structure, total number of faces
 std::size_t

--- a/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
+++ b/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
@@ -1550,7 +1550,8 @@ void ExodusIIMeshReader_object::test< 5 >() {
 
   // Read boundary face-node connectivity
   std::vector< std::size_t > triinpoel;
-  er.readFaces( nbfac, triinpoel );
+  auto nodemap = er.readNodemap();
+  er.readFaces( nbfac, nodemap, triinpoel );
 
   // Generate correct solution for face-node connectivity
   std::vector< int > correct_triinpoel {  2,  9,  3,
@@ -1598,7 +1599,8 @@ void ExodusIIMeshReader_object::test< 6 >() {
     std::vector< std::size_t > triinpoel;
     std::string infile( REGRESSION_DIR "/meshconv/gmsh_output/box_24_ss1.exo" );
     tk::ExodusIIMeshReader er( infile );
-    er.readFaces( 0, triinpoel );
+    auto nodemap = er.readNodemap();
+    er.readFaces( 0, nodemap, triinpoel );
     fail( "should throw exception" );
   }
   catch ( tk::Exception& ) {

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -2423,7 +2423,7 @@ template<> template<>
 void DerivedData_object::test< 65 >() {
   set_test_name( "Boundary faces (genNbfacTet) for tetrahedra" );
 
-  std::map< int, std::vector< std::size_t > > bface;
+  std::map< int, std::vector< std::size_t > > bface, t_bface;
 
   // Create unstructured-mesh object to read into
   tk::UnsMesh inmesh;
@@ -2431,7 +2431,7 @@ void DerivedData_object::test< 65 >() {
   std::string infile( REGRESSION_DIR
                       "/meshconv/gmsh_output/box_24_ss1.exo" );
   tk::ExodusIIMeshReader er( infile );
-  auto tnbfac = er.readSidesetFaces( bface );
+  auto tnbfac = er.readSidesetFaces( t_bface );
 
   // Test if the number of boundary faces is correct
   ensure_equals( "total number of boundary faces incorrect",
@@ -2489,24 +2489,52 @@ void DerivedData_object::test< 65 >() {
                                             4, 14,  8,
                                             1, 14,  4 };
 
+  // Correct Boundary-face node connectivity
+  std::vector< std::size_t > correct_triinpoel {  7, 10,  6,
+                                                  6, 10,  5,
+                                                  8, 10,  7,
+                                                 10,  8,  5,
+                                                  5,  8, 14,
+                                                  1,  5, 14,
+                                                  4, 14,  8,
+                                                  1, 14,  4,
+                                                  2,  9,  3,
+                                                  1,  9,  2,
+                                                  3,  9,  4,
+                                                  1,  4,  9,
+                                                  3, 12,  2,
+                                                 12,  6,  2,
+                                                  7, 12,  3,
+                                                 12,  7,  6,
+                                                 13,  7,  3,
+                                                  4, 13,  3,
+                                                 13,  8,  7,
+                                                  8, 13,  4,
+                                                  6, 11,  2,
+                                                  2, 11,  1,
+                                                 11,  6,  5,
+                                                 11,  5,  1 };
+
   // Shift node IDs to start from zero
   tk::shiftToZero( inpoel );
   tk::shiftToZero( t_triinpoel );
+  tk::shiftToZero( correct_triinpoel );
 
   std::vector< std::size_t > triinpoel;
 
-  auto nbfac = tk::genNbfacTet( tnbfac, inpoel, t_triinpoel, triinpoel );
+  auto nbfac = tk::genNbfacTet( tnbfac, inpoel, t_triinpoel, t_bface,
+                                triinpoel, bface );
 
   ensure_equals( "number of boundary-faces is incorrect",
                  nbfac, tnbfac );
 
   ensure_equals( "total number of entries in triinpoel is incorrect",
-                 triinpoel.size(), t_triinpoel.size() );
+                 triinpoel.size(), correct_triinpoel.size() );
 
   for(std::size_t i=0 ; i<triinpoel.size(); ++i)
   {
     ensure_equals("incorrect entry " + std::to_string(i) + " in triinpoel",
-                    triinpoel[i], t_triinpoel[i]);
+                    triinpoel[i], correct_triinpoel[i]);
   }
 }
 

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -3353,6 +3353,12 @@ void DerivedData_object::test< 68 >() {
                                             13,
                                             10 };
 
+  std::vector< std::size_t > nodemap { 0, 1, 2,  3,  4,  5,  6, 
+                                       7, 8, 9, 10, 11, 12, 13 };
+
+  std::vector< std::size_t > gid { 0, 1, 2,  3,  4,  5,  6, 
+                                   7, 8, 9, 10, 11, 12, 13 };
+
   // Shift node IDs to start from zero
   tk::shiftToZero( inpoel );
   tk::shiftToZero( triinpoel );
@@ -3361,7 +3367,7 @@ void DerivedData_object::test< 68 >() {
   auto esuel = tk::genEsuelTet( inpoel, esup );
   auto ntfac = tk::genNtfac( 4, nbfac, esuel );
   auto inpofa = tk::genInpofaTet( ntfac, nbfac, inpoel, triinpoel, esuel );
-  auto belem = tk::genBelemTet( nbfac, inpofa, esup );
+  auto belem = tk::genBelemTet( nbfac, inpofa, nodemap, gid, esup );
 
   ensure_equals( "total number of entries in belem is incorrect",
                  belem.size(), correct_belem.size() );


### PR DESCRIPTION
This set of commits has two purposes:
1) Get the global node-IDs instead of the local node-IDs, so the the
node-IDs from the code match the ones in the Exodus mesh file.
2) Split the bface map, which associates each boundary face to a side
set, to maps for each mesh-chunk, for parallel computing.

A note for the first point above:
There are three sets of node-IDs in Quinoa. The Exodus-global, Exodus-local, and local-renumbered node IDs. This commit ensures that this mapping from the Exodus-global to local-renumbered and vice-versa is done correctly; since it is required for DG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/204)
<!-- Reviewable:end -->
