### PR TITLE
Re-enable progress indicators in inciter

### DIFF
--- a/src/Base/Progress.h
+++ b/src/Base/Progress.h
@@ -56,7 +56,7 @@ class Progress {
    //!   descriptive of all the sub-tasks we are responsible for. I.e., this
    //!   is usually a list of multiple sub-tasks happening at the same time.
    void start( const std::string& msg ) {
-     m_print.diag( msg );
+     m_print.diagstart( msg );
      m_progress_size = 0;
    }
 
@@ -101,6 +101,7 @@ class Progress {
      m_finished = true;
      m_done = m_max;
      report();
+     m_print.diagend( "done" );
    }
 
   private:

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -169,8 +169,8 @@ class Partitioner : public CBase_Partitioner {
     //! \brief Query our global node IDs and edges by other PEs so they know if
     //!   they are to receive IDs for those from during reordering
     void query( int p,
-                const std::set< std::size_t >& nodes,
-                const tk::UnsMesh::Edges& edges ) const;
+                const std::vector< std::size_t >& nodes,
+                const std::vector< std::size_t >& edges );
 
     //! Receive mask of to-be-received global mesh node IDs
     void mask( int p,
@@ -213,12 +213,17 @@ class Partitioner : public CBase_Partitioner {
     //!   computing global mesh node ID offsets for each PE rquired for node
     //!   reordering later
     std::size_t m_noffset;
+    //! \brief Counter for number of queries for global mesh node IDs
+    //! \details This counts the number of queries received while
+    //!   gathering the node IDs that need to be received (instead of uniquely
+    //!   assigned) by each PE
+    std::size_t m_nquery;
     //! \brief Counter for number of masks of to-be-received global mesh node
     //!   IDs received
     //! \details This counts the to-be-received node ID masks received while
     //!   gathering the node IDs that need to be received (instead of uniquely
     //!   assigned) by each PE
-    std::size_t m_nquery;
+    std::size_t m_nmask;
     //! Tetrtahedron element connectivity of our chunk of the mesh
     std::vector< std::size_t > m_tetinpoel;
     //! Global element IDs we read (our chunk of the mesh)

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -67,12 +67,8 @@ Transporter::Transporter() :
   m_progGraph( m_print, g_inputdeck.get< tag::cmd, tag::feedback >(),
                {{ "g" }}, {{ CkNumPes() }} ),
   m_progReorder( m_print, g_inputdeck.get< tag::cmd, tag::feedback >(),
-                 {{ "f", "m", "r", "b" }},
-                 {{ CkNumPes(), CkNumPes(), CkNumPes(), CkNumPes() }} ),
-  m_progSetup( m_print, g_inputdeck.get< tag::cmd, tag::feedback >(),
-               {{ "r", "m", "b" }} ),
-  m_progStep( m_print, g_inputdeck.get< tag::cmd, tag::feedback >(),
-              {{ "r", "s", "l", "p" }} )
+                 {{ "f", "q", "m", "r", "b" }},
+                 {{ CkNumPes(), CkNumPes(), CkNumPes(), CkNumPes(), CkNumPes() }} )
 // *****************************************************************************
 //  Constructor
 // *****************************************************************************
@@ -195,7 +191,7 @@ Transporter::createPartitioner()
 // *****************************************************************************
 {
   // Create mesh partitioner Charm++ chare group and start partitioning mesh
-  m_progGraph.start( "Creating partitioners and reading mesh graph" );
+  m_progGraph.start( "Creating partitioners and reading mesh ..." );
 
   // Start timing mesh read
   m_timer[ TimerTag::MESHREAD ];
@@ -204,11 +200,9 @@ Transporter::createPartitioner()
   tk::ExodusIIMeshReader er(g_inputdeck.get< tag::cmd, tag::io, tag::input >());
 
   // Read in side sets associated to mesh node IDs from file
-  m_print.diag( "Reading side sets" );
   auto sidenodes = er.readSidesets();
 
   // Read side sets for boundary faces
-  m_print.diag( "Reading side set faces" );
   std::map< int, std::vector< std::size_t > > bface;
   std::size_t nbfac = 0;
 
@@ -220,7 +214,6 @@ Transporter::createPartitioner()
 
   // Read triangle boundary-face connectivity
   if (scheme == ctr::SchemeType::DG) {
-    m_print.diag( "Reading side set faces" );
     nbfac = er.readSidesetFaces( bface );
     er.readFaces( nbfac, nodemap, triinpoel );
   }
@@ -381,7 +374,7 @@ Transporter::part()
 {
   const auto& timer = tk::cref_find( m_timer, TimerTag::MESHREAD );
   m_print.diag( "Mesh read time: " + std::to_string(timer.dsec()) + " sec" );
-  m_progPart.start( "Partitioning and distributing mesh" );
+  m_progPart.start( "Partitioning and distributing mesh ..." );
   // signal to runtime system that all workers are ready for mesh partitioning
   part_complete();
 }
@@ -395,7 +388,7 @@ Transporter::distributed()
 // *****************************************************************************
 {
   m_progPart.end();
-  m_progReorder.start( "Reordering mesh" );
+  m_progReorder.start( "Reordering mesh ..." );
   m_partitioner.flatten();
 }
 

--- a/src/Inciter/Transporter.h
+++ b/src/Inciter/Transporter.h
@@ -426,28 +426,14 @@ class Transporter : public CBase_Transporter {
 
     //! Non-reduction target for receiving progress report on flattening mesh
     void peflattened() { m_progReorder.inc<0>(); }
+    //! Non-reduction target for receiving progress report on node ID query
+    void pequery() { m_progReorder.inc<1>(); }
     //! Non-reduction target for receiving progress report on node ID mask
-    void pemask() { m_progReorder.inc<1>(); }
+    void pemask() { m_progReorder.inc<2>(); }
     //! Non-reduction target for receiving progress report on reordering mesh
-    void pereordered() { m_progReorder.inc<2>(); }
+    void pereordered() { m_progReorder.inc<3>(); }
     //! Non-reduction target for receiving progress report on computing bounds
-    void pebounds() { m_progReorder.inc<3>(); }
-
-    //! Non-reduction target for receiving progress report on establishing comms
-    void pecomfinal() { m_progSetup.inc<0>(); }
-    //! Non-reduction target for receiving progress report on matching BCs
-    void chbcmatched() { m_progSetup.inc<1>(); }
-    //! Non-reduction target for receiving progress report on computing BCs
-    void pebccomplete() { m_progSetup.inc<2>(); }
-
-    //! Non-reduction target for receiving progress report on computing the RHS
-    void chrhs() { m_progStep.inc<0>(); }
-    //! Non-reduction target for receiving progress report on solving the system
-    void pesolve() { m_progStep.inc<1>(); }
-    //! Non-reduction target for receiving progress report on limiting
-    void chlim() { m_progStep.inc<2>(); }
-    //! Non-reduction target for receiving progress report on tracking particles
-    void chtrack() { m_progStep.inc<3>(); }
+    void pebounds() { m_progReorder.inc<4>(); }
 
     //! \brief Reduction target indicating that the communication has been
     //!    established among PEs
@@ -520,11 +506,7 @@ class Transporter : public CBase_Transporter {
     // Progress object for task "Creating partitioners and reading mesh graph"
     tk::Progress< 1 > m_progGraph;
     // Progress object for task "Reordering mesh"
-    tk::Progress< 4 > m_progReorder;
-    // Progress object for task "Computing row IDs, querying BCs, ..."
-    tk::Progress< 3 > m_progSetup;
-    // Progress object for sub-tasks of a time step
-    tk::Progress< 4 > m_progStep;
+    tk::Progress< 5 > m_progReorder;
 
     //! Create linear solver group
     void createSolver();

--- a/src/Inciter/Transporter.h
+++ b/src/Inciter/Transporter.h
@@ -358,6 +358,14 @@ namespace inciter {
 //! Transporter drives the time integration of transport equations
 class Transporter : public CBase_Transporter {
 
+  private:
+    //! Indices for progress report on mesh graph
+    enum ProgGraph{ GRAPH=0 };
+    //! Indices for progress report on mesh partitioning
+    enum ProgPart{ PART=0, DIST };
+    //! Indices for progress report on mesh reordering
+    enum ProgReord{ FLAT=0, QUERY, MASK, REORD, BOUND };
+
   public:
     #if defined(__clang__)
       #pragma clang diagnostic push
@@ -417,23 +425,23 @@ class Transporter : public CBase_Transporter {
     void coord();
 
     //! Non-reduction target for receiving progress report on reading mesh graph
-    void pegraph() { m_progGraph.inc<0>(); }
+    void pegraph() { m_progGraph.inc< GRAPH >(); }
 
     //! Non-reduction target for receiving progress report on partitioning mesh
-    void pepartitioned() { m_progPart.inc<0>(); }
+    void pepartitioned() { m_progPart.inc< PART >(); }
     //! Non-reduction target for receiving progress report on distributing mesh
-    void pedistributed() { m_progPart.inc<1>(); }
+    void pedistributed() { m_progPart.inc< DIST >(); }
 
     //! Non-reduction target for receiving progress report on flattening mesh
-    void peflattened() { m_progReorder.inc<0>(); }
+    void peflattened() { m_progReorder.inc< FLAT >(); }
     //! Non-reduction target for receiving progress report on node ID query
-    void pequery() { m_progReorder.inc<1>(); }
+    void pequery() { m_progReorder.inc< QUERY >(); }
     //! Non-reduction target for receiving progress report on node ID mask
-    void pemask() { m_progReorder.inc<2>(); }
+    void pemask() { m_progReorder.inc< MASK >(); }
     //! Non-reduction target for receiving progress report on reordering mesh
-    void pereordered() { m_progReorder.inc<3>(); }
+    void pereordered() { m_progReorder.inc< REORD >(); }
     //! Non-reduction target for receiving progress report on computing bounds
-    void pebounds() { m_progReorder.inc<4>(); }
+    void pebounds() { m_progReorder.inc< BOUND >(); }
 
     //! \brief Reduction target indicating that the communication has been
     //!    established among PEs

--- a/src/Inciter/partitioner.ci
+++ b/src/Inciter/partitioner.ci
@@ -45,8 +45,8 @@ module partitioner {
       entry void stdCost( tk::real av );
       entry void gather();
       entry void query( int pe,
-                        const std::set< std::size_t >& nodes,
-                        const tk::UnsMesh::Edges& edges );
+                        const std::vector< std::size_t >& nodes,
+                        const std::vector< std::size_t >& edges );
       entry void mask( int pe,
                        const std::unordered_map< std::size_t,
                                                  std::vector< int > >& cn,

--- a/src/Inciter/transporter.ci
+++ b/src/Inciter/transporter.ci
@@ -42,17 +42,10 @@ module transporter {
       entry void pedistributed();
 
       entry void peflattened();
+      entry void pequery();
       entry void pemask();
       entry void pereordered();
       entry void pebounds();
-
-      entry void pecomfinal();
-      entry void chbcmatched();
-      entry void pebccomplete();
-
-      entry void chrhs();
-      entry void pesolve();
-      entry void chlim();
 
       // SDAG code follows. See http://charm.cs.illinois.edu/manuals/html/
       // charm++/manual.html, Sec. "Structured Control Flow: Structured Dagger".

--- a/src/LinSys/Solver.C
+++ b/src/LinSys/Solver.C
@@ -654,7 +654,6 @@ Solver::addbc( CkReductionMsg* msg )
   PUP::fromMem creator( msg->getData() );
   creator | m_bc;
   delete msg;
-  //if (m_feedback) m_host.pebccomplete();    // send progress report to host
   m_nchbc = 0;
   bc_complete();  bc_complete();
 }
@@ -1030,11 +1029,6 @@ Solver::solve()
 // *****************************************************************************
 {
   m_solver.solve( m_A, m_b, m_x );
-
-  // send progress report to host
-  //if (m_feedback) m_host.pesolve();
-
-  //solve_complete();
   updateSol();
 }
 

--- a/src/LinSys/Solver.h
+++ b/src/LinSys/Solver.h
@@ -342,16 +342,16 @@ class Solver : public CBase_Solver {
       , tag::coord, CkCallback
       , tag::diag,  CkCallback
     > m_cb;
-    std::size_t m_ncomp;        //!< Number of scalar components per unknown
-    std::size_t m_nchare;       //!< Number of chares contributing to my PE
-    std::size_t m_nperow;       //!< Number of fellow PEs to send row ids to
-    std::size_t m_nchbc;        //!< Number of chares we received bcs from
-    std::size_t m_lower;        //!< Lower index of the global rows on my PE
-    std::size_t m_upper;        //!< Upper index of the global rows on my PE
+    std::size_t m_ncomp;       //!< Number of scalar components per unknown
+    std::size_t m_nchare;      //!< Number of chares contributing to my PE
+    std::size_t m_nperow;      //!< Number of fellow PEs to send row ids to
+    std::size_t m_nchbc;       //!< Number of chares we received bcs from
+    std::size_t m_lower;       //!< Lower index of the global rows on my PE
+    std::size_t m_upper;       //!< Upper index of the global rows on my PE
     uint64_t m_it;             //!< Iteration count (original in Discretization)
     tk::real m_t;              //!< Physical time (original in Discretization)
     tk::real m_dt;             //!< Time step size (original in Discretization)
-    //bool m_feedback;            //!< Whether to send sub-task feedback to host
+    bool m_feedback;           //!< Whether to send sub-task feedback to host
     //! Ids of workers on my PE
     std::vector< int > m_myworker;
     //! \brief Import map associating a list of global row ids to a worker chare


### PR DESCRIPTION
Progress indicators (`tk::Progress`) can be used for getting additional diagnostics info useful during large runs, enabled by the `-f` (_feedback_) command linear argument for inciter. This commit also takes out some stale, now unused, progress indicators that have been disabledt during a recent revamp of the discretization classes.

Another important change is to convert node and edge sets before sending them in `Partitioner::query` as the receiving side does not search, so a vector is sufficient. This results in 30% speedup, measured on 288 CPU cores with a 18M mesh with and without initial uniform mesh refinement (yielding a 146M mesh) - both 30% speedup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/208)
<!-- Reviewable:end -->
