### PR TITLE
Serial implementation of linear Advection using DGP0

### DIFF
--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -379,13 +379,10 @@ ExodusIIMeshReader::readElements( const std::array< std::size_t, 2 >& ext,
 
 void
 ExodusIIMeshReader::readFaces( std::size_t nbfac,
-                               const std::vector< std::size_t >& node_map,
                                std::vector< std::size_t >& conn )
 // *****************************************************************************
 //  Read face connectivity of a number of boundary faces from ExodusII file
 //! \param[in] nbfac Number of boundary faces
-//! \param[in] node_map Vector mapping the local Exodus node-IDs to global
-//!            node-IDs
 //! \param[inout] conn Connectivity vector to push to
 //! \details This function reads-in the total number of boundary faces 
 //!   also called triangle-elements in the EXO2 file, and their connectivity.
@@ -406,7 +403,7 @@ ExodusIIMeshReader::readFaces( std::size_t nbfac,
     count = f*nnpf;
     for (std::size_t i=0; i<nnpf; ++i)
     {
-      conn.push_back( node_map[ l_triinpoel[count+i] ] );
+      conn.push_back( l_triinpoel[count+i] );
     }
   }
 }

--- a/src/IO/ExodusIIMeshReader.h
+++ b/src/IO/ExodusIIMeshReader.h
@@ -90,7 +90,6 @@ class ExodusIIMeshReader {
 
     //! Read face connectivity of a number boundary faces from file
     void readFaces( std::size_t nbfac,
-                    const std::vector< std::size_t >& nodemap,
                     std::vector< std::size_t >& conn );
 
     //! Read local to global node-ID map

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -39,12 +39,10 @@ DG::DG( const CProxy_Discretization& disc,
   m_fd( fd ),
   m_u( m_disc[thisIndex].ckLocal()->Inpoel().size()/4,
        g_inputdeck.get< tag::component >().nprop() ),
-  m_un( m_disc[thisIndex].ckLocal()->Inpoel().size()/4,
-        g_inputdeck.get< tag::component >().nprop() ),
+  m_un( m_u.nunk(), m_u.nprop() ),
   m_vol( 0.0 ),
   m_lhs( m_disc[thisIndex].ckLocal()->Inpoel().size()/4, 0.0 ),
-  m_rhs( m_disc[thisIndex].ckLocal()->Inpoel().size()/4,
-         g_inputdeck.get< tag::component >().nprop() )
+  m_rhs( m_u.nunk(), m_u.nprop() )
 // *****************************************************************************
 //  Constructor
 // *****************************************************************************

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -64,6 +64,7 @@ class DG : public CBase_DG {
       p | m_fd;
       p | m_nelem;
       p | m_u;
+      p | m_un;
       p | m_vol;
       p | m_geoFace;
       p | m_geoElem;
@@ -90,6 +91,8 @@ class DG : public CBase_DG {
     std::size_t m_nelem;
     //! Vector of unknown/solution average over each mesh element
     tk::Fields m_u;
+    //! Vector of unknown at previous time-step
+    tk::Fields m_un;
     //! Total mesh volume
     tk::real m_vol;
     //! Face geometry
@@ -123,7 +126,7 @@ class DG : public CBase_DG {
                                         std::vector< tk::real > fn );
 
     //! Time stepping
-    void tstep();
+    void tstep( tk::real dt );
 
     //! Prepare for next step
     void next();

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -61,10 +61,17 @@ class DG : public CBase_DG {
       CBase_DG::pup(p);
       p | m_itf;
       p | m_disc;
+      p | m_fd;
+      p | m_nelem;
       p | m_u;
       p | m_vol;
       p | m_geoFace;
       p | m_geoElem;
+      p | m_ax;
+      p | m_ay;
+      p | m_az;
+      p | m_lhs;
+      p | m_rhs;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -77,6 +84,10 @@ class DG : public CBase_DG {
     uint64_t m_itf;
     //! Discretization proxy
     CProxy_Discretization m_disc;
+    //! Face data
+    FaceData m_fd;
+    //! Total number of elements in this chunk
+    std::size_t m_nelem;
     //! Vector of unknown/solution average over each mesh element
     tk::Fields m_u;
     //! Total mesh volume
@@ -85,6 +96,14 @@ class DG : public CBase_DG {
     tk::Fields m_geoFace;
     //! Element geometry
     tk::Fields m_geoElem;
+    //! advection velocity x, y and z components
+    tk::real m_ax;
+    tk::real m_ay;
+    tk::real m_az;
+    //! Left-hand side mass-matrix which is a diagonal matrix
+    std::vector< tk::real > m_lhs;
+    //! Vector of right-hand side
+    tk::Fields m_rhs;
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {
@@ -92,8 +111,19 @@ class DG : public CBase_DG {
       return m_disc[ thisIndex ].ckLocal();
     }
 
+    //! Compute left hand side
+    void lhs();
+
     //! Compute right hand side
     void rhs();
+
+    //! Upwind fluxes
+    std::vector< tk::real > upwindFlux( std::vector< tk::real > ul,
+                                        std::vector< tk::real > ur,
+                                        std::vector< tk::real > fn );
+
+    //! Time stepping
+    void tstep();
 
     //! Prepare for next step
     void next();

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -62,7 +62,6 @@ class DG : public CBase_DG {
       p | m_itf;
       p | m_disc;
       p | m_fd;
-      p | m_nelem;
       p | m_u;
       p | m_un;
       p | m_vol;
@@ -87,8 +86,6 @@ class DG : public CBase_DG {
     CProxy_Discretization m_disc;
     //! Face data
     FaceData m_fd;
-    //! Total number of elements in this chunk
-    std::size_t m_nelem;
     //! Vector of unknown/solution average over each mesh element
     tk::Fields m_u;
     //! Vector of unknown at previous time-step
@@ -123,10 +120,10 @@ class DG : public CBase_DG {
     //! Upwind fluxes
     std::vector< tk::real > upwindFlux( std::vector< tk::real > ul,
                                         std::vector< tk::real > ur,
-                                        std::vector< tk::real > fn );
+                                        std::array< tk::real, 3 > fn );
 
     //! Time stepping
-    void tstep( tk::real dt );
+    void solve( tk::real dt );
 
     //! Prepare for next step
     void next();

--- a/src/Inciter/FaceData.C
+++ b/src/Inciter/FaceData.C
@@ -24,8 +24,7 @@ FaceData::FaceData(
   const std::vector< std::size_t >& conn,
   std::size_t nbfac_complete,
   const std::map< int, std::vector< std::size_t > >& bface_complete,
-  const std::vector< std::size_t >& triinpoel_complete,
-  const std::vector< std::size_t >& nodemap )
+  const std::vector< std::size_t >& triinpoel_complete )
 // *****************************************************************************
 //  Constructor
 //! \param[in] conn Vector of mesh element connectivity owned (global IDs)
@@ -48,30 +47,28 @@ FaceData::FaceData(
     auto el = tk::global2local( conn );   // fills inpoel, m_gid, m_lid
     auto inpoel = std::get< 0 >( el );
     auto gid = std::get< 1 >( el );
+    auto lid = std::get< 2 >( el );
 
-    // Derived face data computations that require zero-based inpoel, esup
     auto esup = tk::genEsup(inpoel,4);
     m_esuel = tk::genEsuelTet( inpoel, esup );
 
     auto l_inpoel = inpoel;
 
-    // Mapping inpoel from local node ids to Exodus-global node ids
+    // Mapping inpoel from local renumbered ids to global renumbered node ids
     for (std::size_t e=0; e<inpoel.size()/4; ++e)
     {
-            inpoel[4*e]   = nodemap[ gid[ l_inpoel[4*e]   ] ];
-            inpoel[4*e+1] = nodemap[ gid[ l_inpoel[4*e+1] ] ];
-            inpoel[4*e+2] = nodemap[ gid[ l_inpoel[4*e+2] ] ];
-            inpoel[4*e+3] = nodemap[ gid[ l_inpoel[4*e+3] ] ];
+      inpoel[4*e]   = gid[ l_inpoel[4*e]   ];
+      inpoel[4*e+1] = gid[ l_inpoel[4*e+1] ];
+      inpoel[4*e+2] = gid[ l_inpoel[4*e+2] ];
+      inpoel[4*e+3] = gid[ l_inpoel[4*e+3] ];
     }
 
-    // Derived face data computations that require Exodus-global node ids
-    // in inpoel, esup
     m_nbfac = tk::genNbfacTet( nbfac_complete, inpoel, triinpoel_complete,
-                               bface_complete, m_triinpoel, m_bface );
+                               bface_complete, lid, m_triinpoel, m_bface );
     m_ntfac = tk::genNtfac( 4, m_nbfac, m_esuel );
-    m_inpofa = tk::genInpofaTet( m_ntfac, m_nbfac, inpoel, m_triinpoel,
+    m_inpofa = tk::genInpofaTet( m_ntfac, m_nbfac, l_inpoel, m_triinpoel,
                                  m_esuel );
-    m_belem =  tk::genBelemTet( m_nbfac, m_inpofa, nodemap, gid, esup );
+    m_belem =  tk::genBelemTet( m_nbfac, m_inpofa, esup );
     m_esuf = tk::genEsuf( 4, m_ntfac, m_nbfac, m_belem, m_esuel );
 
     Assert( m_belem.size() == m_nbfac,

--- a/src/Inciter/FaceData.h
+++ b/src/Inciter/FaceData.h
@@ -26,8 +26,7 @@ class FaceData
         const std::vector< std::size_t >& conn,
         std::size_t nbfac_complete,
         const std::map< int, std::vector< std::size_t > >& bface,
-        const std::vector< std::size_t >& triinpoel_complete,
-        const std::vector< std::size_t >& nodemap );
+        const std::vector< std::size_t >& triinpoel_complete );
 
     /** @name Accessors
       * */

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -34,8 +34,7 @@ Partitioner::Partitioner(
   const Scheme& scheme,
   std::size_t nbfac,
   const std::map< int, std::vector< std::size_t > >& bface,
-  const std::vector< std::size_t >& triinpoel,
-  const std::vector< std::size_t >& nodemap ) :
+  const std::vector< std::size_t >& triinpoel ) :
   m_cb( cb[0], cb[1], cb[2], cb[3], cb[4], cb[5], cb[6] ),
   m_host( host ),
   m_solver( solver ),
@@ -72,8 +71,7 @@ Partitioner::Partitioner(
   m_msumed(),
   m_nbfac( nbfac ),
   m_bface( bface ),
-  m_triinpoel( triinpoel ),
-  m_nodemap( nodemap )
+  m_triinpoel( triinpoel )
 // *****************************************************************************
 //  Constructor
 //! \param[in] cb Charm++ callbacks
@@ -84,8 +82,6 @@ Partitioner::Partitioner(
 //! \param[in] nbfac Total number of boundary faces
 //! \param[in] bface Face lists mapped to side set ids
 //! \param[in] triinpoel Interconnectivity of points and boundary-face
-//! \param[in] nodemap Vector mapping the local Exodus node-IDs to global Exodus
-//!            node-IDs
 // *****************************************************************************
 {
   tk::ExodusIIMeshReader
@@ -1290,8 +1286,15 @@ Partitioner::createWorkers()
     // Make sure (bound) base is already created and accessible
     Assert( m_scheme.get()[cid].ckLocal() != nullptr, "About to pass nullptr" );
 
+    // Reorder the triinpoel
+    for(auto& i : m_triinpoel)
+    {
+      auto n = m_linnodes.find(i);
+      if (n != end(m_linnodes)) i = n->second;
+    }
+
     // Face data class
-    FaceData fd(tk::cref_find(m_chinpoel,cid), m_nbfac, m_bface, m_triinpoel, m_nodemap);
+    FaceData fd(tk::cref_find(m_chinpoel,cid), m_nbfac, m_bface, m_triinpoel);
 
     // Create worker array element
     m_scheme.insert( cid, m_scheme.get(), m_solver, fd, CkMyPe() );

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -122,8 +122,7 @@ class Partitioner : public CBase_Partitioner {
                  const Scheme& scheme,
                  std::size_t nbfac,
                  const std::map< int, std::vector< std::size_t > >& bface,
-                 const std::vector< std::size_t >& triinpoel,
-                 const std::vector< std::size_t >& nodemap );
+                 const std::vector< std::size_t >& triinpoel );
 
     //! Partition the computational mesh
     void partition( int nchare );
@@ -337,12 +336,6 @@ class Partitioner : public CBase_Partitioner {
     std::map< int, std::vector< std::size_t > > m_bface;
     //! \brief Boundary face-node connectivity.
     std::vector< std::size_t > m_triinpoel;
-    //! \brief Local-global node-ID map.
-    //! \details The node-map is required to get the "Exodus-global" node-IDs
-    //!   from the "Exodus-internal" node-IDs, which are returned from the exodus
-    //!   APIs. The node-IDs in the exodus file are referred to as the 
-    //!   "Exodus-global" node-IDs or "fileIDs" in Quinoa.
-    std::vector< std::size_t > m_nodemap;
 
     //! Read our contiguously-numbered chunk of the mesh graph from file
     void readGraph( tk::ExodusIIMeshReader& er );

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -209,13 +209,10 @@ Transporter::createPartitioner()
   std::vector< std::size_t > triinpoel;
   const auto scheme = g_inputdeck.get< tag::selected, tag::scheme >();
 
-  // Read local to global node-ID map from file
-  auto nodemap = er.readNodemap();
-
   // Read triangle boundary-face connectivity
   if (scheme == ctr::SchemeType::DG) {
     nbfac = er.readSidesetFaces( bface );
-    er.readFaces( nbfac, nodemap, triinpoel );
+    er.readFaces( nbfac, triinpoel );
   }
 
   // Verify that side sets to which boundary conditions are assigned by user
@@ -248,7 +245,7 @@ Transporter::createPartitioner()
   // Create mesh partitioner Charm++ chare group
   m_partitioner =
     CProxy_Partitioner::ckNew( cbp, thisProxy, m_solver, m_bc, m_scheme,
-                               nbfac, bface, triinpoel, nodemap );
+                               nbfac, bface, triinpoel );
 }
 
 void

--- a/src/Inciter/partitioner.ci
+++ b/src/Inciter/partitioner.ci
@@ -28,8 +28,7 @@ module partitioner {
         const Scheme& scheme,
         std::size_t nbfac,
         const std::map< int, std::vector< std::size_t > >& bface,
-        const std::vector< std::size_t >& triinpoel,
-        const std::vector< std::size_t >& nodemap );
+        const std::vector< std::size_t >& triinpoel );
       entry void partition( int nchare );
       entry void add( int frompe,
             const std::unordered_map< int, std::vector< std::size_t > >& elem );

--- a/src/Mesh/DerivedData.C
+++ b/src/Mesh/DerivedData.C
@@ -810,6 +810,7 @@ genNbfacTet( std::size_t tnbfac,
              const std::vector< std::size_t >& inpoel,
              const std::vector< std::size_t >& triinpoel_complete,
              const std::map< int, std::vector< std::size_t > >& bface_complete,
+             const std::unordered_map< std::size_t, std::size_t >& lid,
              std::vector< std::size_t >& triinpoel,
              std::map< int, std::vector< std::size_t > >& bface )
 // *****************************************************************************
@@ -823,6 +824,8 @@ genNbfacTet( std::size_t tnbfac,
 //!   in the entire mesh.
 //! \param[in] bface_complete Map of boundary-face lists mapped to corresponding 
 //!   side set ids for the entire mesh.
+//! \param[in] lid Map of global renumbered node-IDs to local renumbered
+//!   node-IDs
 //! \param[inout] triinpoel Interconnectivity of points and boundary-face in
 //!   this mesh-partition.
 //! \param[inout] bface Map of boundary-face lists mapped to corresponding 
@@ -893,9 +896,17 @@ genNbfacTet( std::size_t tnbfac,
       if (tag == nnpf)
       // this is a boundary face
       {
-        triinpoel.push_back( triinpoel_complete[icoun] );
-        triinpoel.push_back( triinpoel_complete[icoun+1] );
-        triinpoel.push_back( triinpoel_complete[icoun+2] );
+        for (std::size_t i=0; i<nnpf; ++i)
+        {
+          auto ip = triinpoel_complete[icoun+i];
+
+          // find local renumbered node-id to store in triinpoel
+          auto nd = lid.find( ip );
+          if (nd != end(lid))
+          {
+            triinpoel.push_back( nd->second );
+          }
+        }
 
         bface[ss.first].push_back(nbfac);
         ++nbfac;
@@ -1154,7 +1165,7 @@ genInpofaTet( std::size_t ntfac,
 //! \param[in] inpoel Element-node connectivity.
 //! \param[in] triinpoel Face-node connectivity.
 //! \param[in] esuelTet Elements surrounding elements.
-//! \return Elements surrounding faces. The unsigned integer vector gives the
+//! \return Points surrounding faces. The unsigned integer vector gives the
 //!   elements to the left and to the right of each face in the mesh.
 // *****************************************************************************
 {
@@ -1211,10 +1222,9 @@ genInpofaTet( std::size_t ntfac,
   for (std::size_t f=0; f<nbfac; ++f)
   {
     icoun = nnpf * f;
-    for(std::size_t i=0; i<nnpf ; ++i)
-    {
-      inpofa[icoun+i] = triinpoel[icoun+i];
-    }
+    inpofa[icoun+0] = triinpoel[icoun+2];
+    inpofa[icoun+1] = triinpoel[icoun+1];
+    inpofa[icoun+2] = triinpoel[icoun+0];
   }
   }
 
@@ -1224,8 +1234,6 @@ genInpofaTet( std::size_t ntfac,
 std::vector< std::size_t >
 genBelemTet( std::size_t nbfac,
               const std::vector< std::size_t >& inpofa,
-              const std::vector< std::size_t >& nodemap,
-              const std::vector< std::size_t >& gid,
               const std::pair< std::vector< std::size_t >,
                                std::vector< std::size_t > >& esup )
 // *****************************************************************************
@@ -1233,10 +1241,6 @@ genBelemTet( std::size_t nbfac,
 //   their faces with the domain boundary (host elements).
 //! \param[in] nbfac Number of boundary faces.
 //! \param[in] inpofa Face-node connectivity.
-//! \param[in] node_map Vector mapping the local Exodus node-IDs to global
-//!            Exodus node-IDs
-//! \param[in] gid Vector mapping the local renumbered node-IDs to local Exodus
-//!            node-IDs
 //! \param[in] esup Elements surrounding points as linked lists, see tk::genEsup
 //! \return Host elements or boundary elements. The unsigned integer vector
 //!   gives the elements to the left of each boundary face in the mesh.
@@ -1263,20 +1267,9 @@ genBelemTet( std::size_t nbfac,
     {
       auto gp = inpofa[nnpf*f + lp];
 
-      // 1. find the Exodus-local node ID for gp
-      auto it = std::find (nodemap.begin(), nodemap.end(), gp);
-      if (it == nodemap.end()) { continue; }
-      auto lgp = static_cast< std::size_t >(it-nodemap.begin());
-
-      // 2. find the renumbered node ID for lgp,
-      //    this is the local node id that esup uses
-      auto ip = std::find (gid.begin(), gid.end(), lgp);
-      Assert( ip != gid.end(), "gid map pointing to nothing!" );
-      auto rgp = static_cast< std::size_t >(ip-gid.begin());
-
-      Assert( rgp < esup.second.size(), "Indexing out of esup2" );
+      Assert( gp < esup.second.size(), "Indexing out of esup2" );
       // loop over elements surrounding this node
-      for (auto i=esup.second[rgp]+1; i<=esup.second[rgp+1]; ++i)
+      for (auto i=esup.second[gp]+1; i<=esup.second[gp+1]; ++i)
       {
         // form element-cluster vector
         elemcluster.push_back(esup.first[i]);

--- a/src/Mesh/DerivedData.C
+++ b/src/Mesh/DerivedData.C
@@ -824,8 +824,9 @@ genNbfacTet( std::size_t tnbfac,
 //!   in the entire mesh.
 //! \param[in] bface_complete Map of boundary-face lists mapped to corresponding 
 //!   side set ids for the entire mesh.
-//! \param[in] lid Map of global renumbered node-IDs to local renumbered
-//!   node-IDs
+//! \param[in] lid Mapping between the node indices used in the smaller inpoel
+//!   connectivity (a subset of the entire triinpoel_complete connectivity),
+//!   e.g., after mesh partitioning.
 //! \param[inout] triinpoel Interconnectivity of points and boundary-face in
 //!   this mesh-partition.
 //! \param[inout] bface Map of boundary-face lists mapped to corresponding 
@@ -901,11 +902,7 @@ genNbfacTet( std::size_t tnbfac,
           auto ip = triinpoel_complete[icoun+i];
 
           // find local renumbered node-id to store in triinpoel
-          auto nd = lid.find( ip );
-          if (nd != end(lid))
-          {
-            triinpoel.push_back( nd->second );
-          }
+          triinpoel.push_back( tk::cref_find(lid,ip) );
         }
 
         bface[ss.first].push_back(nbfac);

--- a/src/Mesh/DerivedData.h
+++ b/src/Mesh/DerivedData.h
@@ -86,6 +86,7 @@ genNbfacTet( std::size_t tnbfac,
              const std::vector< std::size_t >& inpoel,
              const std::vector< std::size_t >& triinpoel_complete,
              const std::map< int, std::vector< std::size_t > >& bface_complete,
+             const std::unordered_map< std::size_t, std::size_t >& lid,
              std::vector< std::size_t >& triinpoel,
              std::map< int, std::vector< std::size_t > >& bface );
 
@@ -115,8 +116,6 @@ genInpofaTet( std::size_t ntfac,
 std::vector< std::size_t >
 genBelemTet( std::size_t nbfac,
               const std::vector< std::size_t >& inpofa,
-              const std::vector< std::size_t >& nodemap,
-              const std::vector< std::size_t >& gid,
               const std::pair< std::vector< std::size_t >,
                                std::vector< std::size_t > >& esup );
 

--- a/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
+++ b/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
@@ -1551,33 +1551,34 @@ void ExodusIIMeshReader_object::test< 5 >() {
   // Read boundary face-node connectivity
   std::vector< std::size_t > triinpoel;
   auto nodemap = er.readNodemap();
-  er.readFaces( nbfac, nodemap, triinpoel );
+  er.readFaces( nbfac, triinpoel );
 
   // Generate correct solution for face-node connectivity
-  std::vector< int > correct_triinpoel {  2,  9,  3,
-                                          1,  9,  2,
-                                          3,  9,  4,
-                                          1,  4,  9,
-                                          7, 10,  6,
-                                          6, 10,  5,
-                                          8, 10,  7,
-                                         10,  8,  5,
-                                          6, 11,  2,
-                                          2, 11,  1,
-                                         11,  6,  5,
-                                         11,  5,  1,
-                                          3, 12,  2,
-                                         12,  6,  2,
-                                          7, 12,  3,
-                                         12,  7,  6,
-                                         13,  7,  3,
-                                          4, 13,  3,
-                                         13,  8,  7,
-                                          8, 13,  4,
-                                          5,  8, 14,
-                                          1,  5, 14,
-                                          4, 14,  8, 
-                                          1, 14,  4 };
+  std::vector< int > correct_triinpoel {   1,  2,  3,
+                                           4,  2,  1,
+                                           3,  2,  5,
+                                           4,  5,  2,
+                                           6,  7,  8,
+                                           8,  7,  9,
+                                          10,  7,  6,
+                                           7, 10,  9,
+                                           8, 11,  1,
+                                           1, 11,  4,
+                                          11,  8,  9,
+                                          11,  9,  4,
+                                           3, 12,  1,
+                                          12,  8,  1,
+                                           6, 12,  3,
+                                          12,  6,  8,
+                                          13,  6,  3,
+                                           5, 13,  3,
+                                          13, 10,  6,
+                                          10, 13,  5,
+                                           9, 10, 14,
+                                           4,  9, 14,
+                                           5, 14, 10,
+                                           4, 14,  5 };
+
 
   ensure_equals( "total number of entries in inpofa is incorrect",
                  triinpoel.size(), correct_triinpoel.size() );
@@ -1600,7 +1601,7 @@ void ExodusIIMeshReader_object::test< 6 >() {
     std::string infile( REGRESSION_DIR "/meshconv/gmsh_output/box_24_ss1.exo" );
     tk::ExodusIIMeshReader er( infile );
     auto nodemap = er.readNodemap();
-    er.readFaces( 0, nodemap, triinpoel );
+    er.readFaces( 0, triinpoel );
     fail( "should throw exception" );
   }
   catch ( tk::Exception& ) {

--- a/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
+++ b/src/UnitTest/tests/IO/TestExodusIIMeshReader.h
@@ -1550,7 +1550,6 @@ void ExodusIIMeshReader_object::test< 5 >() {
 
   // Read boundary face-node connectivity
   std::vector< std::size_t > triinpoel;
-  auto nodemap = er.readNodemap();
   er.readFaces( nbfac, triinpoel );
 
   // Generate correct solution for face-node connectivity
@@ -1600,12 +1599,37 @@ void ExodusIIMeshReader_object::test< 6 >() {
     std::vector< std::size_t > triinpoel;
     std::string infile( REGRESSION_DIR "/meshconv/gmsh_output/box_24_ss1.exo" );
     tk::ExodusIIMeshReader er( infile );
-    auto nodemap = er.readNodemap();
     er.readFaces( 0, triinpoel );
     fail( "should throw exception" );
   }
   catch ( tk::Exception& ) {
     // exception thrown, test ok
+  }
+}
+
+//! Read node-map
+template<> template<>
+void ExodusIIMeshReader_object::test< 7 >() {
+  set_test_name( "read the node-map" );
+
+  // Read in mesh from file
+  std::string infile( REGRESSION_DIR
+                      "/meshconv/gmsh_output/box_24_ss1.exo" );
+  tk::ExodusIIMeshReader er( infile );
+
+  auto nodemap = er.readNodemap();
+
+  // Generate correct solution for face-node connectivity
+  std::vector< std::size_t > correct_nodemap
+              { 2, 9, 3, 1, 4, 7, 10, 6, 5, 8, 11, 12, 13, 14};
+
+  ensure_equals( "total number of entries in inpofa is incorrect",
+                 nodemap.size(), correct_nodemap.size() );
+
+  for(std::size_t i=0 ; i<nodemap.size(); ++i)
+  {
+          ensure_equals("incorrect entry " + std::to_string(i) + " in nodemap",
+                          nodemap[i], correct_nodemap[i]-1);
   }
 }
 

--- a/src/UnitTest/tests/Mesh/TestDerivedData.h
+++ b/src/UnitTest/tests/Mesh/TestDerivedData.h
@@ -2515,6 +2515,22 @@ void DerivedData_object::test< 65 >() {
                                                  11,  6,  5,
                                                  11,  5,  1 };
 
+  std::unordered_map< std::size_t, std::size_t > lid {
+          { {0}, {0} },
+          { {1}, {1} },
+          { {2}, {2} },
+          { {3}, {3} },
+          { {4}, {4} },
+          { {5}, {5} },
+          { {6}, {6} },
+          { {7}, {7} },
+          { {8}, {8} },
+          { {9}, {9} },
+          { {10}, {10} },
+          { {11}, {11} },
+          { {12}, {12} },
+          { {13}, {13} } };
+
   // Shift node IDs to start from zero
   tk::shiftToZero( inpoel );
   tk::shiftToZero( t_triinpoel );
@@ -2522,7 +2538,7 @@ void DerivedData_object::test< 65 >() {
 
   std::vector< std::size_t > triinpoel;
 
-  auto nbfac = tk::genNbfacTet( tnbfac, inpoel, t_triinpoel, t_bface,
+  auto nbfac = tk::genNbfacTet( tnbfac, inpoel, t_triinpoel, t_bface, lid,
                                 triinpoel, bface );
 
   ensure_equals( "number of boundary-faces is incorrect",
@@ -3019,54 +3035,54 @@ void DerivedData_object::test< 67 >() {
   };
 
   // Read boundary face-node connectivity
-  std::vector< std::size_t > triinpoel {  9,  1, 24,
-                                         12,  1,  9,
-                                         24,  1, 20,
-                                         20,  1, 12,
-                                         20, 12, 23,
-                                         13, 24, 20,
-                                         13, 20,  5,
-                                          5, 20, 23,
-                                         13,  5, 16,
-                                          5, 23, 16,
-                                         19, 23, 12,
-                                         17, 24, 13,
-                                         21, 12,  9,
-                                         22, 13, 16,
-                                         17,  9, 24,
-                                         19, 16, 23,
-                                         17, 13,  6,
-                                          6, 13, 14,
-                                         12, 21,  4,
-                                          4, 19, 12,
-                                         10, 21,  9,
-                                          9, 17,  2,
-                                          9,  2, 10,
-                                         16, 19,  8,
-                                         16,  8, 15,
-                                         13, 22, 14,
-                                         22, 16, 15,
-                                         17,  6, 14,
-                                         19,  4, 25,
-                                          8, 19, 15,
-                                          2, 17, 10,
-                                         17, 14, 26,
-                                         25,  4, 11,
-                                         11,  4, 21,
-                                         19, 25, 15,
-                                         10, 17, 26,
-                                         11, 21, 10,
-                                          7, 22, 15,
-                                          7, 14, 22,
-                                         18, 15, 25,
-                                         18, 25, 11,
-                                         11, 10,  3,
-                                         10, 26, 18,
-                                         26, 14,  7,
-                                          7, 15, 18,
-                                         18, 11,  3,
-                                         10, 18,  3,
-                                         26,  7, 18 };
+  std::vector< std::size_t > triinpoel { 24,  1,  9,
+                                          9,  1, 12,
+                                         20,  1, 24,
+                                         12,  1, 20,
+                                         23, 12, 20,
+                                         20, 24, 13,
+                                          5, 20, 13,
+                                         23, 20,  5,
+                                         16,  5, 13,
+                                         16, 23,  5,
+                                         12, 23, 19,
+                                         13, 24, 17,
+                                          9, 12, 21,
+                                         16, 13, 22,
+                                         24,  9, 17,
+                                         23, 16, 19,
+                                          6, 13, 17,
+                                         14, 13,  6,
+                                          4, 21, 12,
+                                         12, 19,  4,
+                                          9, 21, 10,
+                                          2, 17,  9,
+                                         10,  2,  9,
+                                          8, 19, 16,
+                                         15,  8, 16,
+                                         14, 22, 13,
+                                         15, 16, 22,
+                                         14,  6, 17,
+                                         25,  4, 19,
+                                         15, 19,  8,
+                                         10, 17,  2,
+                                         26, 14, 17,
+                                         11,  4, 25,
+                                         21,  4, 11,
+                                         15, 25, 19,
+                                         26, 17, 10,
+                                         10, 21, 11,
+                                         15, 22,  7,
+                                         22, 14,  7,
+                                         25, 15, 18,
+                                         11, 25, 18,
+                                          3, 10, 11,
+                                         18, 26, 10,
+                                          7, 14, 26,
+                                         18, 15,  7,
+                                          3, 11, 18,
+                                          3, 18, 10,
+                                         18,  7, 26 };
 
   // Shift node IDs to start from zero
   tk::shiftToZero( triinpoel );
@@ -3353,12 +3369,6 @@ void DerivedData_object::test< 68 >() {
                                             13,
                                             10 };
 
-  std::vector< std::size_t > nodemap { 0, 1, 2,  3,  4,  5,  6, 
-                                       7, 8, 9, 10, 11, 12, 13 };
-
-  std::vector< std::size_t > gid { 0, 1, 2,  3,  4,  5,  6, 
-                                   7, 8, 9, 10, 11, 12, 13 };
-
   // Shift node IDs to start from zero
   tk::shiftToZero( inpoel );
   tk::shiftToZero( triinpoel );
@@ -3367,7 +3377,7 @@ void DerivedData_object::test< 68 >() {
   auto esuel = tk::genEsuelTet( inpoel, esup );
   auto ntfac = tk::genNtfac( 4, nbfac, esuel );
   auto inpofa = tk::genInpofaTet( ntfac, nbfac, inpoel, triinpoel, esuel );
-  auto belem = tk::genBelemTet( nbfac, inpofa, nodemap, gid, esup );
+  auto belem = tk::genBelemTet( nbfac, inpofa, esup );
 
   ensure_equals( "total number of entries in belem is incorrect",
                  belem.size(), correct_belem.size() );


### PR DESCRIPTION
This commit includes implementation of DGP0 for advection equation in serial. The test is the advection of a 2D Gaussian function. At this time the advection fluxes are hard-coded in a very ‘non-general’ way in DG.C. The next commit will migrate this code to DGPDE, and use the DGAdvection and Problem classes. Another set of changes is that the Global-Exodus node IDs are done away with in the DG.C, and the FaceData class now works with the local renumbered node-IDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/213)
<!-- Reviewable:end -->
