### PR TITLE
Read mesh node coordinates one by one in inciter

### DIFF
--- a/src/IO/ExodusIIMeshReader.C
+++ b/src/IO/ExodusIIMeshReader.C
@@ -140,24 +140,20 @@ ExodusIIMeshReader::readAllNodes( UnsMesh& mesh ) const
 }
 
 std::array< std::vector< tk::real >, 3 >
-ExodusIIMeshReader::readNodes( const std::array< std::size_t, 2 >& ext ) const
+ExodusIIMeshReader::readNodes( const std::vector< std::size_t >& gid ) const
 // *****************************************************************************
 //  Read coordinates of a number of mesh nodes from ExodusII file
-//! \param[in] ext Extents of element ids whose connectivity to read, both
-//!   inclusive
+//! \param[in] gid Node IDs whose coordinates to read
 //! \return Mesh node coordinates
 // *****************************************************************************
 {
-  auto num = ext[1] - ext[0] + 1;
-  std::vector< tk::real > px( num ), py( num ), pz( num );
+  std::vector< tk::real > px( gid.size() ), py( gid.size() ), pz( gid.size() );
 
-  ErrChk(
-    ex_get_partial_coord(
-      m_inFile, static_cast<int64_t>(ext[0])+1, static_cast<int64_t>(num),
-      px.data(), py.data(), pz.data() ) == 0,
-      "Failed to read coordinates of nodes [" + std::to_string(ext[0]) +
-      "..." + std::to_string(ext[1]) + "] from ExodusII file: " +
-      m_filename );
+  std::size_t i=0;
+  for (auto g : gid) {
+    readNode( g, i, px, py, pz );
+    ++i;
+  }
 
   return {{ std::move(px), std::move(py), std::move(pz) }};
 }

--- a/src/IO/ExodusIIMeshReader.h
+++ b/src/IO/ExodusIIMeshReader.h
@@ -78,7 +78,7 @@ class ExodusIIMeshReader {
 
     //! Read coordinates of a number of mesh nodes from ExodusII file
     std::array< std::vector< tk::real >, 3 >
-    readNodes( const std::array< std::size_t, 2 >& ext ) const;
+    readNodes( const std::vector< std::size_t >& gid ) const;
 
     //! Read element block IDs from file
     std::size_t readElemBlockIDs();

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -607,13 +607,12 @@ Partitioner::computeCentroids( tk::ExodusIIMeshReader& er )
 //! \param[in] er ExodusII mesh reader
 // *****************************************************************************
 {
-  // Construct unique global mesh point indices of our chunk
-  auto gid = m_tetinpoel;
-  tk::unique( gid );
+  auto el = tk::global2local( m_tetinpoel );
+  const auto& gid = std::get< 1 >( el );
+  const auto& lid = std::get< 2 >( el );
 
   // Read node coordinates of our chunk of the mesh elements from file
-  auto ext = tk::extents( gid );
-  auto coord = er.readNodes( ext );
+  auto coord = er.readNodes( gid );
   const auto& x = std::get< 0 >( coord );
   const auto& y = std::get< 1 >( coord );
   const auto& z = std::get< 2 >( coord );
@@ -629,10 +628,10 @@ Partitioner::computeCentroids( tk::ExodusIIMeshReader& er )
 
   // Compute element centroids for our chunk of the mesh elements
   for (std::size_t e=0; e<num; ++e) {
-    auto A = m_tetinpoel[e*4+0] - ext[0];
-    auto B = m_tetinpoel[e*4+1] - ext[0];
-    auto C = m_tetinpoel[e*4+2] - ext[0];
-    auto D = m_tetinpoel[e*4+3] - ext[0];
+    auto A = tk::cref_find( lid, m_tetinpoel[e*4+0] );
+    auto B = tk::cref_find( lid, m_tetinpoel[e*4+1] );
+    auto C = tk::cref_find( lid, m_tetinpoel[e*4+2] );
+    auto D = tk::cref_find( lid, m_tetinpoel[e*4+3] );
     cx[e] = (x[A] + x[B] + x[C] + x[D]) / 4.0;
     cy[e] = (y[A] + y[B] + y[C] + y[D]) / 4.0;
     cz[e] = (z[A] + z[B] + z[C] + z[D]) / 4.0;


### PR DESCRIPTION
_Note_: this is to be merged to branch `boundary` instead of `develop`, to show only the diff relevant to this single step towards several ones improving on the setup for mesh reordering in `Partitioner`.

Somewhat counterintuitively, reading mesh node coordinates one by one does not make reading the coordinates slower but it allows inciter to use a lot less memory when reading the mesh node coordinates in parallel.

_Background_: Since in a parallel run reading the mesh is distributed by elements, i.e., PE0 reads approximately elements 0...n, PE1 reads approximately elements n+1...2n, etc., node coordinates of all node IDs associated to elements that are read must be read in.  However, there is no reason to assume that the node IDs of the elements read are nicely contiguously numbered (and experience shows that they are usually not). Thus so far inciter has computed the extents, i.e., the minimum and maximum, of the global node IDs and read in all nodes between them, in the hope that reading in multiple node coordinates will always be faster than reading them one by one. This however, is not very good since there is still a lot of nodes that get read in such a way, because the nodes are so arbitrarily badly ordered in the file compared to the consecutively read elements. As a result, most PEs read most of the coordinates, which does not scale. Thus this commit replaces this extent-based node reading strategy with a more memory-efficient one, which reads only those nodes that are absolutely necessary on a given PE, reading node coordinates one by one but with global node IDs in increasing order, which other than that though, are arbitrary.

The symptom of this problem came when a 144M-cell mesh was fine on 25 compute nodes (each with 128GB RAM), but the nodes of a 288M-cell mesh could not be read on 25 nodes and not even on 70. As a result of this commit, a 288M-cell mesh can now be read fine on 25 nodes (with or without initial uniform mesh refinement, which of course, uses additional memory).