### PR TITLE
Debug the element-communication maps for DG

### DIFF
--- a/src/Base/Data.h
+++ b/src/Base/Data.h
@@ -362,7 +362,9 @@ class Data {
 
     //! Resize data store by multiple elements initialized to 0.0
     //! \param[in] count Resize store to contain count elements
-    void resize( std::size_t count ) { resize( count, int2type< Layout >() ); }
+    //! \param[in] value Value to initialize new data with
+    void resize( std::size_t count, tk::real value = 0.0 )
+    { resize( count, value, int2type< Layout >() ); }
 
     //! Remove a number of unknowns
     //! \param[in] unknown Set of indices of unknowns to remove
@@ -518,10 +520,11 @@ class Data {
 
     //! Resize data store by multiple elements initialized to 0.0
     //! \param[in] newsize Resize store to contain newsize elements
+    //! \param[in] value Value to initialize new data with
     //! \note Only the UnkEqComp overload is provided as this operation would be
     //!   too inefficient with the EqCompUnk data layout.
-    void resize( std::size_t newsize, int2type< UnkEqComp > ) {
-      m_vec.resize( newsize * m_nprop, 0.0 );
+    void resize( std::size_t newsize, tk::real value, int2type< UnkEqComp > ) {
+      m_vec.resize( newsize * m_nprop, value );
       m_nunk = newsize;
     }
 

--- a/src/Base/Data.h
+++ b/src/Base/Data.h
@@ -360,9 +360,11 @@ class Data {
     void push_back( const std::vector< tk::real >& prop )
     { return push_back( prop, int2type< Layout >() ); }
 
-    //! Resize data store by multiple elements initialized to 0.0
-    //! \param[in] count Resize store to contain count elements
-    //! \param[in] value Value to initialize new data with
+    //! Resize data store to contain 'count' elements
+    //! \param[in] count Resize store to contain 'count' elements
+    //! \param[in] value Value to initialize new data with (default: 0.0)
+    //! \note This works for both shrinking and enlarging, as this simply
+    //!   translates to std::vector::resize().
     void resize( std::size_t count, tk::real value = 0.0 )
     { resize( count, value, int2type< Layout >() ); }
 
@@ -518,14 +520,16 @@ class Data {
       for (ncomp_t i=0; i<m_nprop; ++i) operator()( u, i, 0 ) = prop[i];
     }
 
-    //! Resize data store by multiple elements initialized to 0.0
-    //! \param[in] newsize Resize store to contain newsize elements
+    //! Resize data store to contain 'count' elements
+    //! \param[in] count Resize store to contain 'count' elements
     //! \param[in] value Value to initialize new data with
     //! \note Only the UnkEqComp overload is provided as this operation would be
     //!   too inefficient with the EqCompUnk data layout.
-    void resize( std::size_t newsize, tk::real value, int2type< UnkEqComp > ) {
-      m_vec.resize( newsize * m_nprop, value );
-      m_nunk = newsize;
+    //! \note This works for both shrinking and enlarging, as this simply
+    //!   translates to std::vector::resize().
+    void resize( std::size_t count, tk::real value, int2type< UnkEqComp > ) {
+      m_vec.resize( count * m_nprop, value );
+      m_nunk = count;
     }
 
     // Overloads for the name-queries of data lauouts

--- a/src/Base/Data.h
+++ b/src/Base/Data.h
@@ -360,9 +360,9 @@ class Data {
     void push_back( const std::vector< tk::real >& prop )
     { return push_back( prop, int2type< Layout >() ); }
 
-    //! Enlarge data store by multiple elements initialized to 0.0
-    //! \param[in] by Grow store by this many unknowns * m_nprop
-    void enlarge( std::size_t by ) { enlarge( by, int2type< Layout >() ); }
+    //! Resize data store by multiple elements initialized to 0.0
+    //! \param[in] count Resize store to contain count elements
+    void resize( std::size_t count ) { resize( count, int2type< Layout >() ); }
 
     //! Remove a number of unknowns
     //! \param[in] unknown Set of indices of unknowns to remove
@@ -516,12 +516,11 @@ class Data {
       for (ncomp_t i=0; i<m_nprop; ++i) operator()( u, i, 0 ) = prop[i];
     }
 
-    //! Enlarge data store by multiple elements initialized to 0.0
-    //! \param[in] by Grow store by this many unknowns * m_nprop
+    //! Resize data store by multiple elements initialized to 0.0
+    //! \param[in] newsize Resize store to contain newsize elements
     //! \note Only the UnkEqComp overload is provided as this operation would be
     //!   too inefficient with the EqCompUnk data layout.
-    void enlarge( std::size_t by, int2type< UnkEqComp > ) {
-      auto newsize = m_nunk + by;
+    void resize( std::size_t newsize, int2type< UnkEqComp > ) {
       m_vec.resize( newsize * m_nprop, 0.0 );
       m_nunk = newsize;
     }

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -118,7 +118,6 @@ DG::DG( const CProxy_Discretization& disc,
         sumz += geoface_tmp(0,0,0)* geoface_tmp(0,3,0);
 
         // if does not exist in ipface, store as a potential chare-boundary face
-        // associated to neighbor chare
         if (m_ipface.find(t) == end(m_ipface)){
           ++m_expChbface;
 
@@ -195,8 +194,8 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
   // single node or an edge but note a face with that chare.
   auto& bndface = m_bndFace[ fromch ];  // will associate to sender chare
   // Try to find incoming faces among our faces we potentially share with
-  // fromch. If found, generate and assign new local ID to face, associated to
-  // sender chare.
+  // neighboring chares. If found, generate and assign new local ID to face,
+  // associated to sender chare.
   auto d = Disc();
   const auto& gid = d->Gid();
   const auto& inpoel = d->Inpoel();
@@ -231,7 +230,8 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
       bcount += ich.second.size();
     }
 
-    //std::cout <<thisIndex<<" | found: "<<bcount<<"/"<<m_expChbface<<"\n";
+    // Check if expected number of chare-faces match with actual number of 
+    // chare faces detected
     Assert( bcount == m_expChbface, "Incorrect # of entries in m_bndFace" );
 
     // Basic error checking on chare-boundary-face map
@@ -533,9 +533,9 @@ DG::adj()
       IGNORE(i);
     }
 
-  // Error checking on enlarged geoFace by checking the sum of all the
-  // face-normals for the physical and chare boundary faces. This sum
-  // should be equal to zero for a closed domain.
+  // Error checking on enlarged geoFace by checking the discrete surface
+  // integral of the face-normals for the physical and chare boundary faces.
+  // This sum should be equal to zero for a closed domain.
   tk::real sumx(0), sumy(0), sumz(0);
   for (std::size_t f=0; f<m_fd.Nbfac(); ++f) {
       sumx += m_geoFace(f,0,0) * m_geoFace(f,1,0);
@@ -569,10 +569,6 @@ DG::adj()
   for (const auto& c : m_ghost)
     for (const auto& g : c.second)
       gh.insert( g.second );
-
-//   std::cout << thisIndex << ": ";
-//   for (auto g : gh) std::cout << g << ' ';
-//   std::cout << '\n';
 
   // Signal the runtime system that all workers have received their adjacency
   auto d = Disc();

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -191,12 +191,15 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
   auto b = m_potBndFace.find( fromch );
   if (b != end(m_potBndFace)) {
     auto& bndface = m_bndFace[ fromch ];  // will associate to sender chare
-    // try to find incoming faces among our faces we potentially share with
-    // fromch, if found, generate and assign new local ID to face (associated to
-    // sender chare)
-    for (const auto& t : infaces)
-      if (b->second.find(t) != end(b->second))
-        bndface[t][0] = m_nfac++;    // assign new local face ID
+    // Try to find incoming faces among our faces we potentially share with
+    // fromch. If found, generate and assign new local ID to face, associated to
+    // sender chare. Note that the order of the node IDs of each face is
+    // reversed as these faces are received.
+    for (const auto& t : infaces) {
+      tk::UnsMesh::Face r{{ t[0], t[2], t[1] }};
+      if (b->second.find(r) != end(b->second))
+        bndface[r][0] = m_nfac++;    // assign new local face ID
+    }
     // if at this point we have not found any face among our faces we
     // potentially share with fromch, there is no need to keep an empty set of
     // faces associated to fromch as we only share nodes or edges with it, but
@@ -394,8 +397,8 @@ DG::comGhost( int fromch, const GhostData& ghost )
     Assert( geo.size() % 4 == 0, "Ghost geometry size mismathc" );
     Assert( geo.size() == m_geoElem.nprop(), "Ghost geometry number mismatch" );
     for (std::size_t n=0; n<nodes.size()/3; ++n) {  // face(s) of ghost e
-      // node IDs of face on chare boundary
-      tk::UnsMesh::Face t{{ nodes[n*3+0], nodes[n*3+1], nodes[n*3+2] }};
+      // node IDs of face on chare boundary (reverse order as it is received)
+      tk::UnsMesh::Face t{{ nodes[n*3+0], nodes[n*3+2], nodes[n*3+1] }};
       // must find t in nodelist of chare-boundary adjacent to fromch
       Assert( nl.find(t[0]) != end(nl) &&
               nl.find(t[1]) != end(nl) &&
@@ -430,7 +433,7 @@ void
 DG::addEsuf( const std::array< std::size_t, 2 >& id, std::size_t ghostid )
 // *****************************************************************************
 // Fill elements surrounding a face along chare boundary
-//! \param[in] id Local face and (inner) tet id adjacent to face t
+//! \param[in] id Local face and (inner) tet id adjacent to it
 //! \param[in] ghostid Local ID for ghost tet
 //! \details This function extends and fills in the elements surrounding faces
 //!   data structure (esuf) so that the left and  right element id is filled
@@ -474,9 +477,9 @@ DG::addGeoFace( const tk::UnsMesh::Face& t,
   auto lid = d->Lid();
 
   // get global node IDs reversing order to get outward-pointing normal
-  auto A = tk::cref_find( lid, t[2] );
+  auto A = tk::cref_find( lid, t[0] );
   auto B = tk::cref_find( lid, t[1] );
-  auto C = tk::cref_find( lid, t[0] );
+  auto C = tk::cref_find( lid, t[2] );
   auto geochf = tk::geoFaceTri( {{coord[0][A], coord[0][B], coord[0][C]}},
                                 {{coord[1][A], coord[1][B], coord[1][C]}},
                                 {{coord[2][A], coord[2][B], coord[2][C]}} );

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -208,13 +208,10 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
     auto& bndface = m_bndFace[ fromch ];  // will associate to sender chare
     // Try to find incoming faces among our faces we potentially share with
     // fromch. If found, generate and assign new local ID to face, associated to
-    // sender chare. Note that the order of the node IDs of each face is
-    // reversed as these faces are received.
-    for (const auto& t : infaces) {
-      tk::UnsMesh::Face r{{ t[0], t[2], t[1] }};
-      if (b->second.find(r) != end(b->second))
-        bndface[r][0] = m_nfac++;    // assign new local face ID
-    }
+    // sender chare.
+    for (const auto& t : infaces)
+      if (b->second.find(t) != end(b->second))
+        bndface[t][0] = m_nfac++;    // assign new local face ID
     // if at this point we have not found any face among our faces we
     // potentially share with fromch, there is no need to keep an empty set of
     // faces associated to fromch as we only share nodes or edges with it, but
@@ -427,8 +424,8 @@ DG::comGhost( int fromch, const GhostData& ghost )
     Assert( geo.size() % 4 == 0, "Ghost geometry size mismathc" );
     Assert( geo.size() == m_geoElem.nprop(), "Ghost geometry number mismatch" );
     for (std::size_t n=0; n<nodes.size()/3; ++n) {  // face(s) of ghost e
-      // node IDs of face on chare boundary (reverse order as it is received)
-      tk::UnsMesh::Face t{{ nodes[n*3+0], nodes[n*3+2], nodes[n*3+1] }};
+      // node IDs of face on chare boundary
+      tk::UnsMesh::Face t{{ nodes[n*3+0], nodes[n*3+1], nodes[n*3+2] }};
       // must find t in nodelist of chare-boundary adjacent to fromch
       Assert( nl.find(t[0]) != end(nl) &&
               nl.find(t[1]) != end(nl) &&
@@ -507,9 +504,9 @@ DG::addGeoFace( const tk::UnsMesh::Face& t,
   auto lid = d->Lid();
 
   // get global node IDs reversing order to get outward-pointing normal
-  auto A = tk::cref_find( lid, t[0] );
+  auto A = tk::cref_find( lid, t[2] );
   auto B = tk::cref_find( lid, t[1] );
-  auto C = tk::cref_find( lid, t[2] );
+  auto C = tk::cref_find( lid, t[0] );
   auto geochf = tk::geoFaceTri( {{coord[0][A], coord[0][B], coord[0][C]}},
                                 {{coord[1][A], coord[1][B], coord[1][C]}},
                                 {{coord[2][A], coord[2][B], coord[2][C]}} );

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -11,6 +11,7 @@
 // *****************************************************************************
 
 #include <algorithm>
+#include <numeric>
 
 #include "DG.h"
 #include "Discretization.h"
@@ -40,7 +41,6 @@ DG::DG( const CProxy_Discretization& disc,
   m_ncomfac( 0 ),
   m_nadj( 0 ),
   m_nrecvsol( 0 ),
-  m_nstorsol( 0 ),
   m_itf( 0 ),
   m_disc( disc ),
   m_fd( fd ),
@@ -59,7 +59,6 @@ DG::DG( const CProxy_Discretization& disc,
   m_msumset( msumset() ),
   m_esuelTet( tk::genEsuelTet( m_disc[thisIndex].ckLocal()->Inpoel(),
                 tk::genEsup( m_disc[thisIndex].ckLocal()->Inpoel(), 4 ) ) ),
-  m_potBndFace(),
   m_bndFace(),
   m_ghostData(),
   m_ghostReq( 0 ),
@@ -71,6 +70,9 @@ DG::DG( const CProxy_Discretization& disc,
 //! \param[in] Face data structures
 // *****************************************************************************
 {
+  // Perform leak test on mesh partition
+  Assert( !leakyPartition(), "Mesh partition leaky" );
+
   // Activate SDAG waits for face adjacency map (ghost data) calculation
   wait4ghost();
 
@@ -91,52 +93,32 @@ DG::DG( const CProxy_Discretization& disc,
   // chare-domain and on the physical boundary but not on chare boundaries,
   // hence the name internal + physical boundary faces.
 
-  const auto& coord = d->Coord();
-
-  tk::real sumx(0), sumy(0), sumz(0);
-
   // Build a set of faces (each face given by 3 global node IDs) associated to
-  // chares we potentially share boundary faces with
+  // chares we potentially share boundary faces with.
+  tk::UnsMesh::FaceSet potbndface;
   for (std::size_t e=0; e<m_esuelTet.size()/4; ++e) {   // for all our tets
     auto mark = e*4;
     for (std::size_t f=0; f<4; ++f)     // for all tet faces
       if (m_esuelTet[mark+f] == -1) {   // if face has no outside-neighbor tet
+        // if does not exist in among the internal and physical boundary faces,
+        // store as a potential chare-boundary face
         tk::UnsMesh::Face t{{ gid[ inpoel[ mark + tk::lpofa[f][0] ] ],
                               gid[ inpoel[ mark + tk::lpofa[f][1] ] ],
                               gid[ inpoel[ mark + tk::lpofa[f][2] ] ] }};
-
-        auto A = inpoel[ mark + tk::lpofa[f][0] ];
-        auto B = inpoel[ mark + tk::lpofa[f][1] ];
-        auto C = inpoel[ mark + tk::lpofa[f][2] ];
-
-        auto geoface_tmp = tk::geoFaceTri( {{coord[0][A], coord[0][B], coord[0][C]}},
-                                           {{coord[1][A], coord[1][B], coord[1][C]}},
-                                           {{coord[2][A], coord[2][B], coord[2][C]}} );
-
-        sumx += geoface_tmp(0,0,0)* geoface_tmp(0,1,0);
-        sumy += geoface_tmp(0,0,0)* geoface_tmp(0,2,0);
-        sumz += geoface_tmp(0,0,0)* geoface_tmp(0,3,0);
-
-        // if does not exist in ipface, store as a potential chare-boundary face
-        if (m_ipface.find(t) == end(m_ipface)){
-          ++m_expChbface;
-
-          m_potBndFace.insert( t );
+        if (m_ipface.find(t) == end(m_ipface)) {
+          ++m_expChbface;       // sum up expected number of boundary faces
+          potbndface.insert( t );
         }
       }
   }
 
-  Assert(sumx<1.0e-12, "x-component of surface-integral of face normals in ctor not zero");
-  Assert(sumy<1.0e-12, "y-component of surface-integral of face normals in ctor not zero");
-  Assert(sumz<1.0e-12, "z-component of surface-integral of face normals in ctor not zero");
-
-  // Note that while the (potential) boundary-face adjacency map (m_potBndFace)
-  // is derived from the node adjacency map (m_msumset), their sizes is not
-  // necessarily the same. This is because while a node can be shared at a
-  // single corner or along an edge, that does not necessarily share a face as
-  // well (in other words, shared nodes or edges can exist that are not part of
-  // a shared face). So the chares we communicate with across faces are not
-  // necessarily the same as the chares we would communicate nodes with.
+  // In the following we assume that the size of the (potential) boundary-face
+  // adjacency map above does not necessarily equal the node adjacency map
+  // (m_msumset). This is because while a node can be shared at a single corner
+  // or along an edge, that does not necessarily share a face as well (in other
+  // words, shared nodes or edges can exist that are not part of a shared face).
+  // So the chares we communicate with across faces are not necessarily the same
+  // as the chares we would communicate nodes with.
   //
   // Since the sizes of the node and face adjacency maps are not the same, while
   // sending the faces on chare boundaries would be okay, however, the receiver
@@ -159,8 +141,90 @@ DG::DG( const CProxy_Discretization& disc,
     adj();
   else
     for (const auto& c : m_msumset) {   // for all chares we share nodes with
-      thisProxy[ c.first ].comfac( thisIndex, m_potBndFace );
+      thisProxy[ c.first ].comfac( thisIndex, potbndface );
     }
+}
+
+bool
+DG::leakyPartition()
+// *****************************************************************************
+// Perform leak-test on mesh partition
+//! \details This function computes a surface integral over the boundary of the
+//!   incoming mesh partition. A non-zero vector result indicates a leak, e.g.,
+//!   a hole in the partition, which indicates an error upstream of this code,
+//!   either in the mesh geometry, mesh partitioning, or in the data structures
+//!   that represent faces.
+//! \return True if partition leaks.
+// *****************************************************************************
+{
+  auto d = Disc();
+  const auto& inpoel = d->Inpoel();
+  const auto& coord = d->Coord();
+  const auto& x = coord[0];
+  const auto& y = coord[1];
+  const auto& z = coord[2];
+
+  // Storage for surface integral over our mesh partition
+  std::array< tk::real, 3 > s{{ 0.0, 0.0, 0.0}};
+
+  for (std::size_t e=0; e<m_esuelTet.size()/4; ++e) {   // for all our tets
+    auto mark = e*4;
+    for (std::size_t f=0; f<4; ++f)     // for all tet faces
+      if (m_esuelTet[mark+f] == -1) {   // if face has no outside-neighbor tet
+        // 3 local node IDs of face
+        auto A = inpoel[ mark + tk::lpofa[f][0] ];
+        auto B = inpoel[ mark + tk::lpofa[f][1] ];
+        auto C = inpoel[ mark + tk::lpofa[f][2] ];
+        // Compute geometry data for face
+        auto geoface = tk::geoFaceTri( {{x[A], x[B], x[C]}},
+                                       {{y[A], y[B], y[C]}},
+                                       {{z[A], z[B], z[C]}} );
+        // Sum up face area * face unit-normal
+        s[0] += geoface(0,0,0) * geoface(0,1,0);
+        s[1] += geoface(0,0,0) * geoface(0,2,0);
+        s[2] += geoface(0,0,0) * geoface(0,3,0);
+      }
+  }
+
+  auto eps = std::numeric_limits< tk::real >::epsilon() * 100;
+  return std::abs(s[0]) > eps || std::abs(s[1]) > eps || std::abs(s[2]) > eps;
+}
+
+bool
+DG::leakyAdjacency()
+// *****************************************************************************
+// Perform leak-test on chare boundary faces
+//! \details This function computes a surface integral over the boundary of the
+//!   faces after the face adjacency communication map is completed.. A non-zero
+//!   vector result indicates a leak, e.g., a hole in the partition (covered by
+//!   the faces of the face adjacency communication map), which indicates an
+//!   error upstream in code setting up the face communication data structures.
+//! \note Compared to leakyPartition() this function performs the leak-test on
+//!   the face geometry data structure enlarged by ghost faces on this partition
+//!   by computing a discrete surface integral considering the physical and
+//!   chare boundary faces, which should be equal to zero for a closed domain.
+//! \return True if partition leaks.
+// *****************************************************************************
+{
+  // Storage for surface integral over our chunk of the adjacency
+  std::array< tk::real, 3 > s{{ 0.0, 0.0, 0.0}};
+
+  // physical boundary faces
+  for (std::size_t f=0; f<m_fd.Nbfac(); ++f) {
+    s[0] += m_geoFace(f,0,0) * m_geoFace(f,1,0);
+    s[1] += m_geoFace(f,0,0) * m_geoFace(f,2,0);
+    s[2] += m_geoFace(f,0,0) * m_geoFace(f,3,0);
+  }
+
+  // chare-boundary faces
+  for (std::size_t f=m_fd.Ntfac(); f<m_fd.Esuf().size()/2; ++f) {
+    s[0] += m_geoFace(f,0,0) * m_geoFace(f,1,0);
+    s[1] += m_geoFace(f,0,0) * m_geoFace(f,2,0);
+    s[2] += m_geoFace(f,0,0) * m_geoFace(f,3,0);
+  }
+
+  auto eps = std::numeric_limits< tk::real >::epsilon() * 100;
+  return std::abs(s[0]) > eps || std::abs(s[1]) > eps || std::abs(s[2]) > eps;
 }
 
 std::unordered_map< int, std::unordered_set< std::size_t > >
@@ -193,9 +257,9 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
   // set of faces associated to that chare. This can happen if we only share a
   // single node or an edge but note a face with that chare.
   auto& bndface = m_bndFace[ fromch ];  // will associate to sender chare
-  // Try to find incoming faces among our faces we potentially share with
-  // neighboring chares. If found, generate and assign new local ID to face,
-  // associated to sender chare.
+  // Try to find incoming faces on our chare boundary with other chares. If
+  // found, generate and assign new local ID to face, associated to sender
+  // chare.
   auto d = Disc();
   const auto& gid = d->Gid();
   const auto& inpoel = d->Inpoel();
@@ -206,33 +270,32 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
         tk::UnsMesh::Face t{{ gid[ inpoel[ mark + tk::lpofa[f][0] ] ],
                               gid[ inpoel[ mark + tk::lpofa[f][1] ] ],
                               gid[ inpoel[ mark + tk::lpofa[f][2] ] ] }};
-
-        if ( infaces.find(t) != end(infaces)
-             && m_ipface.find(t) == end(m_ipface) )
+        // if found among the incoming faces and if not one of our internal nor
+        // physical boundary faces
+        if ( infaces.find(t) != end(infaces) &&
+             m_ipface.find(t) == end(m_ipface) )
           bndface[t][0] = m_nfac++;    // assign new local face ID
       }
     }
   }
-  // if at this point we have not found any face among our faces we
-  // potentially share with fromch, there is no need to keep an empty set of
-  // faces associated to fromch as we only share nodes or edges with it, but
-  // not faces
+  // If at this point we have not found any face among our faces we potentially
+  // share with fromch, there is no need to keep an empty set of faces
+  // associated to fromch as we only share nodes or edges with it, but not
+  // faces.
   if (bndface.empty()) m_bndFace.erase( fromch );
 
   // if we have heard from all fellow chares that we share at least a single
   // node, edge, or face with
   if (++m_ncomfac == m_msumset.size()) {
 
-    // Ensure the -1 entries in m_esuelTet are equal to the number of entries
-    // in m_bndFace + m_nbfac
-    std::size_t bcount(0);
-    for (const auto& ich : m_bndFace) {
-      bcount += ich.second.size();
-    }
-
-    // Check if expected number of chare-faces match with actual number of 
-    // chare faces detected
-    Assert( bcount == m_expChbface, "Incorrect # of entries in m_bndFace" );
+    // Error checking on the number of expected vs received/found chare-boundary
+    // faces
+    Assert( m_expChbface ==
+             std::accumulate( m_bndFace.cbegin(), m_bndFace.cend(),
+               std::size_t(0),
+               []( std::size_t acc, const decltype(m_bndFace)::value_type& b )
+                 { return acc + b.second.size(); } ),
+            "Expected and received number of boundary faces mismatch" );
 
     // Basic error checking on chare-boundary-face map
     Assert( m_bndFace.find( thisIndex ) == m_bndFace.cend(),
@@ -256,16 +319,13 @@ DG::comfac( int fromch, const tk::UnsMesh::FaceSet& infaces )
       }
     }
 
-    // Free memory for intermediate data used to set up boundary-face comm map
-    tk::destroy( m_potBndFace );
-
     // At this point m_bndFace is complete on this PE. This means that starting
-    // from the sets of faces we potentially share with fellow chares
-    // (m_potBndFace), we now only have those faces we actually share faces with
-    // (through which we need to communicate later). Also, m_bndFace not only
-    // has the unique faces associated to fellow chares, but also a newly
-    // assigned local face ID as well as the local id of the inner tet adjacent
-    // to the face. Continue by starting setting up ghost data
+    // from the sets of faces we potentially share with fellow chares we now
+    // only have those faces we actually share faces with (through which we need
+    // to communicate later). Also, m_bndFace not only has the unique faces
+    // associated to fellow chares, but also a newly assigned local face ID as
+    // well as the local id of the inner tet adjacent to the face. Continue by
+    // starting setting up ghost data
     setupGhost();
     // Besides setting up our own ghost data, we also issue requests (for ghost
     // data) to those chares which we share faces with. Note that similar to
@@ -328,7 +388,7 @@ DG::setupGhost()
           nodes.push_back( t[0] );
           nodes.push_back( t[1] );
           nodes.push_back( t[2] );
-          Assert( nodes.size() < 13, "Overflow of faces/tet to send" );
+          Assert( nodes.size() <= 4*3, "Overflow of faces/tet to send" );
         }
       }
     }
@@ -383,8 +443,8 @@ DG::findchare( const tk::UnsMesh::Face& t )
 // *****************************************************************************
 // Find any chare for face (given by 3 global node IDs)
 //! \param[in] t Face given by three global node IDs
-//! \return chare ID if found among any of the chares we communication along
-//!   faces with, -1 if not
+//! \return Chare ID if found among any of the chares we communicate along
+//!   faces with, -1 if the face cannot be found.
 // *****************************************************************************
 {
   for (const auto& cf : m_bndFace)
@@ -414,7 +474,7 @@ DG::comGhost( int fromch, const GhostData& ghost )
     const auto& geo = std::get< 1 >( g.second );    // ghost elem geometry data
     Assert( nodes.size() % 3 == 0, "Face node IDs must be triplets" );
     Assert( nodes.size() <= 4*3, "Overflow of faces/tet received" );
-    Assert( geo.size() % 4 == 0, "Ghost geometry size mismathc" );
+    Assert( geo.size() % 4 == 0, "Ghost geometry size mismatch" );
     Assert( geo.size() == m_geoElem.nprop(), "Ghost geometry number mismatch" );
     for (std::size_t n=0; n<nodes.size()/3; ++n) {  // face(s) of ghost e
       // node IDs of face on chare boundary
@@ -533,24 +593,8 @@ DG::adj()
       IGNORE(i);
     }
 
-  // Error checking on enlarged geoFace by checking the discrete surface
-  // integral of the face-normals for the physical and chare boundary faces.
-  // This sum should be equal to zero for a closed domain.
-  tk::real sumx(0), sumy(0), sumz(0);
-  for (std::size_t f=0; f<m_fd.Nbfac(); ++f) {
-      sumx += m_geoFace(f,0,0) * m_geoFace(f,1,0);
-      sumy += m_geoFace(f,0,0) * m_geoFace(f,2,0);
-      sumz += m_geoFace(f,0,0) * m_geoFace(f,3,0);
-  }
-  for (std::size_t f=m_fd.Ntfac(); f<m_fd.Esuf().size()/2; ++f) {
-      sumx += m_geoFace(f,0,0) * m_geoFace(f,1,0);
-      sumy += m_geoFace(f,0,0) * m_geoFace(f,2,0);
-      sumz += m_geoFace(f,0,0) * m_geoFace(f,3,0);
-  }
-
-  Assert(sumx<1.0e-12, "x-component of surface-integral of face normals in DG::adj() not zero");
-  Assert(sumy<1.0e-12, "y-component of surface-integral of face normals in DG::adj() not zero");
-  Assert(sumz<1.0e-12, "z-component of surface-integral of face normals in DG::adj() not zero");
+  // Perform leak test on face geometry data structure enlarged by ghosts
+  Assert( !leakyAdjacency(), "Face adjacency leaky" );
 
   // Resize solution vectors, lhs, and rhs by the number of ghost tets
   m_u.resize( m_nunk );
@@ -568,7 +612,7 @@ DG::adj()
   // Ghost tet IDs expected
   for (const auto& c : m_ghost)
     for (const auto& g : c.second)
-      gh.insert( g.second );
+      egh.insert( g.second );
 
   // Signal the runtime system that all workers have received their adjacency
   auto d = Disc();
@@ -650,10 +694,6 @@ DG::dt()
 
   }
 
-  // Activate SDAG waits for time step
-  //wait4sol();
-  //storsol_complete();
-
   rgh.clear();
 
   // Contribute to minimum dt across all chares then advance to next step
@@ -705,8 +745,6 @@ DG::comsol( int fromch,
   // Find local-to-ghost tet id map for sender chare
   const auto& n = tk::cref_find( m_ghost, fromch );
 
-//std::cout << thisIndex << " com, it=" << Disc()->It() << '\n';
-
   for (std::size_t i=0; i<tetid.size(); ++i) {
     auto j = tk::cref_find( n, tetid[i] );
     Assert( j >= m_esuelTet.size()/4, "Receiving solution non-ghost data" );
@@ -719,7 +757,7 @@ DG::comsol( int fromch,
   // if we have received all solution ghost contributions from those chares we
   // communicate along chare-boundary faces with, tell the runtime system
   if (++m_nrecvsol == m_ghostData.size()) {
-    Assert( gh == rgh, "Expected/received ghost tet id mismatch" );
+    Assert( egh == rgh, "Expected/received ghost tet id mismatch" );
     m_nrecvsol = 0;
     solve();
   }
@@ -828,8 +866,6 @@ DG::solve()
 {
   auto d = Disc();
 
-//std::cout << thisIndex << " sol, it=" << Disc()->It() << '\n';
-
   for (const auto& eq : g_dgpde)
     eq.rhs( d->T(), m_geoFace, m_fd, m_u, m_rhs );
 
@@ -866,7 +902,6 @@ DG::eval()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep)
     dt();
-    //contribute( CkCallback( CkReductionTarget(Transporter,dt), d->Tr() ) );
   else
     contribute( CkCallback( CkReductionTarget(Transporter,finish), d->Tr() ) );
 }

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -157,6 +157,7 @@ class DG : public CBase_DG {
       p | m_ghostReq;
       p | m_expTotbface;
       p | m_ghost;
+      p | m_ipface;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -222,7 +223,7 @@ class DG : public CBase_DG {
     //!   be considered as an intermediate results towards m_bndFace, which only
     //!   stores the faces (associated to chares) we actually need to
     //!   communicate with.
-    std::unordered_map< int, tk::UnsMesh::FaceSet > m_potBndFace;
+    tk::UnsMesh::FaceSet m_potBndFace;
     //! Face * tet IDs associated to global node IDs of the face for each chare
     //! \details Compared to m_potBndFace, this map stores those faces we
     //!   actually share faces with (through which we need to communicate
@@ -235,6 +236,7 @@ class DG : public CBase_DG {
     //! Number of chares requesting ghost data
     std::size_t m_ghostReq;
     std::size_t m_expTotbface;
+    tk::UnsMesh::FaceSet m_ipface;  // internal + physical boundary faces
     //! Local element id associated to ghost remote id charewise
     //! \details This map associates the local element id (inner map value) to
     //!    the (remote) element id of the ghost (inner map key) based on the

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -155,6 +155,7 @@ class DG : public CBase_DG {
       p | m_bndFace;
       p | m_ghostData;
       p | m_ghostReq;
+      p | m_expTotbface;
       p | m_ghost;
     }
     //! \brief Pack/Unpack serialize operator|
@@ -233,6 +234,7 @@ class DG : public CBase_DG {
     std::unordered_map< int, GhostData > m_ghostData;
     //! Number of chares requesting ghost data
     std::size_t m_ghostReq;
+    std::size_t m_expTotbface;
     //! Local element id associated to ghost remote id charewise
     //! \details This map associates the local element id (inner map value) to
     //!    the (remote) element id of the ghost (inner map key) based on the

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -155,7 +155,7 @@ class DG : public CBase_DG {
       p | m_bndFace;
       p | m_ghostData;
       p | m_ghostReq;
-      p | m_expTotbface;
+      p | m_expChbface;
       p | m_ghost;
       p | m_ipface;
     }
@@ -235,7 +235,7 @@ class DG : public CBase_DG {
     std::unordered_map< int, GhostData > m_ghostData;
     //! Number of chares requesting ghost data
     std::size_t m_ghostReq;
-    std::size_t m_expTotbface;
+    std::size_t m_expChbface;
     tk::UnsMesh::FaceSet m_ipface;  // internal + physical boundary faces
     //! Local element id associated to ghost remote id charewise
     //! \details This map associates the local element id (inner map value) to

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -216,7 +216,7 @@ class DG : public CBase_DG {
     std::unordered_map< int, std::unordered_set< std::size_t > > m_msumset;
     //! Elements surrounding elements with -1 at boundaries, see genEsuelTet()
     std::vector< int > m_esuelTet;
-    //! Faces associated to chares we potentially share boundary faces with
+    //! All the faces we potentially share with neighboring cells
     //! \details Compared to m_bndFace, this map stores a set of unique faces we
     //!   only potentially share with fellow chares. This is because this data
     //!   structure is derived from the the chare-node adjacency map and ths can

--- a/src/Inciter/DiagCG.C
+++ b/src/Inciter/DiagCG.C
@@ -593,7 +593,7 @@ DiagCG::next( const tk::Fields& a )
   // Output field data to file
   out();
   // Compute diagnostics, e.g., residuals
- auto diag =  m_diag.compute( *d, m_u );
+  auto diag =  m_diag.compute( *d, m_u );
   // Increase number of iterations and physical time
   d->next();
   // Output one-liner status report

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -1381,26 +1381,6 @@ Partitioner::createWorkers()
             }
           }
         }
-
-        //for (std::size_t i=0; i<nnpf; ++i)
-        //{
-        //  auto n = chlinnodes.find( m_triinpoel[nnpf*f + i] );
-        //  if (n != end(chlinnodes))
-        //  {
-        //    tbface[i] = n->second;
-        //    ++count;
-        //  }
-        //}
-
-        //if (count == nnpf)
-        //// this boundary face is present on this chunk
-        //{
-        //  for (std::size_t i=0; i<nnpf; ++i)
-        //    chtriinpoel.push_back( tbface[i] );
-
-        //  chbface[ss.first].push_back(chnbfac);
-        //  ++chnbfac;
-        //}
       }
     }
 

--- a/src/Inciter/Partitioner.C
+++ b/src/Inciter/Partitioner.C
@@ -1356,15 +1356,51 @@ Partitioner::createWorkers()
           }
         }
 
-        if (count == nnpf)
-        // this boundary face is present on this chunk
-        {
-          for (std::size_t i=0; i<nnpf; ++i)
-            chtriinpoel.push_back( tbface[i] );
+        // store tbface in a set for comparison
+        std::set< std::size_t > tbfset (tbface.begin(), tbface.end());
 
-          chbface[ss.first].push_back(chnbfac);
-          ++chnbfac;
+        if (count == nnpf)
+        for (std::size_t e=0; e<chinpoel.size()/4; ++e) {   // for all our tets
+          auto mark = e*4;
+          for (std::size_t ef=0; ef<4; ++ef) {   // for all tet faces
+            std::array< std::size_t, 3 > t{{ chinpoel[ mark + tk::lpofa[ef][0] ],
+                                             chinpoel[ mark + tk::lpofa[ef][1] ],
+                                             chinpoel[ mark + tk::lpofa[ef][2] ] }};
+
+            // store t in a set for comparison
+            std::set< std::size_t > tset (t.begin(), t.end());
+
+            if (tset == tbfset) {
+            // this boundary face is present on this chunk
+              for (std::size_t i=0; i<nnpf; ++i)
+                chtriinpoel.push_back( tbface[i] );
+
+              chbface[ss.first].push_back(chnbfac);
+              ++chnbfac;
+              break;
+            }
+          }
         }
+
+        //for (std::size_t i=0; i<nnpf; ++i)
+        //{
+        //  auto n = chlinnodes.find( m_triinpoel[nnpf*f + i] );
+        //  if (n != end(chlinnodes))
+        //  {
+        //    tbface[i] = n->second;
+        //    ++count;
+        //  }
+        //}
+
+        //if (count == nnpf)
+        //// this boundary face is present on this chunk
+        //{
+        //  for (std::size_t i=0; i<nnpf; ++i)
+        //    chtriinpoel.push_back( tbface[i] );
+
+        //  chbface[ss.first].push_back(chnbfac);
+        //  ++chnbfac;
+        //}
       }
     }
 

--- a/src/Inciter/Scheme.h
+++ b/src/Inciter/Scheme.h
@@ -289,9 +289,9 @@ class Scheme : public SchemeBase {
     }
 
     //////  proxy.eval(...)
-    //! function to call the dt entry method of an array proxy (broadcast)
+    //! function to call the eval entry method of an array proxy (broadcast)
     //! \param[in] args arguments to member function (entry method) to be called
-    //! \details this function calls the dt member function of a chare array
+    //! \details this function calls the eval member function of a chare array
     //!   proxy and thus equivalent to proxy.eval(...), specifying a
     //!   non-default last argument.
     template< class Op, typename... Args, typename std::enable_if<
@@ -301,10 +301,10 @@ class Scheme : public SchemeBase {
                             proxy );
     }
     //////  proxy[x].eval(...)
-    //! Function to call the dt entry method of an element proxy (p2p)
+    //! Function to call the eval entry method of an element proxy (p2p)
     //! \param[in] x Chare array element index
     //! \param[in] args Arguments to member function (entry method) to be called
-    //! \details This function calls the dt member function of a chare array
+    //! \details This function calls the eval member function of a chare array
     //!   element proxy and thus equivalent to proxy[x].eval(...), specifying a
     //!   non-default last argument.
     template< typename Op, typename... Args, typename std::enable_if<

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -244,7 +244,7 @@ Transporter::createPartitioner()
   m_timer[ TimerTag::MESH_PREP ];
 
   // Create mesh partitioner Charm++ chare group and start preparing mesh
-  m_progMesh.start( "Preparing mesh (read, refine, centroids) ..." );
+  m_progMesh.start( "Preparing mesh (read, optional refine, centroids) ..." );
 
   // Create mesh partitioner Charm++ chare group
   m_partitioner =

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -501,7 +501,6 @@ Transporter::comfinal()
   // Tell the runtime system that every PE is done with dynamically inserting
   // Discretization worker (MatCG, DiagCG, DG, ...) chare array elements
   m_scheme.doneInserting< tag::bcast >();
-
   com_complete();
 }
 

--- a/src/Inciter/dg.ci
+++ b/src/Inciter/dg.ci
@@ -1,7 +1,7 @@
 // *****************************************************************************
 /*!
   \file      src/Inciter/dg.ci
-  \copyright 2012-2015, J. Bakosi, 2016-2018, Los Alamos National Security, LLC.
+  \copyright 2016-2018, Los Alamos National Security, LLC.
   \brief     Charm++ module interface file for the discontinuous Galerkin scheme
   \details   Charm++ module interface file for the discontinuous Galerking
              scheme.
@@ -27,13 +27,13 @@ module dg {
                 const FaceData& fd );
       entry void comfac( int fromch, const tk::UnsMesh::FaceSet& infaces );
       entry void comGhost( int fromch, const GhostData& ghost );
-      entry void reqGhost( int fromch );
+      entry void reqGhost();
       initnode void registerReducers();      
       entry void setup( tk::real v );
       entry void dt();
       entry void eval();
-      entry void comrhs( int fromch,
-                         const std::vector< std::size_t >& geid,
+      entry void comsol( int fromch,
+                         const std::vector< std::size_t >& tetid,
                          const std::vector< std::vector< tk::real > >& u );
       entry [reductiontarget] void advance( tk::real newdt );
 

--- a/src/Inciter/dg.ci
+++ b/src/Inciter/dg.ci
@@ -23,7 +23,7 @@ module dg {
 
     array [1D] DG {
       entry DG( const CProxy_Discretization& disc,
-                const tk::CProxy_Solver& solver,
+                const tk::CProxy_Solver&,
                 const FaceData& fd );
       entry void comfac( int fromch, const tk::UnsMesh::FaceSet& infaces );
       entry void comGhost( int fromch, const GhostData& ghost );
@@ -34,7 +34,7 @@ module dg {
       entry void eval();
       entry void comrhs( int fromch,
                          const std::vector< std::size_t >& geid,
-                         const std::vector< std::vector< tk::real > >& V );
+                         const std::vector< std::vector< tk::real > >& u );
       entry [reductiontarget] void advance( tk::real newdt );
 
       // SDAG code follows. See http://charm.cs.illinois.edu/manuals/html/

--- a/src/Mesh/UnsMesh.h
+++ b/src/Mesh/UnsMesh.h
@@ -62,12 +62,17 @@ class UnsMesh {
                std::hash< std::size_t >()( key[2] );
       }
     };
-    //! Key-equal function for node triplet (Face)
+    //! Key-equal function for node triplet (Face) where order also matters
+    //! \details The fact the node ordering matters means that not only the left
+    //!   and right hand sides must contains the same exact ids but the ordering
+    //!   must also match. For example face {A,B,C} is considered equal to face
+    //!   {C,A,B} as well as {B,C,A} bot not any other combination of the same
+    //!   these same ids.
     struct FaceEq {
       bool operator()( const Face& l, const Face& r ) const {
-        return (l[0] == r[0] || l[0] == r[1] || l[0] == r[2]) &&
-               (l[1] == r[0] || l[1] == r[1] || l[1] == r[2]) &&
-               (l[2] == r[0] || l[2] == r[1] || l[2] == r[2]);
+        return (l[0] == r[0] && l[1] == r[1] && l[2] == r[2]) ||
+               (l[2] == r[0] && l[0] == r[1] && l[1] == r[2]) ||
+               (l[1] == r[0] && l[2] == r[1] && l[0] == r[2]);
       }
     };
     //! Unique set of node ID triplets representing unique tetrahedron faces

--- a/src/Mesh/UnsMesh.h
+++ b/src/Mesh/UnsMesh.h
@@ -62,17 +62,12 @@ class UnsMesh {
                std::hash< std::size_t >()( key[2] );
       }
     };
-    //! Key-equal function for node triplet (Face) where order also matters
-    //! \details The fact the node ordering matters means that not only the left
-    //!   and right hand sides must contains the same exact ids but the ordering
-    //!   must also match. For example face {A,B,C} is considered equal to face
-    //!   {C,A,B} as well as {B,C,A} bot not any other combination of the same
-    //!   these same ids.
+    //! Key-equal function for node triplet (Face)
     struct FaceEq {
       bool operator()( const Face& l, const Face& r ) const {
-        return (l[0] == r[0] && l[1] == r[1] && l[2] == r[2]) ||
-               (l[2] == r[0] && l[0] == r[1] && l[1] == r[2]) ||
-               (l[1] == r[0] && l[2] == r[1] && l[0] == r[2]);
+        return (l[0] == r[0] || l[0] == r[1] || l[0] == r[2]) &&
+               (l[1] == r[0] || l[1] == r[1] || l[1] == r[2]) &&
+               (l[2] == r[0] || l[2] == r[1] || l[2] == r[2]);
       }
     };
     //! Unique set of node ID triplets representing unique tetrahedron faces

--- a/src/PDE/Transport/DGTransport.h
+++ b/src/PDE/Transport/DGTransport.h
@@ -94,7 +94,7 @@ class Transport {
 
         const auto s = Problem::solution( m_c, m_ncomp, xcc, ycc, zcc, t );
         for (ncomp_t c=0; c<m_ncomp; ++c)
-          unk(e, c, m_offset)   = s[c];
+          unk(e, c, m_offset) = s[c];
       }
     }
 
@@ -153,19 +153,18 @@ class Transport {
       }
 
       // compute boundary surface flux integrals
-
-      for (const auto& s : m_bcsym) {      // for all sidesets where sym bc is set
-        auto bc = bface.find( std::stoi(s) );  // find faces for sym bc side set
+      for (const auto& s : m_bcsym) {    // for all symbc sidesets
+        auto bc = bface.find( std::stoi(s) );  // faces for sym bc side set
         if (bc != end(bface))
           surfInt< Sym >( bc->second, esuf, geoFace, U, R );
       }
-      for (const auto& s : m_bcinlet) {    // for all sidesets where inlet bc is set
-        auto bc = bface.find( std::stoi(s) );  // find faces for inlet bc side set
+      for (const auto& s : m_bcinlet) {  // for all inlet bc sidesets
+        auto bc = bface.find( std::stoi(s) );// faces for inlet bc side set
         if (bc != end(bface))
           surfInt< Inlet > ( bc->second, esuf, geoFace, U, R );
       }
-      for (const auto& s : m_bcoutlet) {   // for all sidesets where outlet bc is set
-        auto bc = bface.find( std::stoi(s) );  // find faces for outlet bc side set
+      for (const auto& s : m_bcoutlet) {// for all outlet bc sidesets
+        auto bc = bface.find( std::stoi(s) );// faces for outlet bc side set
         if (bc != end(bface))
           surfInt< Outlet >( bc->second, esuf, geoFace, U, R );
       }

--- a/src/UnitTest/tests/Base/TestData.h
+++ b/src/UnitTest/tests/Base/TestData.h
@@ -1713,9 +1713,47 @@ void Data_object::test< 38 >() {
   // tk::Data::resize() unimplemented with EqCompUnk data layout
 }
 
-//! Test tk::Data::rm()
+//! Test tk::Data::resize()
 template<> template<>
 void Data_object::test< 39 >() {
+  set_test_name( "resize with non-default value" );
+
+  // Test with UnkEqComp data layout
+  tk::Data< tk::UnkEqComp > p( 3, 2 );
+  p(0,0,0) = 1.0;  p(0,1,0) = 2.0;
+  p(1,0,0) = 3.0;  p(1,1,0) = 4.0;
+  p(2,0,0) = 5.0;  p(2,1,0) = 6.0;
+
+  // Enlarge by 4*2 (nprop=2 stays constant)
+  p.resize( p.nunk()+4, -2.13 );
+
+  ensure_equals( "nunk after <UnkEqComp>::resize() incorrect", p.nunk(), 7 );
+  ensure_equals( "nprop after <UnkEqComp>::resize() incorrect", p.nprop(), 2 );
+
+  using unittest::veceq;
+
+  veceq( "<UnkEqComp>::resize() at 0 incorrect",
+         std::vector< tk::real >{ 1.0, 2.0 }, p[0] );
+  veceq( "<UnkEqComp>::resize() at 1 incorrect",
+         std::vector< tk::real >{ 3.0, 4.0 }, p[1] );
+  veceq( "<UnkEqComp>::resize() at 2 incorrect",
+         std::vector< tk::real >{ 5.0, 6.0 }, p[2] );
+
+  veceq( "<UnkEqComp>::resize() at 3 incorrect",
+         std::vector< tk::real >{ -2.13, -2.13 }, p[3] );
+  veceq( "<UnkEqComp>::resize() at 4 incorrect",
+         std::vector< tk::real >{ -2.13, -2.13 }, p[4] );
+  veceq( "<UnkEqComp>::resize() at 5 incorrect",
+         std::vector< tk::real >{ -2.13, -2.13 }, p[5] );
+  veceq( "<UnkEqComp>::resize() at 6 incorrect",
+         std::vector< tk::real >{ -2.13, -2.13 }, p[6] );
+
+  // tk::Data::resize() unimplemented with EqCompUnk data layout
+}
+
+//! Test tk::Data::rm()
+template<> template<>
+void Data_object::test< 40 >() {
   set_test_name( "rm" );
 
   // Test with UnkEqComp data layout with a single component

--- a/src/UnitTest/tests/Base/TestData.h
+++ b/src/UnitTest/tests/Base/TestData.h
@@ -1675,10 +1675,10 @@ void Data_object::test< 37 >() {
   // tk::Data::push_back() unimplemented with EqCompUnk data layout
 }
 
-//! Test tk::Data::enlarge()
+//! Test tk::Data::resize()
 template<> template<>
 void Data_object::test< 38 >() {
-  set_test_name( "enlarge" );
+  set_test_name( "resize" );
 
   // Test with UnkEqComp data layout
   tk::Data< tk::UnkEqComp > p( 3, 2 );
@@ -1687,30 +1687,30 @@ void Data_object::test< 38 >() {
   p(2,0,0) = 5.0;  p(2,1,0) = 6.0;
 
   // Enlarge by 4*2 (nprop=2 stays constant)
-  p.enlarge( 4 );
+  p.resize( p.nunk()+4 );
 
-  ensure_equals( "nunk after <UnkEqComp>::enlarge() incorrect", p.nunk(), 7 );
-  ensure_equals( "nprop after <UnkEqComp>::enlarge() incorrect", p.nprop(), 2 );
+  ensure_equals( "nunk after <UnkEqComp>::resize() incorrect", p.nunk(), 7 );
+  ensure_equals( "nprop after <UnkEqComp>::resize() incorrect", p.nprop(), 2 );
 
   using unittest::veceq;
 
-  veceq( "<UnkEqComp>::enlarge() at 0 incorrect",
+  veceq( "<UnkEqComp>::resize() at 0 incorrect",
          std::vector< tk::real >{ 1.0, 2.0 }, p[0] );
-  veceq( "<UnkEqComp>::enlarge() at 1 incorrect",
+  veceq( "<UnkEqComp>::resize() at 1 incorrect",
          std::vector< tk::real >{ 3.0, 4.0 }, p[1] );
-  veceq( "<UnkEqComp>::enlarge() at 2 incorrect",
+  veceq( "<UnkEqComp>::resize() at 2 incorrect",
          std::vector< tk::real >{ 5.0, 6.0 }, p[2] );
 
-  veceq( "<UnkEqComp>::enlarge() at 3 incorrect",
+  veceq( "<UnkEqComp>::resize() at 3 incorrect",
          std::vector< tk::real >{ 0.0, 0.0 }, p[3] );
-  veceq( "<UnkEqComp>::enlarge() at 4 incorrect",
+  veceq( "<UnkEqComp>::resize() at 4 incorrect",
          std::vector< tk::real >{ 0.0, 0.0 }, p[4] );
-  veceq( "<UnkEqComp>::enlarge() at 5 incorrect",
+  veceq( "<UnkEqComp>::resize() at 5 incorrect",
          std::vector< tk::real >{ 0.0, 0.0 }, p[5] );
-  veceq( "<UnkEqComp>::enlarge() at 6 incorrect",
+  veceq( "<UnkEqComp>::resize() at 6 incorrect",
          std::vector< tk::real >{ 0.0, 0.0 }, p[6] );
 
-  // tk::Data::enlarge() unimplemented with EqCompUnk data layout
+  // tk::Data::resize() unimplemented with EqCompUnk data layout
 }
 
 //! Test tk::Data::rm()


### PR DESCRIPTION
This set of commits attempts to fix the element communication maps required in DG. Multiple Assert tests have also been added to ensure the correctness of the generated data structures. This seems to fix the issues with running the DG advection problem in parallel, and gives qualitatively same numerical results as serial. Further testing involving L2-norms of errors will be considered in the next commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/224)
<!-- Reviewable:end -->
