### PR TITLE
Construct-initialize RK coeffs in DG

### DIFF
--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -66,22 +66,14 @@ DG::DG( const CProxy_Discretization& disc,
   m_exptGhost(),
   m_recvGhost(),
   m_diag(),
-  m_stage( 0 ),
-  m_rkcoef()
+  m_stage( 0 )
 // *****************************************************************************
 //  Constructor
 //! \param[in] disc Discretization proxy
+//! \param[in] solver Linear system solver (Solver) proxy
 //! \param[in] Face data structures
 // *****************************************************************************
 {
-  m_rkcoef[0][0] = 0.0;
-  m_rkcoef[0][1] = 3.0/4.0;
-  m_rkcoef[0][2] = 1.0/3.0;
-
-  m_rkcoef[1][0] = 1.0;
-  m_rkcoef[1][1] = 1.0/4.0;
-  m_rkcoef[1][2] = 2.0/3.0;
-
   // Perform leak test on mesh partition
   Assert( !leakyPartition(), "Mesh partition leaky" );
 

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -255,7 +255,8 @@ class DG : public CBase_DG {
     //! Runge-Kutta stage counter
     std::size_t m_stage;
     //! Runge-Kutta coefficients
-    std::array< std::array< tk::real, 3 >, 2 > m_rkcoef;
+    std::array< std::array< tk::real, 3 >, 2 >
+      m_rkcoef{{ {{ 0.0, 3.0/4.0, 1.0/3.0 }}, {{ 1.0, 1.0/4.0, 2.0/3.0 }} }};
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {


### PR DESCRIPTION
This replaces creating an array of arrays and initializing them later with constructing + initializing it in a single step. Simpler and faster -- though most likely immeasurable ;-).

Sorry, I meant to suggest this during code review, but I forgot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/243)
<!-- Reviewable:end -->
