### PR TITLE
Add optional backward-cpp stack trace output to exceptions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tpl"]
+	path = tpl
+	url = ../../quinoacomputing/quinoa-tpl.git

--- a/docker/Dockerfile.quinoa-build-alpine
+++ b/docker/Dockerfile.quinoa-build-alpine
@@ -33,7 +33,7 @@ RUN apk update && apk add libtool autoconf automake bash m4 file git cmake gfort
 
 # Install OpenMPI
 ADD https://www.open-mpi.org/software/ompi/v2.0/downloads/openmpi-2.0.2.tar.gz /openmpi/
-RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --disable-shared --enable-static --enable-mpi-cxx --without-hwloc --prefix=/opt/openmpi && make -sj$(grep -c processor /proc/cpuinfo) install
+RUN cd /openmpi/ && tar xzf openmpi-2.0.2.tar.gz && cd openmpi-2.0.2 && ./configure --disable-shared --enable-static --enable-mpi-cxx --prefix=/opt/openmpi && make -sj$(grep -c processor /proc/cpuinfo) install
 ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 RUN rm -rf /openmpi

--- a/src/Base/Exception.C
+++ b/src/Base/Exception.C
@@ -18,6 +18,10 @@
 #include "QuinoaConfig.h"
 #include "Exception.h"
 
+#ifdef HAS_BACKWARD
+  #include "backward.hpp"
+#endif
+
 using tk::Exception;
 
 Exception::Exception( std::string&& message,
@@ -175,11 +179,21 @@ Exception::handleException() noexcept
 //!   throws exceptions.
 // *****************************************************************************
 {
+  printf("\n>>> Error: %s\n", what());
+
   if (m_addrLength > 0) {
     fprintf( stderr, ">>>\n>>> =========== CALL TRACE ===========\n>>>\n" );
     echoTrace();
     fprintf( stderr, ">>>\n>>> ======= END OF CALL TRACE ========\n>>>\n" );
   }
+
+  #ifdef HAS_BACKWARD
+  fprintf( stderr, ">>>\n>>> =========== STACK TRACE ==========\n>>>\n" );
+  using namespace backward;
+  StackTrace st; st.load_here(64);
+  Printer p; p.print( st, stderr );
+  fprintf( stderr, ">>>\n>>> ======= END OF STACK TRACE =======\n>>>\n" );
+  #endif
  
   return tk::ErrCode::FAILURE;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -546,6 +546,7 @@ include_directories(${QUINOA_SOURCE_DIR}
                     ${TPL_INCLUDE_DIR}
                     ${CHARM_INCLUDE_DIRS}
                     ${RNGTEST_BIN_DIR}
+                    ${BACKWARD_INCLUDE_DIRS}
                     ${PROJECT_BINARY_DIR}/LoadBalance   # for Charm++ modules
                     ${PROJECT_BINARY_DIR}/Main          # for Charm++ modules
                     ${PROJECT_BINARY_DIR}/Walker        # for Charm++ modules

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(${UNITTEST_EXECUTABLE}
                       ${HDF5_HL_LIBRARIES}      # only for static link
                       ${HDF5_C_LIBRARIES}
                       ${AEC_LIBRARIES}          # only for static link
+                      ${BACKWARD_LIBRARIES}
 )
 
 # Add custom dependencies for UnitTest's main Charm++ module
@@ -103,6 +104,7 @@ target_link_libraries(${INCITER_EXECUTABLE}
                       ${HDF5_HL_LIBRARIES}      # only for static link
                       ${HDF5_C_LIBRARIES}
                       ${AEC_LIBRARIES}          # only for static link
+                      ${BACKWARD_LIBRARIES}
 )
 
 # Add custom dependencies for Inciter's main Charm++ module
@@ -131,6 +133,7 @@ if (HAS_TESTU01)
                         ${MKL_CORE_LIBRARY}
                         ${MKL_SEQUENTIAL_LAYER_LIBRARY}
                         ${RNGSSE2_LIBRARIES}
+                        ${BACKWARD_LIBRARIES}
   )
 
   # Add custom dependencies for RNGTest's main Charm++ module
@@ -160,6 +163,7 @@ target_link_libraries(${MESHCONV_EXECUTABLE}
                       ${HDF5_HL_LIBRARIES}      # only for static link
                       ${HDF5_C_LIBRARIES}
                       ${AEC_LIBRARIES}          # only for static link
+                      ${BACKWARD_LIBRARIES}
 )
 
 # Add custom dependencies for MeshConv's main Charm++ module
@@ -196,6 +200,7 @@ target_link_libraries(${WALKER_EXECUTABLE}
                       ${HDF5_HL_LIBRARIES}      # only for static link
                       ${HDF5_C_LIBRARIES}
                       ${AEC_LIBRARIES}          # only for static link
+                      ${BACKWARD_LIBRARIES}
 )
 
 # Add custom dependencies for Walker's main Charm++ module
@@ -221,6 +226,7 @@ if (HAS_ROOT)
 	                ${SEACASExodus_LIBRARIES}
 	                ${ROOT_LIBRARIES}
 		        ${NETCDF_LIBRARIES}       # only for static link
+                        ${BACKWARD_LIBRARIES}
   )
 
   # Add custom dependencies for FileConv's main Charm++ module

--- a/src/Main/QuinoaConfig.h.in
+++ b/src/Main/QuinoaConfig.h.in
@@ -34,6 +34,15 @@ namespace tk {
 #cmakedefine HAS_RNGSSE2
 #cmakedefine HAS_TESTU01
 #cmakedefine HAS_ROOT
+#cmakedefine HAS_BACKWARD
+
+// Backward-cpp config
+#cmakedefine01 BACKWARD_HAS_UNWIND
+#cmakedefine01 BACKWARD_HAS_BACKTRACE
+#cmakedefine01 BACKWARD_HAS_BACKTRACE_SYMBOL
+#cmakedefine01 BACKWARD_HAS_DW
+#cmakedefine01 BACKWARD_HAS_BFD
+#cmakedefine01 BACKWARD_HAS_DWARF
 
 // Accessor declarations as strings of configuration values imported from cmake
 


### PR DESCRIPTION
This is part of 3 PRs across 3 repos, as usual whenever we add a new TPL. This one adds the stack trace provided by [backward-cpp](https://github.com/bombela/backward-cpp), to all exceptions. We add the libraries detected by backward-cpp's cmake code to all of our executables via `BACKWARD_LIBRARIES`. We also export a number of configuration variables as compiler macros from cmake and ultimately from backward-cpp's cmake code, so they are available in `QuinoaConfig.h` when we include `backward.hpp`, this this latter is configured consistently with its detection of the its TPLs.

Note that, as described on its [README](https://github.com/bombela/backward-cpp), backward-cpp can be configured to use various optional third-party libraries that read the stack trace and associated information in various ways. There is a sensible default, which is does not provide a very fancy stack trace, but installing some libraries usually available system-wide, the output gets pretty cool and helpful for debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/245)
<!-- Reviewable:end -->
