### PR TITLE
Mark user-defined edges for initial mesh refinement

### DIFF
--- a/src/Control/CommonGrammar.h
+++ b/src/Control/CommonGrammar.h
@@ -116,6 +116,7 @@ namespace grm {
     WRONGSIZE,          //!< Size of parameter vector incorrect
     HYDROTIMESCALES,    //!< Missing required hydrotimescales vector
     HYDROPRODUCTIONS,   //!< Missing required hydroproductions vector
+    INITREFODD,         //!< AMR initref vector size is odd (must be even)
     CHARMARG };         //!< Argument inteded for the Charm++ runtime system
 
   //! Associate parser errors to error messages
@@ -268,6 +269,10 @@ namespace grm {
       "Specification of a 'hydrotimescales' vector missing." },
     { MsgKey::HYDROPRODUCTIONS, "Error in the preceding line or block. "
       "Specification of a 'hydroproductions' vector missing." },
+    { MsgKey::INITREFODD, "Error in the preceding line or block. "
+      "The number of edge-nodes, marking edges as pairs of nodes, used for "
+      "explicit tagging of edges for initial mesh refineoment is odd (it must "
+      "be even)." },
     { MsgKey::CHARMARG, "Arguments starting with '+' are assumed to be inteded "
       "for the Charm++ runtime system. Did you forget to prefix the command "
       "line with charmrun? If this warning persists even after running with "

--- a/src/Control/Inciter/InputDeck/Grammar.h
+++ b/src/Control/Inciter/InputDeck/Grammar.h
@@ -294,10 +294,10 @@ namespace grm {
 
   //! Rule used to trigger action
   struct check_amr_errors : pegtl::success {};
-  //! \brief Set defaults and do error checking on the transport equation block
-  //! \details This is error checking that only the transport equation block
-  //!   must satisfy. Besides error checking we also set defaults here as
-  //!   this block is called when parsing of a transport...end block has
+  //! Do error checking for the amr...end block
+  //! \details This is error checking that only the amr...end block
+  //!   must satisfy. Besides error checking this can also set defaults
+  //!   as this block is called when parsing of a amr...end block has
   //!   just finished.
   template<>
   struct action< check_amr_errors > {

--- a/src/Control/Inciter/InputDeck/InputDeck.h
+++ b/src/Control/Inciter/InputDeck/InputDeck.h
@@ -130,6 +130,8 @@ class InputDeck :
                                        kw::amr_error,
                                        kw::amr_jump,
                                        kw::amr_hessian,
+                                       kw::amr_refvar,
+                                       kw::amr_initref,
                                        kw::scheme,
                                        kw::matcg,
                                        kw::diagcg,

--- a/src/Control/Inciter/Types.h
+++ b/src/Control/Inciter/Types.h
@@ -45,7 +45,9 @@ using amr = tk::tuple::tagged_tuple<
   tag::init,   std::vector< AMRInitialType >,    //!< List of initial AMR types
   tag::refvar, std::vector< std::string >,       //!< List of refinement vars
   tag::id,     std::vector< std::size_t >,       //!< List of refvar indices
-  tag::error,  AMRErrorType                      //!< Error estimator for AMR
+  tag::error,  AMRErrorType,                     //!< Error estimator for AMR
+  //! List of edges-node pairs
+  tag::edge,   std::vector< kw::amr_initref::info::expect::type >
 >;
 
 //! Discretization parameters storage

--- a/src/Control/Keywords.h
+++ b/src/Control/Keywords.h
@@ -3844,6 +3844,25 @@ struct amr_refvar_info {
 };
 using amr_refvar = keyword< amr_refvar_info, TAOCPP_PEGTL_STRING("refvar") >;
 
+struct amr_initref_info {
+  static std::string name() { return "initial refinement edge-nodes"; }
+  static std::string shortDescription() { return
+    "Configure edge-node pairs for initial refinement"; }
+  static std::string longDescription() { return
+    R"(This keyword can be used to configure a list of edges that are explicitly
+    tagged for initial refinement during setup in inciter. The keyword
+    introduces an initref ... end block within an amr ... end block and must
+    contain a list of integer pairs, i.e., the number of ids must be even,
+    denoting the end-points of the nodes (=edge) which should be tagged for
+    refinement.)"; }
+  struct expect {
+    using type = std::size_t;
+    static constexpr type lower = 0;
+    static std::string description() { return "pairs of integers"; }
+  };
+};
+using amr_initref = keyword< amr_initref_info, TAOCPP_PEGTL_STRING("initref") >;
+
 struct amr_jump_info {
   static std::string name() { return "jump"; }
   static std::string shortDescription() { return

--- a/src/Control/Tags.h
+++ b/src/Control/Tags.h
@@ -162,6 +162,7 @@ struct bcoutlet {};
 struct bcextrapolate {};
 struct material {};
 struct id {};
+struct edge {};
 struct cv {};
 struct k {};
 struct com {};

--- a/src/Inciter/Partitioner.h
+++ b/src/Inciter/Partitioner.h
@@ -399,6 +399,9 @@ class Partitioner : public CBase_Partitioner {
     //! Do error-based mesh refinement
     void errorRefine();
 
+    //! Do mesh refinement based on user explicitly tagging edges
+    void userRefine();
+
     //! Do mesh refinement correcting PE-boundary edges
     void correctRefine( const tk::UnsMesh::EdgeSet& extra );
 

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -140,6 +140,7 @@ Transporter::Transporter() :
     m_print.refvar( g_inputdeck.get< tag::amr, tag::refvar >(),
                     g_inputdeck.get< tag::amr, tag::id >() );
     m_print.Item< ctr::AMRError, tag::amr, tag::error >();
+    m_print.initref( g_inputdeck.get< tag::amr, tag::edge >() );
   }
 
   // If the desired max number of time steps is larger than zero, and the

--- a/src/Main/InciterPrint.C
+++ b/src/Main/InciterPrint.C
@@ -78,3 +78,17 @@ void InciterPrint::refvar( const std::vector< std::string >& refvar,
    name[0] = static_cast< char >( std::toupper( name[0] ) );
    item( name, c );
 }
+
+void InciterPrint::initref( const std::vector< std::size_t >& edgenodes )
+// *****************************************************************************
+// Print initial mesh refinement edge-node pairs
+// *****************************************************************************
+{
+   if (edgenodes.empty()) return;
+
+   std::string c;
+   for (auto i : edgenodes) c += std::to_string(i) + ' ';
+   auto name = kw::amr_initref::name();
+   name[0] = static_cast< char >( std::toupper( name[0] ) );
+   item( name, c );
+}

--- a/src/Main/InciterPrint.h
+++ b/src/Main/InciterPrint.h
@@ -144,6 +144,9 @@ class InciterPrint : public tk::Print {
     void refvar( const std::vector< std::string >& refvar,
                  const std::vector< std::size_t >& refidx );
 
+    //! Print initial mesh refinement edge-node pairs
+    void initref( const std::vector< std::size_t >& edgenodes );
+
   private:
     //! Return partial differential equation name
     //! \param[in] key Equation key


### PR DESCRIPTION
Usage in input file within the `inciter ... end` block:
```
  amr

    initref
      1 2 3 4
    end

  end
```
The above config block tags edges `{1,2}` and `{3,4}` for initial mesh refinement. Basic error checking is done during parsing, which trips on odd size of the above list.

Note: merge to branch _dgref_ so that only the small diff, related to this capability, is visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/248)
<!-- Reviewable:end -->
