### PR TITLE
AMR DiagCG with correct BCs

### DIFF
--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -945,7 +945,7 @@ DG::refine()
   // if t>0 refinement enabled and we hit the frequency
   if (dtref && !(d->It() % dtfreq)) {   // refine
 
-    d->Ref()->dtref( d->T(), thisProxy );
+    d->Ref()->dtref( d->T(), thisProxy, m_fd.Bnode() );
 
   } else {      // do not refine
 

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -961,13 +961,16 @@ DG::resize( const tk::UnsMesh::Chunk& /*chunk*/,
             const tk::UnsMesh::Coords& /*coord*/,
             const tk::Fields& /*u*/,
             const std::unordered_map< int,
-                    std::vector< std::size_t > >& /*msum*/ )
+                    std::vector< std::size_t > >& /*msum*/,
+            const std::map< int, std::vector< std::size_t > >& /*bnode*/ )
 // *****************************************************************************
 //  Receive new mesh from refiner
 //! \param[in] chunk New mesh chunk (connectivity and global<->local id maps)
 //! \param[in] coord New mesh node coordinates
 //! \param[in] u New solution on new mesh
 //! \param[in] msum New node communication map
+//! \param[in] bnode Map of boundary-node lists mapped to corresponding
+//!   side set ids for this mesh chunk
 // *****************************************************************************
 {
   //auto d = Disc();

--- a/src/Inciter/DG.h
+++ b/src/Inciter/DG.h
@@ -116,7 +116,8 @@ class DG : public CBase_DG {
                  const tk::UnsMesh::Coords& coord,
                  const tk::Fields& u,
                  const std::unordered_map< int,
-                         std::vector< std::size_t > >& msum );
+                         std::vector< std::size_t > >& msum,
+                 const std::map< int, std::vector< std::size_t > >& bnode );
 
     //! Compute left hand side
     void lhs();

--- a/src/Inciter/DiagCG.C
+++ b/src/Inciter/DiagCG.C
@@ -699,13 +699,16 @@ DiagCG::resize( const tk::UnsMesh::Chunk& chunk,
                 const tk::UnsMesh::Coords& coord,
                 const tk::Fields& u,
                 const std::unordered_map< int,
-                      std::vector< std::size_t > >& msum )
+                      std::vector< std::size_t > >& msum,
+                const std::map< int, std::vector< std::size_t > >& bnode )
 // *****************************************************************************
 //  Receive new mesh from Refiner
 //! \param[in] chunk New mesh chunk (connectivity and global<->local id maps)
 //! \param[in] coord New mesh node coordinates
 //! \param[in] u New solution on new mesh
 //! \param[in] msum New node communication map
+//! \param[in] bnode Map of boundary-node lists mapped to corresponding
+//!   side set ids for this mesh chunk
 // *****************************************************************************
 {
   auto d = Disc();
@@ -736,6 +739,9 @@ DiagCG::resize( const tk::UnsMesh::Chunk& chunk,
   m_lhs.resize( npoin, nprop );
   m_rhs.resize( npoin, nprop );
   m_dif.resize( npoin, nprop );
+
+  // Update physical-boundary node lists
+  m_fd.Bnode() = bnode;
 
   // Resize communication buffers
   resizeComm();

--- a/src/Inciter/DiagCG.C
+++ b/src/Inciter/DiagCG.C
@@ -683,7 +683,7 @@ DiagCG::refine()
   // if t>0 refinement enabled and we hit the frequency
   if (dtref && !(d->It() % dtfreq)) {   // refine
 
-    d->Ref()->dtref( d->T(), thisProxy );
+    d->Ref()->dtref( d->T(), thisProxy, m_fd.Bnode() );
 
   } else {      // do not refine
 

--- a/src/Inciter/DiagCG.h
+++ b/src/Inciter/DiagCG.h
@@ -133,7 +133,8 @@ class DiagCG : public CBase_DiagCG {
                  const tk::UnsMesh::Coords& coord,
                  const tk::Fields& u,
                  const std::unordered_map< int,
-                         std::vector< std::size_t > >& msum );
+                         std::vector< std::size_t > >& msum,
+                 const std::map< int, std::vector< std::size_t > >& bnode );
 
     //! Const-ref access to current solution
     //! \param[in,out] u Reference to update with current solution

--- a/src/Inciter/Discretization.C
+++ b/src/Inciter/Discretization.C
@@ -654,7 +654,7 @@ Discretization::status()
     // Augment one-liner with output indicators
     if (!(m_it % field)) print << 'F';
     if (!(m_it % diag)) print << 'D';
-    if (!(m_it % dtfreq)) print << 'H';
+    if (!(m_it % dtfreq)) print << 'h';
   
     print << std::endl;
   }

--- a/src/Inciter/Discretization.C
+++ b/src/Inciter/Discretization.C
@@ -425,8 +425,14 @@ Discretization::writeMesh(
         const auto scheme = g_inputdeck.get< tag::discr, tag::scheme >();
         if (scheme == ctr::SchemeType::DG)
           ew.writeMesh( m_inpoel, m_coord, bface, triinpoel );
-        else
-          ew.writeMesh( m_inpoel, m_coord, bnode );
+        else {
+          // Convert boundary node lists to local ids for output
+          auto lbnode = bnode;
+          for (auto& s : lbnode)
+            for (auto& p : s.second)
+              p = tk::cref_find(m_lid,p);
+          ew.writeMesh( m_inpoel, m_coord, lbnode );
+        }
 
       } else {
         ew.writeMesh( m_inpoel, m_coord );

--- a/src/Inciter/FaceData.h
+++ b/src/Inciter/FaceData.h
@@ -50,6 +50,7 @@ class FaceData {
     { return m_bface; }
     const std::map< int, std::vector< std::size_t > >& Bnode() const
     { return m_bnode; }
+    std::map< int, std::vector< std::size_t > >& Bnode() { return m_bnode; }
     const std::vector< std::size_t >& Triinpoel() const { return m_triinpoel; }
     std::size_t Nbfac() const { return tk::sumvalsize( m_bface ); }
     const std::vector< int >& Esuel() const { return m_esuel; }

--- a/src/Inciter/MatCG.C
+++ b/src/Inciter/MatCG.C
@@ -464,7 +464,7 @@ MatCG::refine()
   // if t>0 refinement enabled and we hit the frequency
   if (dtref && !(d->It() % dtfreq)) {   // refine
 
-    d->Ref()->dtref( d->T(), thisProxy );
+    d->Ref()->dtref( d->T(), thisProxy, m_fd.Bnode() );
 
   } else {      // do not refine
 

--- a/src/Inciter/MatCG.C
+++ b/src/Inciter/MatCG.C
@@ -480,13 +480,16 @@ MatCG::resize( const tk::UnsMesh::Chunk& /*chunk*/,
                const tk::UnsMesh::Coords& /*coord*/,
                const tk::Fields& /*u*/,
                const std::unordered_map< int,
-                       std::vector< std::size_t > >& /*msum*/ )
+                       std::vector< std::size_t > >& /*msum*/,
+               const std::map< int, std::vector< std::size_t > >& /*bnode*/ )
 // *****************************************************************************
 //  Receive new mesh from refiner
 //! \param[in] chunk New mesh chunk (connectivity and global<->local id maps)
 //! \param[in] coord New mesh node coordinates
 //! \param[in] u New solution on new mesh
 //! \param[in] msum New node communication map
+//! \param[in] bnode Map of boundary-node lists mapped to corresponding
+//!   side set ids for this mesh chunk
 // *****************************************************************************
 {
   //auto d = Disc();

--- a/src/Inciter/MatCG.h
+++ b/src/Inciter/MatCG.h
@@ -126,7 +126,8 @@ class MatCG : public CBase_MatCG {
                  const tk::UnsMesh::Coords& coord,
                  const tk::Fields& u,
                  const std::unordered_map< int,
-                         std::vector< std::size_t > >& msum );
+                         std::vector< std::size_t > >& msum,
+                 const std::map< int, std::vector< std::size_t > >& bnode );
 
     //! Const-ref access to current solution
     //! \param[in,out] u Reference to update with current solution

--- a/src/Inciter/Refiner.C
+++ b/src/Inciter/Refiner.C
@@ -525,7 +525,7 @@ Refiner::eval()
     Assert( m_scheme.get()[thisIndex].ckLocal() != nullptr,
             "About to use nullptr" );
     auto e = tk::element< SchemeBase::ProxyElem >( m_schemeproxy, thisIndex );
-    boost::apply_visitor( Resize(m_el,m_coord,m_u,m_msum), e );
+    boost::apply_visitor( Resize(m_el,m_coord,m_u,m_msum,m_bnode), e );
 
   }
 }

--- a/src/Inciter/Refiner.h
+++ b/src/Inciter/Refiner.h
@@ -291,14 +291,16 @@ class Refiner : public CBase_Refiner {
       const tk::UnsMesh::Coords& Coord;
       const tk::Fields& U;
       const std::unordered_map< int, std::vector< std::size_t > >& Msum;
+      const std::map< int, std::vector< std::size_t > > Bnode;
       Resize( const tk::UnsMesh::Chunk& chunk,
               const tk::UnsMesh::Coords& coord,
               const tk::Fields& u,
               const std::unordered_map< int,
-                      std::vector< std::size_t > >& msum )
-        : Chunk(chunk), Coord(coord), U(u), Msum(msum) {}
+                      std::vector< std::size_t > >& msum,
+              const std::map< int, std::vector< std::size_t > >& bnode )
+        : Chunk(chunk), Coord(coord), U(u), Msum(msum), Bnode(bnode) {}
       template< typename P > void operator()( const P& p ) const {
-        p.ckLocal()->resize( Chunk, Coord, U, Msum );
+        p.ckLocal()->resize( Chunk, Coord, U, Msum, Bnode );
       }
     };
 };

--- a/src/Inciter/Refiner.h
+++ b/src/Inciter/Refiner.h
@@ -68,7 +68,9 @@ class Refiner : public CBase_Refiner {
     static void registerReducers();
 
     //! Start mesh refinement (during time stepping, t>0)
-    void dtref( tk::real t, const SchemeBase::Proxy& s );
+    void dtref( tk::real t,
+                const SchemeBase::Proxy& s,
+                const std::map< int, std::vector< std::size_t > >& bnode );
 
     //! Receive boundary edges from all PEs (including this one)
     void addBndEdges( CkReductionMsg* msg );
@@ -258,7 +260,8 @@ class Refiner : public CBase_Refiner {
     void updateBndMesh( const std::unordered_set< std::size_t >& old,
                         const std::unordered_set< std::size_t >& ref );
 
-    //! Generate boundary data structures after mesh refinement
+    //! \brief Generate boundary data structure used to update refined
+    //!   boundary faces and nodes assigned to side sets
     BndFaces boundary();
 
     //! Regenerate boundary faces after mesh refinement step

--- a/src/Inciter/Sorter.C
+++ b/src/Inciter/Sorter.C
@@ -576,7 +576,6 @@ Sorter::createWorkers()
   // Make boundary node IDs unique for each physical boundary (side set)
   for (auto& s : chbnode) tk::unique( s.second );
 
-
   // Generate set of all mesh faces
   tk::UnsMesh::FaceSet faceset;
   for (std::size_t e=0; e<m_ginpoel.size()/4; ++e) { // for all tets

--- a/src/Inciter/Transporter.C
+++ b/src/Inciter/Transporter.C
@@ -705,7 +705,7 @@ Transporter::stat()
   "       out - output-saved flags\n"
   "             F - field\n"
   "             D - diagnostics\n"
-  "             H - h-refinement\n",
+  "             h - h-refinement\n",
   "\n      it             t            dt        ETE        ETA   out\n"
     " ---------------------------------------------------------------\n" );
 

--- a/src/Inciter/refiner.ci
+++ b/src/Inciter/refiner.ci
@@ -31,7 +31,10 @@ module refiner {
                      const std::map< int, std::vector< std::size_t > >& bnode,
                      int nchare );
       initnode void registerReducers();
-      entry void dtref( tk::real t, const SchemeBase::Proxy& s );
+      entry
+        void dtref( tk::real t,
+                    const SchemeBase::Proxy& s,
+                    const std::map< int, std::vector< std::size_t > >& bnode );
       entry [reductiontarget] void addBndEdges( CkReductionMsg* msg );
       entry void addRefBndEdges( int fromch,
                                  const tk::UnsMesh::EdgeNodeCoord& en );


### PR DESCRIPTION
This makes `DiagCG` work with Dirichlet boundary conditions with mesh refinement during time stepping.

What makes this work is `DG:.C:948` (first change in the diff below), which passes the boundary node lists to `Refiner`. (There are other minor fixes related to this, but this is the essence.)

This is necessary _now_, because this data structure is different as passed in to `Refiner`'s constructor (from `Partitioner`) compared to this data structure as it exists in `DiagCG` (created and initialized later). The reason this data structure is different between these two points in the code is because `Partitioner` reshuffles the volume mesh after partitioning but does _not_ reshuffle this boundary node list data structure. This data becomes _correct_ (for computation but not for refinement in parallel) in `Sorter`, only after `Refiner` has been created. Thus these node lists were out of sync between `DiagCG` and `Refiner`, which this latter is now reused for during-time-stepping mesh refinement.

The `smp` branch sets up this data structure differently by reshuffling it `Partitioner`, immediately after mesh partitioning, which means that this data should be already consistent in both `Refiner` as well as in `DiagCG`, so passing `m_fd.Bnode()` to `Refiner::dtref()` will no longer be necessary when `smp` is ready to merge in. (The `smp` branch is not ready for a PR, since it fails a `DG` and all the `MatCG` regression tests.)