### PR TITLE
Command-line option to control frequency of load-balancing.

### DIFF
--- a/regression/inciter/transport/CylAdvect/CMakeLists.txt
+++ b/regression/inciter/transport/CylAdvect/CMakeLists.txt
@@ -45,6 +45,28 @@ add_regression_test(cyl_advect_dgp1 ${INCITER_EXECUTABLE}
                     TEXT_RESULT diag
                     TEXT_DIFF_PROG_CONF cyl_advect_diag.ndiff.cfg)
 
+# Non-blocking migration
+
+add_regression_test(cyl_advect_dgp1_lbfreq5_migr ${INCITER_EXECUTABLE}
+                    NUMPES 4
+                    INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
+                    ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v
+                         -l 5 -n +balancer RandCentLB +LBDebug 1
+                    BIN_BASELINE cyl_advect_dgp1_pe4_u0.0.std.exo.0
+                                 cyl_advect_dgp1_pe4_u0.0.std.exo.1
+                                 cyl_advect_dgp1_pe4_u0.0.std.exo.2
+                                 cyl_advect_dgp1_pe4_u0.0.std.exo.3
+                    BIN_RESULT out.e-s.0.4.0
+                               out.e-s.0.4.1
+                               out.e-s.0.4.2
+                               out.e-s.0.4.3
+                    BIN_DIFF_PROG_ARGS -m
+                    BIN_DIFF_PROG_CONF exodiff.cfg
+                    TEXT_BASELINE diag_dgp1.std
+                    TEXT_RESULT diag
+                    LABELS migration
+                    TEXT_DIFF_PROG_CONF cyl_advect_diag.ndiff.cfg)
+
 # Virtualization = 0.90
 
 add_regression_test(cyl_advect_dgp1_u0.90 ${INCITER_EXECUTABLE}
@@ -144,6 +166,98 @@ add_regression_test(cyl_advect_dgp1_u0.90_migr ${INCITER_EXECUTABLE}
                     INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v -u 0.90
                          +balancer RandCentLB +LBDebug 1
+                    BIN_BASELINE cyl_advect_dgp1_pe4_u0.90.std.exo.0
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.1
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.2
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.3
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.4
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.5
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.6
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.7
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.8
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.9
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.10
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.11
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.12
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.13
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.14
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.15
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.16
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.17
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.18
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.19
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.20
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.21
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.22
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.23
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.24
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.25
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.26
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.27
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.28
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.29
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.30
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.31
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.32
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.33
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.34
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.35
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.36
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.37
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.38
+                                 cyl_advect_dgp1_pe4_u0.90.std.exo.39
+                    BIN_RESULT out.e-s.0.40.0
+                               out.e-s.0.40.1
+                               out.e-s.0.40.2
+                               out.e-s.0.40.3
+                               out.e-s.0.40.4
+                               out.e-s.0.40.5
+                               out.e-s.0.40.6
+                               out.e-s.0.40.7
+                               out.e-s.0.40.8
+                               out.e-s.0.40.9
+                               out.e-s.0.40.10
+                               out.e-s.0.40.11
+                               out.e-s.0.40.12
+                               out.e-s.0.40.13
+                               out.e-s.0.40.14
+                               out.e-s.0.40.15
+                               out.e-s.0.40.16
+                               out.e-s.0.40.17
+                               out.e-s.0.40.18
+                               out.e-s.0.40.19
+                               out.e-s.0.40.20
+                               out.e-s.0.40.21
+                               out.e-s.0.40.22
+                               out.e-s.0.40.23
+                               out.e-s.0.40.24
+                               out.e-s.0.40.25
+                               out.e-s.0.40.26
+                               out.e-s.0.40.27
+                               out.e-s.0.40.28
+                               out.e-s.0.40.29
+                               out.e-s.0.40.30
+                               out.e-s.0.40.31
+                               out.e-s.0.40.32
+                               out.e-s.0.40.33
+                               out.e-s.0.40.34
+                               out.e-s.0.40.35
+                               out.e-s.0.40.36
+                               out.e-s.0.40.37
+                               out.e-s.0.40.38
+                               out.e-s.0.40.39
+                    BIN_DIFF_PROG_ARGS -m
+                    BIN_DIFF_PROG_CONF exodiff.cfg
+                    TEXT_BASELINE diag_dgp1.std
+                    TEXT_RESULT diag
+                    TEXT_DIFF_PROG_CONF cyl_advect_diag.ndiff.cfg
+                    LABELS migration)
+
+add_regression_test(cyl_advect_dgp1_u0.90_lbfreq5_migr ${INCITER_EXECUTABLE}
+                    NUMPES 4
+                    INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
+                    ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v -u 0.90
+                         +balancer RandCentLB +LBDebug 1 -l 5
                     BIN_BASELINE cyl_advect_dgp1_pe4_u0.90.std.exo.0
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.1
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.2

--- a/src/Control/Inciter/CmdLine/CmdLine.h
+++ b/src/Control/Inciter/CmdLine/CmdLine.h
@@ -48,7 +48,8 @@ class CmdLine : public tk::Control<
                   tag::cmdinfo,        tk::ctr::HelpFactory,
                   tag::ctrinfo,        tk::ctr::HelpFactory,
                   tag::helpkw,         tk::ctr::HelpKw,
-                  tag::error,          std::vector< std::string > > {
+                  tag::error,          std::vector< std::string >,
+                  tag::lbfreq,         kw::lbfreq::info::expect::type > {
 
   public:
     //! \brief Inciter command-line keywords
@@ -67,6 +68,7 @@ class CmdLine : public tk::Control<
                                  , kw::output
                                  , kw::diagnostics
                                  , kw::quiescence
+                                 , kw::lbfreq
                                  >;
 
     //! \brief Constructor: set all defaults.
@@ -110,6 +112,7 @@ class CmdLine : public tk::Control<
       set< tag::nonblocking>( false ); // Blocking migration by default
       set< tag::benchmark >( false ); // No benchmark mode by default
       set< tag::feedback >( false ); // No detailed feedback by default
+      set< tag::lbfreq >( 1 ); // Load balancing every time-step by default
       // Initialize help: fill from own keywords + add map passed in
       brigand::for_each< keywords >( tk::ctr::Info( get< tag::cmdinfo >() ) );
       get< tag::ctrinfo >() = std::move( ctrinfo );
@@ -133,7 +136,8 @@ class CmdLine : public tk::Control<
                    tag::cmdinfo,        tk::ctr::HelpFactory,
                    tag::ctrinfo,        tk::ctr::HelpFactory,
                    tag::helpkw,         tk::ctr::HelpKw,
-                   tag::error,          std::vector< std::string > >::pup(p);
+                   tag::error,          std::vector< std::string >,
+                   tag::lbfreq,         kw::lbfreq::info::expect::type >::pup(p);
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference

--- a/src/Control/Inciter/CmdLine/Grammar.h
+++ b/src/Control/Inciter/CmdLine/Grammar.h
@@ -89,6 +89,12 @@ namespace cmd {
          tk::grm::process_cmd_switch< use< kw::quiescence >,
                                       tag::quiescence > {};
 
+  //! Match and set load-balancing frequency
+  struct lbfreq :
+         tk::grm::process_cmd< use< kw::lbfreq >,
+                               tk::grm::Store< tag::lbfreq >,
+                               tk::grm::number > {};
+
   //! Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -101,6 +107,7 @@ namespace cmd {
                      helpctr,
                      helpkw,
                      quiescence,
+                     lbfreq,
                      io< use< kw::control >, tag::control >,
                      io< use< kw::input >, tag::input >,
                      io< use< kw::output >, tag::output >,

--- a/src/Control/Inciter/Types.h
+++ b/src/Control/Inciter/Types.h
@@ -100,7 +100,8 @@ using floatformat = tk::tuple::tagged_tuple<
 using intervals = tk::tuple::tagged_tuple<
   tag::tty,   kw::ttyi::info::expect::type,       //!< TTY output interval
   tag::field, kw::interval::info::expect::type,   //!< Field output interval
-  tag::diag,  kw::interval::info::expect::type    //!< Diags output interval
+  tag::diag,  kw::interval::info::expect::type,   //!< Diags output interval
+  tag::lbfreq,kw::lbfreq::info::expect::type      //!< load-balancing frequency
 >;
 
 //! IO parameters storage

--- a/src/Control/Keywords.h
+++ b/src/Control/Keywords.h
@@ -3411,11 +3411,14 @@ using nonblocking =
 struct lbfreq_info {
   static std::string name() { return "lbfreq"; }
   static std::string shortDescription()
-  { return "Set load-balancing frequency during time-stepping"; }
+  { return "Set load-balancing frequency during time stepping"; }
   static std::string longDescription() { return
     R"(This keyword is used to set frequency of load-balancing during
-       time-stepping. The default is 1, which means that load-balancing will be
-       performed every time-step.)";
+       time stepping. The default is 1, which means that load balancing is
+       initiated every time step. Note, however, that this does not necessarily
+       mean that load balancing will be performed by the runtime system every
+       time step, only that the Charm++ load-balancer is initiated. For more
+       information, see the Charm++ manual.)";
   }
   using alias = Alias< l >;
   struct expect {

--- a/src/Control/Keywords.h
+++ b/src/Control/Keywords.h
@@ -3408,6 +3408,29 @@ struct nonblocking_info {
 using nonblocking =
   keyword< nonblocking_info, TAOCPP_PEGTL_STRING("nonblocking") >;
 
+struct lbfreq_info {
+  static std::string name() { return "lbfreq"; }
+  static std::string shortDescription()
+  { return "Set load-balancing frequency during time-stepping"; }
+  static std::string longDescription() { return
+    R"(This keyword is used to set frequency of load-balancing during
+       time-stepping. The default is 1, which means that load-balancing will be
+       performed every time-step.)";
+  }
+  using alias = Alias< l >;
+  struct expect {
+    using type = std::size_t;
+    static constexpr type lower = 1;
+    static constexpr type upper = std::numeric_limits< tk::real >::digits10 + 1;
+    static std::string description() { return "int"; }
+    static std::string choices() {
+      return "integer between [" + std::to_string(lower) + "..." +
+             std::to_string(upper) + "] (both inclusive)";
+    }
+  };
+};
+using lbfreq = keyword< lbfreq_info, TAOCPP_PEGTL_STRING("lbfreq") >;
+
 struct feedback_info {
   static std::string name() { return "feedback"; }
   static std::string shortDescription() { return "Enable on-screen feedback"; }

--- a/src/Control/Tags.h
+++ b/src/Control/Tags.h
@@ -48,6 +48,7 @@ struct lboff {};
 struct feedback {};
 struct reorder {};
 struct error {};
+struct lbfreq {};
 struct pdf {};
 struct ordpdf {};
 struct cenpdf {};

--- a/src/Inciter/ALECG.C
+++ b/src/Inciter/ALECG.C
@@ -578,13 +578,15 @@ ALECG::step()
   const auto term = g_inputdeck.get< tag::discr, tag::term >();
   const auto nstep = g_inputdeck.get< tag::discr, tag::nstep >();
   const auto eps = std::numeric_limits< tk::real >::epsilon();
+  const auto lbfreq = g_inputdeck.get< tag::cmd, tag::lbfreq >();
+  const auto nonblocking = g_inputdeck.get< tag::cmd, tag::nonblocking >();
 
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+    if ( (d->It()) % lbfreq == 0 ) {
       AtSync();
-      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+      if (nonblocking) dt();
     }
     else {
       dt();

--- a/src/Inciter/ALECG.C
+++ b/src/Inciter/ALECG.C
@@ -582,8 +582,13 @@ ALECG::step()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    AtSync();
-    if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+      AtSync();
+      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+    }
+    else {
+      dt();
+    }
 
   } else {
     d->contribute( CkCallback( CkReductionTarget(Transporter,finish), d->Tr() ) );

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -1436,8 +1436,13 @@ DG::step()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    AtSync();
-    if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) next();
+    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+      AtSync();
+      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) next();
+    }
+    else {
+      next();
+    }
 
   } else {
     contribute(CkCallback( CkReductionTarget(Transporter,finish), d->Tr() ));

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -1432,13 +1432,15 @@ DG::step()
   const auto term = g_inputdeck.get< tag::discr, tag::term >();
   const auto nstep = g_inputdeck.get< tag::discr, tag::nstep >();
   const auto eps = std::numeric_limits< tk::real >::epsilon();
+  const auto lbfreq = g_inputdeck.get< tag::cmd, tag::lbfreq >();
+  const auto nonblocking = g_inputdeck.get< tag::cmd, tag::nonblocking >();
 
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+    if ( (d->It()) % lbfreq == 0 ) {
       AtSync();
-      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) next();
+      if (nonblocking) next();
     }
     else {
       next();

--- a/src/Inciter/DiagCG.C
+++ b/src/Inciter/DiagCG.C
@@ -688,13 +688,15 @@ DiagCG::step()
   const auto term = g_inputdeck.get< tag::discr, tag::term >();
   const auto nstep = g_inputdeck.get< tag::discr, tag::nstep >();
   const auto eps = std::numeric_limits< tk::real >::epsilon();
+  const auto lbfreq = g_inputdeck.get< tag::cmd, tag::lbfreq >();
+  const auto nonblocking = g_inputdeck.get< tag::cmd, tag::nonblocking >();
 
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+    if ( (d->It()) % lbfreq == 0 ) {
       AtSync();
-      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+      if (nonblocking) dt();
     }
     else {
       dt();

--- a/src/Inciter/DiagCG.C
+++ b/src/Inciter/DiagCG.C
@@ -692,8 +692,13 @@ DiagCG::step()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    AtSync();
-    if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+    if ( (d->It()) % (g_inputdeck.get< tag::cmd, tag::lbfreq >()) == 0 ) {
+      AtSync();
+      if (g_inputdeck.get< tag::cmd, tag::nonblocking >()) dt();
+    }
+    else {
+      dt();
+    }
 
   } else {
     d->contribute( CkCallback( CkReductionTarget(Transporter,finish), d->Tr() ) );

--- a/src/Main/InciterDriver.C
+++ b/src/Main/InciterDriver.C
@@ -45,6 +45,14 @@ InciterDriver::InciterDriver( const InciterPrint& print,
   print.item( "Benchmark mode, -" + *kw::benchmark::alias(),
                cmdline.get< tag::benchmark >() ? "on" : "off" );
 
+  auto lbfreq = cmdline.get< tag::lbfreq >();
+  if ( lbfreq < kw::lbfreq::info::expect::lower ||
+       lbfreq > kw::lbfreq::info::expect::upper ) {
+    Throw( "Load-balancing frequency should be greater than 0." );
+  }
+  print.item( "Load-balancing frequency, -" + *kw::lbfreq::alias(),
+               std::to_string(cmdline.get< tag::lbfreq >()) );
+
   // Parse input deck into g_inputdeck
   m_print.item( "Control file", cmdline.get< tag::io, tag::control >() );  
   InputDeckParser inputdeckParser( m_print, cmdline, g_inputdeck );


### PR DESCRIPTION
Added command-line option to control frequency of load-balancing.
Control by: -l <frequency>
Added two regression tests for this.
Default is every time-step (frequency=1).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/297)
<!-- Reviewable:end -->
