### PR TITLE
Scale CFL appropriately for DG-order.

### DIFF
--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -984,7 +984,8 @@ DG::dt()
         dgp = 2.0;
       }
 
-      // Scale smallest dt with CFL coefficient
+      // Scale smallest dt with CFL coefficient and the CFL is scaled by (2*p+1)
+      // where p is the order of the DG polynomial by linear stability theory.
       mindt *= g_inputdeck.get< tag::discr, tag::cfl >()
                / (2.0*dgp + 1.0);
 

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -972,24 +972,21 @@ DG::dt()
         if (eqdt < mindt) mindt = eqdt;
       }
 
-      auto dgp = g_inputdeck.get< tag::discr, tag::ndof >();
+      auto ndof = g_inputdeck.get< tag::discr, tag::ndof >();
+      tk::real dgp = 0.0;
 
-      if (dgp == 4)
+      if (ndof == 4)
       {
-        dgp = 1;
+        dgp = 1.0;
       }
-      else if (dgp == 10)
+      else if (ndof == 10)
       {
-        dgp = 2;
-      }
-      else
-      {
-        dgp = 0;
+        dgp = 2.0;
       }
 
       // Scale smallest dt with CFL coefficient
       mindt *= g_inputdeck.get< tag::discr, tag::cfl >()
-               / (2.0*static_cast< tk::real >(dgp) + 1.0);
+               / (2.0*dgp + 1.0);
 
     }
   }

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -972,8 +972,24 @@ DG::dt()
         if (eqdt < mindt) mindt = eqdt;
       }
 
+      auto dgp = g_inputdeck.get< tag::discr, tag::ndof >();
+
+      if (dgp == 4)
+      {
+        dgp = 1;
+      }
+      else if (dgp == 10)
+      {
+        dgp = 2;
+      }
+      else
+      {
+        dgp = 0;
+      }
+
       // Scale smallest dt with CFL coefficient
-      mindt *= g_inputdeck.get< tag::discr, tag::cfl >();
+      mindt *= g_inputdeck.get< tag::discr, tag::cfl >()
+               / (2.0*static_cast< tk::real >(dgp) + 1.0);
 
     }
   }

--- a/tests/regression/inciter/compflow/Euler/SedovBlastwave/sedov_blastwave_dgp1.q
+++ b/tests/regression/inciter/compflow/Euler/SedovBlastwave/sedov_blastwave_dgp1.q
@@ -7,7 +7,7 @@ title "Sedov blast wave"
 inciter
 
   nstep 20   # Max number of time steps
-  cfl 0.1
+  cfl 0.3
   ttyi 5      # TTY output interval
   scheme dgp1
   limiter superbeep1


### PR DESCRIPTION
CFL number is scaled appropriately dependent on the DG(p) order, so that the input-deck 'cfl' can be ignorant of stricter restrictions due to discretization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/311)
<!-- Reviewable:end -->
