### PR TITLE
Added load-balancing after the second time-step as a default.

### DIFF
--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -1442,8 +1442,8 @@ DG::step()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    // Load balancing if frequency is reached and also at the second time-step
-    if ( ( (d->It()) % lbfreq == 0 ) || ( d->It() == 2 ) ) {
+    // Load balancing if user frequency is reached or after the second time-step
+    if ( (d->It()) % lbfreq == 0 || d->It() == 2 ) {
       AtSync();
       if (nonblocking) next();
     }

--- a/src/Inciter/DG.C
+++ b/src/Inciter/DG.C
@@ -1442,7 +1442,8 @@ DG::step()
   // If neither max iterations nor max time reached, continue, otherwise finish
   if (std::fabs(d->T()-term) > eps && d->It() < nstep) {
 
-    if ( (d->It()) % lbfreq == 0 ) {
+    // Load balancing if frequency is reached and also at the second time-step
+    if ( ( (d->It()) % lbfreq == 0 ) || ( d->It() == 2 ) ) {
       AtSync();
       if (nonblocking) next();
     }


### PR DESCRIPTION
This is important for problems where a low frequency of load balancing is desired, but the initial p-refinement leads to an unbalanced load. This initial imbalance is evened-out by performing a load balancing step after the second time-step by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/312)
<!-- Reviewable:end -->
