### PR TITLE
Add grind-time to inciter's one-liner status

### DIFF
--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -57,7 +57,8 @@ Discretization::Discretization(
   m_volc(),
   m_bid(),
   m_timer(),
-  m_refined( 0 )
+  m_refined( 0 ),
+  m_prevstatus( std::chrono::high_resolution_clock::now() )
 // *****************************************************************************
 //  Constructor
 //! \param[in] fctproxy Distributed FCT proxy
@@ -508,6 +509,14 @@ Discretization::status()
     tk::Timer::Watch ete, eta;
     m_timer.eta( term-t0, m_t-t0, nstep, m_it, ete, eta );
  
+    // estimate grind time (taken between this and the previous status line
+    // measurement) in milliseconds
+    using std::chrono::duration_cast;
+    using ms = std::chrono::milliseconds;
+    using clock = std::chrono::high_resolution_clock;
+    auto grind_time = duration_cast< ms >( clock::now() - m_prevstatus ).count();
+    m_prevstatus = clock::now();
+
     tk::Print print( verbose ? std::cout : std::clog );
  
     // Output one-liner
@@ -521,7 +530,9 @@ Discretization::status()
           << std::setw(2) << ete.sec.count() << "  "
           << std::setw(3) << eta.hrs.count() << ":"
           << std::setw(2) << eta.min.count() << ":"
-          << std::setw(2) << eta.sec.count() << "  ";
+          << std::setw(2) << eta.sec.count() << "  "
+          << std::scientific << std::setprecision(6) << std::setfill(' ')
+          << std::setw(9) << grind_time << "  ";
   
     // Augment one-liner with output indicators
     if (!(m_it % field)) print << 'f';

--- a/src/Inciter/Discretization.hpp
+++ b/src/Inciter/Discretization.hpp
@@ -317,6 +317,8 @@ class Discretization : public CBase_Discretization {
     tk::Timer m_timer;
     //! 1 if mesh was refined in a time step, 0 if it was not
     int m_refined;
+    //! Time point storing clock state at status()
+    std::chrono::high_resolution_clock::time_point m_prevstatus;
 
     //! Set mesh coordinates based on coordinates map
     tk::UnsMesh::Coords setCoord( const tk::UnsMesh::CoordMap& coordmap );

--- a/src/Inciter/Transporter.cpp
+++ b/src/Inciter/Transporter.cpp
@@ -820,12 +820,13 @@ Transporter::stat()
   "        dt - time step size\n"
   "       ETE - estimated time elapsed (h:m:s)\n"
   "       ETA - estimated time for accomplishment (h:m:s)\n"
+  "       EGT - estimated grind time (ms/status)\n"
   "       out - output-saved flags\n"
   "             f - field\n"
   "             d - diagnostics\n"
   "             h - h-refinement\n",
-  "\n      it             t            dt        ETE        ETA   out\n"
-    " ---------------------------------------------------------------\n" );
+  "\n      it             t            dt        ETE        ETA        EGT  out\n"
+    " -------------------------------------------------------------------------\n" );
 
   m_progWork.start( "Preparing workers",
                     {{ m_nchare, m_nchare, m_nchare, m_nchare, m_nchare }} );


### PR DESCRIPTION
This adds a new timer output to inciter's timestepping status line, named 'estimated grind time', which measures the time elapsed between two `Discretization::status()` calls in milliseconds.

This can be useful as quantitative visual feedback on grind time as his can sometimes significantly change for no apparent reason during large runs, probably due to other activity on the machine, which then helps ignoring benchmarking runs compared to others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/316)
<!-- Reviewable:end -->
