### PR TITLE
Increase tolerance for boundary integral testing leaky BCs

### DIFF
--- a/src/Inciter/Transporter.cpp
+++ b/src/Inciter/Transporter.cpp
@@ -487,20 +487,25 @@ Transporter::bndint( tk::real sx, tk::real sy, tk::real sz, tk::real cb )
 //!   compute the partial surface integrals.
 // *****************************************************************************
 {
-  auto eps = std::numeric_limits< tk::real >::epsilon() * 100;
-
-  std::string err;
-  if (cb < 0.0)  // called from Refiner
-    err = "Mesh boundary leaky after mesh refinement step; this is due to a "
+  std::stringstream err;
+  if (cb < 0.0) {  // called from Refiner
+    err << "Mesh boundary leaky after mesh refinement step; this is due to a "
      "problem with updating the side sets used to specify boundary conditions "
-     "on faces, required for DG methods";
-  else if (cb > 0.0)  // called from DG
-    err = "Mesh boundary leaky during initialization of the DG algorithm; this "
+     "on faces, required for DG methods: ";
+  } else if (cb > 0.0) {  // called from DG
+    err << "Mesh boundary leaky during initialization of the DG algorithm; this "
     "is due to incorrect or incompletely specified boundary conditions for a "
-    "given input mesh";
+    "given input mesh: ";
+  }
 
-  if (std::abs(sx) > eps || std::abs(sy) > eps || std::abs(sz) > eps)
-    Throw( std::move(err) );
+  auto eps = std::numeric_limits< tk::real >::epsilon() * 1.0e+3; // ~ 2.0e-13
+
+  if (std::abs(sx) > eps || std::abs(sy) > eps || std::abs(sz) > eps) {
+    err << "Integral result must be a zero vector: " << std::setprecision(12) <<
+           std::abs(sx) << ", " << std::abs(sy) << ", " << std::abs(sz) <<
+           ", eps = " << eps;
+    Throw( err.str() );
+  }
 
   if (cb > 0.0) m_scheme.resizeComm();
 }


### PR DESCRIPTION
This commit increases the tolerance by an order of magnitude that we still accept for the individual components of the surface integral computed over the physical boundary involving the side sets specified by the user for a DG calculation. This appears necessary, as this can be triggered on some number of partitions while passing on some other number of partitions in parallel (everything else being the same) with data, such as
```
>>> Exception: Mesh boundary leaky during initialization of the DG algorithm; this is due to incorrect or incompletely specified boundary conditions for a given input mesh: Integral result must be a zero vector: 6.84102397862e-14, 6.965638461e-14, 6.37719044239e-14, eps = 2.22044604925e-14
```
The above triggers, which it should not, because the vector is practically zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/317)
<!-- Reviewable:end -->
