### PR TITLE
Add version and license info to all executables

### DIFF
--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -449,6 +449,17 @@ class Print {
       }
     }
 
+    //! Print version information
+    template< Style s = VERBOSE >
+    void version( const std::string& executable,
+                  const std::string& version,
+                  const std::string& commit ) const
+    {
+      auto ce = executable;
+      ce[0] = static_cast< char >( std::toupper( ce[0] ) );
+      stream<s>() << m_version_fmt % ce % version % commit;
+    }
+
     //! Print lower and upper bounds for a keyword if defined
     template< Style s = VERBOSE, typename Info >
     void bounds( const Info& info ) const {
@@ -773,6 +784,8 @@ class Print {
     mutable format m_item_widename_value_fmt = format("%s%-75s : %s\n");
     mutable format m_part_underline_fmt = format("      %|=68|\n");
     mutable format m_section_underline_fmt = format("%s%s\n");
+    mutable format m_version_fmt =
+              format("\nQuinoa::%s, version %s (SHA1: %s)\n\n");
 
     // Stream objects
     std::stringstream m_null;   //!< Default verbose stream

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -456,9 +456,7 @@ class Print {
                   const std::string& commit,
                   const std::string& copyright ) const
     {
-      auto ce = executable;
-      ce[0] = static_cast< char >( std::toupper( ce[0] ) );
-      stream<s>() << m_version_fmt % ce % version % commit % copyright;
+      stream<s>() << m_version_fmt % executable % version % commit % copyright;
     }
 
     //! Print license information
@@ -466,9 +464,7 @@ class Print {
     void license( const std::string& executable,
                   const std::string& license ) const
     {
-      auto ce = executable;
-      ce[0] = static_cast< char >( std::toupper( ce[0] ) );
-      stream<s>() << m_license_fmt % ce % license;
+      stream<s>() << m_license_fmt % executable % license;
     }
 
     //! Print lower and upper bounds for a keyword if defined

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -453,11 +453,12 @@ class Print {
     template< Style s = VERBOSE >
     void version( const std::string& executable,
                   const std::string& version,
-                  const std::string& commit ) const
+                  const std::string& commit,
+                  const std::string& copyright ) const
     {
       auto ce = executable;
       ce[0] = static_cast< char >( std::toupper( ce[0] ) );
-      stream<s>() << m_version_fmt % ce % version % commit;
+      stream<s>() << m_version_fmt % ce % version % commit % copyright;
     }
 
     //! Print lower and upper bounds for a keyword if defined
@@ -785,7 +786,7 @@ class Print {
     mutable format m_part_underline_fmt = format("      %|=68|\n");
     mutable format m_section_underline_fmt = format("%s%s\n");
     mutable format m_version_fmt =
-              format("\nQuinoa::%s, version %s (SHA1: %s)\n\n");
+              format("\nQuinoa::%s, version %s (SHA1: %s)\n%s\n\n");
 
     // Stream objects
     std::stringstream m_null;   //!< Default verbose stream

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -461,6 +461,16 @@ class Print {
       stream<s>() << m_version_fmt % ce % version % commit % copyright;
     }
 
+    //! Print license information
+    template< Style s = VERBOSE >
+    void license( const std::string& executable,
+                  const std::string& license ) const
+    {
+      auto ce = executable;
+      ce[0] = static_cast< char >( std::toupper( ce[0] ) );
+      stream<s>() << m_license_fmt % ce % license;
+    }
+
     //! Print lower and upper bounds for a keyword if defined
     template< Style s = VERBOSE, typename Info >
     void bounds( const Info& info ) const {
@@ -787,6 +797,7 @@ class Print {
     mutable format m_section_underline_fmt = format("%s%s\n");
     mutable format m_version_fmt =
               format("\nQuinoa::%s, version %s (SHA1: %s)\n%s\n\n");
+    mutable format m_license_fmt = format("\nQuinoa::%s\n\n%s\n\n");
 
     // Stream objects
     std::stringstream m_null;   //!< Default verbose stream

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -452,19 +452,19 @@ class Print {
     //! Print version information
     template< Style s = VERBOSE >
     void version( const std::string& executable,
-                  const std::string& version,
+                  const std::string& ver,
                   const std::string& commit,
                   const std::string& copyright ) const
     {
-      stream<s>() << m_version_fmt % executable % version % commit % copyright;
+      stream<s>() << m_version_fmt % executable % ver % commit % copyright;
     }
 
     //! Print license information
     template< Style s = VERBOSE >
     void license( const std::string& executable,
-                  const std::string& license ) const
+                  const std::string& lic ) const
     {
-      stream<s>() << m_license_fmt % executable % license;
+      stream<s>() << m_license_fmt % executable % lic;
     }
 
     //! Print lower and upper bounds for a keyword if defined

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,11 +113,11 @@ if (NOT ENABLE_TESTS)
   message(STATUS "Tests disabled.")
 endif()
 
-# Extract copyright info from LICENSE file
-set(LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE")
-file(STRINGS ${LICENSE} license)
-string(REGEX REPLACE "All rights reserved\.*" "All rights reserved. See --license for details." COPYRIGHT "${license}")
+# Save contents of license file and copyright info in cmake variables
+file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE" LICENSE)
+string(REGEX REPLACE "All rights reserved\.*" "All rights reserved. See --license for details." COPYRIGHT "${LICENSE}")
 string(REGEX REPLACE ";" "\\\\n" COPYRIGHT "${COPYRIGHT}")
+string(REGEX REPLACE ";" "\\\\n" LICENSE "${LICENSE}")
 
 # Include third-party libraries configuration
 include(TPLs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,12 @@ if (NOT ENABLE_TESTS)
   message(STATUS "Tests disabled.")
 endif()
 
+# Extract copyright info from LICENSE file
+set(LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE")
+file(STRINGS ${LICENSE} license)
+string(REGEX REPLACE "All rights reserved\.*" "All rights reserved. See --license for details." COPYRIGHT "${license}")
+string(REGEX REPLACE ";" "\\\\n" COPYRIGHT "${COPYRIGHT}")
+
 # Include third-party libraries configuration
 include(TPLs)
 
@@ -529,7 +535,7 @@ set(EXECUTABLES ${INCITER_EXECUTABLE}
 configure_file( "${PROJECT_SOURCE_DIR}/Main/QuinoaConfig.hpp.in"
                 "${PROJECT_BINARY_DIR}/Main/QuinoaConfig.hpp" )
 configure_file( "${PROJECT_SOURCE_DIR}/Main/QuinoaConfig.cpp.in"
-                "${PROJECT_BINARY_DIR}/Main/QuinoaConfig.cpp" )
+                "${PROJECT_BINARY_DIR}/Main/QuinoaConfig.cpp" ESCAPE_QUOTES)
 
 # Remove build hostname from cmake cache
 unset(HOSTNAME CACHE)

--- a/src/Control/FileConv/CmdLine/CmdLine.hpp
+++ b/src/Control/FileConv/CmdLine/CmdLine.hpp
@@ -41,6 +41,8 @@ class CmdLine :
                       tag::help,       bool,
                       tag::quiescence, bool,
                       tag::trace,      bool,
+                      tag::version,    bool,
+                      tag::license,    bool,
                       tag::cmdinfo,    tk::ctr::HelpFactory,
                       tag::ctrinfo,    tk::ctr::HelpFactory,
                       tag::helpkw,     tk::ctr::HelpKw,
@@ -56,6 +58,8 @@ class CmdLine :
                                      , kw::output
                                      , kw::quiescence
                                      , kw::trace
+                                     , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set defaults.
@@ -68,6 +72,8 @@ class CmdLine :
       set< tag::verbose >( false ); // Use quiet output by default
       set< tag::chare >( false ); // No chare state output by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
     }
@@ -83,6 +89,8 @@ class CmdLine :
                    tag::help,        bool,
                    tag::quiescence,  bool,
                    tag::trace,       bool,
+                   tag::version,     bool,
+                   tag::license,     bool,
                    tag::cmdinfo,     tk::ctr::HelpFactory,
                    tag::ctrinfo,     tk::ctr::HelpFactory,
                    tag::helpkw,      tk::ctr::HelpKw,

--- a/src/Control/FileConv/CmdLine/Grammar.hpp
+++ b/src/Control/FileConv/CmdLine/Grammar.hpp
@@ -70,6 +70,16 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::trace,
                                       tag::trace > {};
 
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! \brief Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -78,6 +88,8 @@ namespace cmd {
                      helpkw,
                      quiescence,
                      trace,
+                     version,
+                     license,
                      io< kw::input, tag::input >,
                      io< kw::output, tag::output > > {};
 

--- a/src/Control/Inciter/CmdLine/CmdLine.hpp
+++ b/src/Control/Inciter/CmdLine/CmdLine.hpp
@@ -45,6 +45,7 @@ class CmdLine : public tk::Control<
                   tag::quiescence,     bool,
                   tag::trace,          bool,
                   tag::version,        bool,
+                  tag::license,        bool,
                   tag::cmdinfo,        tk::ctr::HelpFactory,
                   tag::ctrinfo,        tk::ctr::HelpFactory,
                   tag::helpkw,         tk::ctr::HelpKw,
@@ -71,6 +72,7 @@ class CmdLine : public tk::Control<
                                      , kw::lbfreq
                                      , kw::trace
                                      , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set all defaults.
@@ -117,6 +119,7 @@ class CmdLine : public tk::Control<
       set< tag::lbfreq >( 1 ); // Load balancing every time-step by default
       set< tag::trace >( true ); // Output call and stack trace by default
       set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords + add map passed in
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
       get< tag::ctrinfo >() = std::move( ctrinfo );
@@ -139,6 +142,7 @@ class CmdLine : public tk::Control<
                    tag::quiescence,     bool,
                    tag::trace,          bool,
                    tag::version,        bool,
+                   tag::license,        bool,
                    tag::cmdinfo,        tk::ctr::HelpFactory,
                    tag::ctrinfo,        tk::ctr::HelpFactory,
                    tag::helpkw,         tk::ctr::HelpKw,

--- a/src/Control/Inciter/CmdLine/CmdLine.hpp
+++ b/src/Control/Inciter/CmdLine/CmdLine.hpp
@@ -44,6 +44,7 @@ class CmdLine : public tk::Control<
                   tag::helpctr,        bool,
                   tag::quiescence,     bool,
                   tag::trace,          bool,
+                  tag::version,        bool,
                   tag::cmdinfo,        tk::ctr::HelpFactory,
                   tag::ctrinfo,        tk::ctr::HelpFactory,
                   tag::helpkw,         tk::ctr::HelpKw,
@@ -69,6 +70,7 @@ class CmdLine : public tk::Control<
                                      , kw::quiescence
                                      , kw::lbfreq
                                      , kw::trace
+                                     , kw::version
                                      >;
 
     //! \brief Constructor: set all defaults.
@@ -114,6 +116,7 @@ class CmdLine : public tk::Control<
       set< tag::feedback >( false ); // No detailed feedback by default
       set< tag::lbfreq >( 1 ); // Load balancing every time-step by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
       // Initialize help: fill from own keywords + add map passed in
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
       get< tag::ctrinfo >() = std::move( ctrinfo );
@@ -135,6 +138,7 @@ class CmdLine : public tk::Control<
                    tag::helpctr,        bool,
                    tag::quiescence,     bool,
                    tag::trace,          bool,
+                   tag::version,        bool,
                    tag::cmdinfo,        tk::ctr::HelpFactory,
                    tag::ctrinfo,        tk::ctr::HelpFactory,
                    tag::helpkw,         tk::ctr::HelpKw,

--- a/src/Control/Inciter/CmdLine/Grammar.hpp
+++ b/src/Control/Inciter/CmdLine/Grammar.hpp
@@ -105,6 +105,11 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::trace,
                                       tag::trace > {};
 
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
   //! Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -119,6 +124,7 @@ namespace cmd {
                      quiescence,
                      lbfreq,
                      trace,
+                     version,
                      io< kw::control, tag::control >,
                      io< kw::input, tag::input >,
                      io< kw::output, tag::output >,

--- a/src/Control/Inciter/CmdLine/Grammar.hpp
+++ b/src/Control/Inciter/CmdLine/Grammar.hpp
@@ -110,6 +110,11 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::version,
                                       tag::version > {};
 
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -125,6 +130,7 @@ namespace cmd {
                      lbfreq,
                      trace,
                      version,
+                     license,
                      io< kw::control, tag::control >,
                      io< kw::input, tag::input >,
                      io< kw::output, tag::output >,

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -110,7 +110,8 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   if (version)
     print.version< tk::QUIET >( tk::inciter_executable(),
                                 tk::quinoa_version(),
-                                tk::git_commit() );
+                                tk::git_commit(),
+                                tk::copyright() );
 
   // Immediately exit if any help was output or was called without any argument
   // or version info was requested with zero exit code

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -105,7 +105,7 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::inciter_executable(), helpkw );
 
-  // See if version information was requested
+  // Print out version information if it was requested
   const auto version = cmdline.get< tag::version >();
   if (version)
     print.version< tk::QUIET >( tk::inciter_executable(),
@@ -113,10 +113,18 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
                                 tk::git_commit(),
                                 tk::copyright() );
 
+  // Print out license information if it was requested
+  const auto license = cmdline.get< tag::license >();
+  if (license)
+    print.license< tk::QUIET >( tk::inciter_executable(), tk::license() );
+
   // Immediately exit if any help was output or was called without any argument
-  // or version info was requested with zero exit code
-  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty() || version)
+  // or version or license info was requested with zero exit code
+  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty() || version ||
+      license)
+  {
     CkExit();
+  }
 
   // Make sure mandatory arguments are set
   auto ctralias = kw::control().alias();

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -105,9 +105,17 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::inciter_executable(), helpkw );
 
+  // See if version information was requested
+  const auto version = cmdline.get< tag::version >();
+  if (version)
+    print.version< tk::QUIET >( tk::inciter_executable(),
+                                tk::quinoa_version(),
+                                tk::git_commit() );
+
   // Immediately exit if any help was output or was called without any argument
-  // with zero exit code
-  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty()) CkExit();
+  // or version info was requested with zero exit code
+  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty() || version)
+    CkExit();
 
   // Make sure mandatory arguments are set
   auto ctralias = kw::control().alias();

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -11,17 +11,12 @@
 */
 // *****************************************************************************
 
-#include <map>
-#include <ostream>
-#include <type_traits>
-
 #include "NoWarning/pegtl.hpp"
 #include "NoWarning/charm.hpp"
 
-#include "Print.hpp"
 #include "QuinoaConfig.hpp"
 #include "Exception.hpp"
-#include "HelpFactory.hpp"
+#include "Print.hpp"
 #include "Keywords.hpp"
 #include "Inciter/Types.hpp"
 #include "Inciter/CmdLine/Parser.hpp"

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -3506,12 +3506,23 @@ struct version_info {
   static std::string name() { return "Show version"; }
   static std::string shortDescription() { return "Show version information"; }
   static std::string longDescription() { return
-    R"(This keyword is used to display version information for the executable/tool,
-       on the standard output and exit successfully.)";
+    R"(This keyword is used to display version information for the
+       executable/tool on the standard output and exit successfully.)";
   }
   using alias = Alias< V >;
 };
 using version = keyword< version_info, TAOCPP_PEGTL_STRING("version") >;
+
+struct license_info {
+  static std::string name() { return "Show license"; }
+  static std::string shortDescription() { return "Show license information"; }
+  static std::string longDescription() { return
+    R"(This keyword is used to display license information for the
+       executable/tool on the standard output and exit successfully.)";
+  }
+  using alias = Alias< L >;
+};
+using license = keyword< license_info, TAOCPP_PEGTL_STRING("license") >;
 
 struct trace_info {
   static std::string name() { return "trace"; }

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -3500,8 +3500,18 @@ struct feedback_info {
   }
   using alias = Alias< f >;
 };
-
 using feedback = keyword< feedback_info, TAOCPP_PEGTL_STRING("feedback") >;
+
+struct version_info {
+  static std::string name() { return "Show version"; }
+  static std::string shortDescription() { return "Show version information"; }
+  static std::string longDescription() { return
+    R"(This keyword is used to display version information for the executable/tool,
+       on the standard output and exit successfully.)";
+  }
+  using alias = Alias< V >;
+};
+using version = keyword< version_info, TAOCPP_PEGTL_STRING("version") >;
 
 struct trace_info {
   static std::string name() { return "trace"; }
@@ -3514,7 +3524,6 @@ struct trace_info {
     option.)"; }
   using alias = Alias< t >;
 };
-
 using trace = keyword< trace_info, TAOCPP_PEGTL_STRING("trace") >;
 
 struct quiescence_info {
@@ -3529,7 +3538,6 @@ struct quiescence_info {
   }
   using alias = Alias< q >;
 };
-
 using quiescence =
   keyword< quiescence_info, TAOCPP_PEGTL_STRING("quiescence") >;
 

--- a/src/Control/MeshConv/CmdLine/CmdLine.hpp
+++ b/src/Control/MeshConv/CmdLine/CmdLine.hpp
@@ -42,6 +42,8 @@ class CmdLine :
                       tag::help,       bool,
                       tag::quiescence, bool,
                       tag::trace,      bool,
+                      tag::version,    bool,
+                      tag::license,    bool,
                       tag::cmdinfo,    tk::ctr::HelpFactory,
                       tag::ctrinfo,    tk::ctr::HelpFactory,
                       tag::helpkw,     tk::ctr::HelpKw,
@@ -59,6 +61,8 @@ class CmdLine :
                                      , kw::reorder
                                      , kw::quiescence
                                      , kw::trace
+                                     , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set defaults.
@@ -88,6 +92,8 @@ class CmdLine :
                    tag::help,       bool,
                    tag::quiescence, bool,
                    tag::trace,      bool,
+                   tag::version,    bool,
+                   tag::license,    bool,
                    tag::cmdinfo,    tk::ctr::HelpFactory,
                    tag::ctrinfo,    tk::ctr::HelpFactory,
                    tag::helpkw,     tk::ctr::HelpKw,

--- a/src/Control/MeshConv/CmdLine/CmdLine.hpp
+++ b/src/Control/MeshConv/CmdLine/CmdLine.hpp
@@ -76,6 +76,8 @@ class CmdLine :
       set< tag::chare >( false ); // No chare state output by default
       set< tag::reorder >( false ); // Do not reorder by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
     }

--- a/src/Control/MeshConv/CmdLine/Grammar.hpp
+++ b/src/Control/MeshConv/CmdLine/Grammar.hpp
@@ -68,6 +68,21 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::quiescence,
                                       tag::quiescence > {};
 
+  //! Match switch on trace output
+  struct trace :
+         tk::grm::process_cmd_switch< use, kw::trace,
+                                      tag::trace > {};
+
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! \brief Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -76,6 +91,9 @@ namespace cmd {
                      help,
                      helpkw,
                      quiescence,
+                     trace,
+                     version,
+                     license,
                      io< kw::input, tag::input >,
                      io< kw::output, tag::output > > {};
 

--- a/src/Control/MeshConv/CmdLine/Parser.cpp
+++ b/src/Control/MeshConv/CmdLine/Parser.cpp
@@ -11,19 +11,13 @@
 */
 // *****************************************************************************
 
-#include <map>
-#include <ostream>
-#include <string>
-#include <type_traits>
-
 #include "NoWarning/pegtl.hpp"
-
 #include "NoWarning/charm.hpp"
+
 #include "QuinoaConfig.hpp"
 #include "Exception.hpp"
 #include "Print.hpp"
 #include "Keywords.hpp"
-#include "HelpFactory.hpp"
 #include "MeshConv/Types.hpp"
 #include "MeshConv/CmdLine/Parser.hpp"
 #include "MeshConv/CmdLine/Grammar.hpp"
@@ -92,9 +86,23 @@ CmdLineParser::CmdLineParser( int argc,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::meshconv_executable(), helpkw );
 
+  // Print out version information if it was requested
+  const auto version = cmdline.get< tag::version >();
+  if (version)
+    print.version< tk::QUIET >( tk::meshconv_executable(),
+                                tk::quinoa_version(),
+                                tk::git_commit(),
+                                tk::copyright() );
+
+  // Print out license information if it was requested
+  const auto license = cmdline.get< tag::license >();
+  if (license)
+    print.license< tk::QUIET >( tk::meshconv_executable(), tk::license() );
+
   // Immediately exit if any help was output or was called without any argument
-  // with zero exit code
-  if (argc == 1 || helpcmd || !helpkw.keyword.empty()) CkExit();
+  // or version or license info was requested with zero exit code
+  if (argc == 1 || helpcmd || !helpkw.keyword.empty() || version || license)
+    CkExit();
 
   // Make sure mandatory arguments are set
   auto ialias = kw::input().alias();

--- a/src/Control/RNGTest/CmdLine/CmdLine.hpp
+++ b/src/Control/RNGTest/CmdLine/CmdLine.hpp
@@ -37,6 +37,8 @@ class CmdLine : public tk::Control<
                   tag::helpctr,    bool,
                   tag::quiescence, bool,
                   tag::trace,      bool,
+                  tag::version,    bool,
+                  tag::license,    bool,
                   tag::cmdinfo,    tk::ctr::HelpFactory,
                   tag::ctrinfo,    tk::ctr::HelpFactory,
                   tag::helpkw,     tk::ctr::HelpKw,
@@ -52,6 +54,8 @@ class CmdLine : public tk::Control<
                                      , kw::helpkw
                                      , kw::quiescence
                                      , kw::trace
+                                     , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set all defaults.
@@ -89,6 +93,8 @@ class CmdLine : public tk::Control<
       set< tag::verbose >( false ); // Use quiet output by default
       set< tag::chare >( false ); // No chare state output by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords + add map passed in
       brigand::for_each< keywords::set >( tk::ctr::Info( get<tag::cmdinfo>()) );
       get< tag::ctrinfo >() = std::move( ctrinfo );
@@ -106,6 +112,8 @@ class CmdLine : public tk::Control<
                    tag::helpctr,    bool,
                    tag::quiescence, bool,
                    tag::trace,      bool,
+                   tag::version,    bool,
+                   tag::license,    bool,
                    tag::cmdinfo,    tk::ctr::HelpFactory,
                    tag::ctrinfo,    tk::ctr::HelpFactory,
                    tag::helpkw,     tk::ctr::HelpKw,

--- a/src/Control/RNGTest/CmdLine/Grammar.hpp
+++ b/src/Control/RNGTest/CmdLine/Grammar.hpp
@@ -74,6 +74,16 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::trace,
                                       tag::trace > {};
 
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! Match all command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -83,7 +93,9 @@ namespace cmd {
                      helpctr,
                      helpkw,
                      quiescence,
-                     trace > {};
+                     trace,
+                     version,
+                     license > {};
 
   //! \brief Grammar entry point: parse keywords until end of string
   struct read_string :

--- a/src/Control/RNGTest/CmdLine/Parser.cpp
+++ b/src/Control/RNGTest/CmdLine/Parser.cpp
@@ -11,19 +11,13 @@
 */
 // *****************************************************************************
 
-#include <map>
-#include <ostream>
-#include <string>
-#include <type_traits>
-
 #include "NoWarning/pegtl.hpp"
-
 #include "NoWarning/charm.hpp"
+
 #include "QuinoaConfig.hpp"
 #include "Exception.hpp"
 #include "Print.hpp"
 #include "Keywords.hpp"
-#include "HelpFactory.hpp"
 #include "RNGTest/Types.hpp"
 #include "RNGTest/CmdLine/Parser.hpp"
 #include "RNGTest/CmdLine/Grammar.hpp"
@@ -107,9 +101,26 @@ CmdLineParser::CmdLineParser( int argc,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::rngtest_executable(), helpkw );
 
+  // Print out version information if it was requested
+  const auto version = cmdline.get< tag::version >();
+  if (version)
+    print.version< tk::QUIET >( tk::rngtest_executable(),
+                                tk::quinoa_version(),
+                                tk::git_commit(),
+                                tk::copyright() );
+
+  // Print out license information if it was requested
+  const auto license = cmdline.get< tag::license >();
+  if (license)
+    print.license< tk::QUIET >( tk::rngtest_executable(), tk::license() );
+
   // Immediately exit if any help was output or was called without any argument
-  // with zero exit code
-  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty()) CkExit();
+  // or version or license info was requested with zero exit code
+  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty() || version ||
+      license)
+  {
+    CkExit();
+  }
 
   // Make sure mandatory arguments are set
   auto alias = kw::control().alias();

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -20,6 +20,7 @@ struct high {};
 struct io {};
 struct quiescence {};
 struct trace {};
+struct version {};
 struct input {};
 struct output {};
 struct diag {};

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -21,6 +21,7 @@ struct io {};
 struct quiescence {};
 struct trace {};
 struct version {};
+struct license {};
 struct input {};
 struct output {};
 struct diag {};

--- a/src/Control/UnitTest/CmdLine/CmdLine.hpp
+++ b/src/Control/UnitTest/CmdLine/CmdLine.hpp
@@ -39,6 +39,8 @@ class CmdLine : public tk::Control<
                   tag::help,        bool,
                   tag::quiescence,  bool,
                   tag::trace,       bool,
+                  tag::version,     bool,
+                  tag::license,     bool,
                   tag::cmdinfo,     tk::ctr::HelpFactory,
                   tag::ctrinfo,     tk::ctr::HelpFactory,
                   tag::helpkw,      tk::ctr::HelpKw,
@@ -54,6 +56,8 @@ class CmdLine : public tk::Control<
                                      , kw::group
                                      , kw::quiescence
                                      , kw::trace
+                                     , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set defaults.
@@ -66,6 +70,8 @@ class CmdLine : public tk::Control<
       set< tag::verbose >( false ); // Use quiet output by default
       set< tag::chare >( false ); // No chare state output by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
     }
@@ -80,6 +86,8 @@ class CmdLine : public tk::Control<
                    tag::help,       bool,
                    tag::quiescence, bool,
                    tag::trace,      bool,
+                   tag::version,    bool,
+                   tag::license,    bool,
                    tag::cmdinfo,    tk::ctr::HelpFactory,
                    tag::ctrinfo,    tk::ctr::HelpFactory,
                    tag::helpkw,     tk::ctr::HelpKw,

--- a/src/Control/UnitTest/CmdLine/Grammar.hpp
+++ b/src/Control/UnitTest/CmdLine/Grammar.hpp
@@ -70,10 +70,20 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::trace,
                                       tag::trace > {};
 
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! \brief Match all command line keywords
   struct keywords :
          pegtl::sor< verbose, charestate, help, helpkw, group,
-                     trace, quiescence > {};
+                     quiescence, trace, version, license > {};
 
   //! \brief Grammar entry point: parse keywords until end of string
   struct read_string :

--- a/src/Control/UnitTest/CmdLine/Parser.cpp
+++ b/src/Control/UnitTest/CmdLine/Parser.cpp
@@ -11,14 +11,9 @@
 */
 // *****************************************************************************
 
-#include <map>
-#include <ostream>
-#include <type_traits>
-
 #include "NoWarning/pegtl.hpp"
 
 #include "Print.hpp"
-#include "HelpFactory.hpp"
 #include "UnitTest/Types.hpp"
 #include "UnitTest/CmdLine/Parser.hpp"
 #include "UnitTest/CmdLine/Grammar.hpp"
@@ -89,9 +84,23 @@ CmdLineParser::CmdLineParser( int argc,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::unittest_executable(), helpkw );
 
+  // Print out version information if it was requested
+  const auto version = cmdline.get< tag::version >();
+  if (version)
+    print.version< tk::QUIET >( tk::unittest_executable(),
+                                tk::quinoa_version(),
+                                tk::git_commit(),
+                                tk::copyright() );
+
+  // Print out license information if it was requested
+  const auto license = cmdline.get< tag::license >();
+  if (license)
+    print.license< tk::QUIET >( tk::unittest_executable(), tk::license() );
+
   // Will exit in main chare constructor if any help was output
   if (cmdline.get< tag::help >() ||           // help on all cmdline args
-      !cmdline.get< tag::helpkw >().keyword.empty()) // help on a keyword
+      !cmdline.get< tag::helpkw >().keyword.empty() || // help on a keyword
+      version || license)                     // version or license output
     helped = true;
   else
     helped = false;

--- a/src/Control/Walker/CmdLine/CmdLine.hpp
+++ b/src/Control/Walker/CmdLine/CmdLine.hpp
@@ -36,6 +36,8 @@ class CmdLine : public tk::Control<
                   tag::helpctr,        bool,
                   tag::quiescence,     bool,
                   tag::trace,          bool,
+                  tag::version,        bool,
+                  tag::license,        bool,
                   tag::cmdinfo,        tk::ctr::HelpFactory,
                   tag::ctrinfo,        tk::ctr::HelpFactory,
                   tag::helpkw,         tk::ctr::HelpKw,
@@ -52,8 +54,10 @@ class CmdLine : public tk::Control<
                                      , kw::control
                                      , kw::pdf
                                      , kw::stat
-                                     , kw::trace
                                      , kw::quiescence
+                                     , kw::trace
+                                     , kw::version
+                                     , kw::license
                                      >;
 
     //! \brief Constructor: set all defaults.
@@ -95,6 +99,8 @@ class CmdLine : public tk::Control<
       set< tag::verbose >( false ); // Quiet output by default
       set< tag::chare >( false ); // No chare state output by default
       set< tag::trace >( true ); // Output call and stack trace by default
+      set< tag::version >( false ); // Do not display version info by default
+      set< tag::license >( false ); // Do not display license info by default
       // Initialize help: fill from own keywords + add map passed in
       brigand::for_each< keywords::set >( tk::ctr::Info(get<tag::cmdinfo>()) );
       get< tag::ctrinfo >() = std::move( ctrinfo );
@@ -110,6 +116,8 @@ class CmdLine : public tk::Control<
                    tag::helpctr,        bool,
                    tag::quiescence,     bool,
                    tag::trace,          bool,
+                   tag::version,        bool,
+                   tag::license,        bool,
                    tag::cmdinfo,        tk::ctr::HelpFactory,
                    tag::ctrinfo,        tk::ctr::HelpFactory,
                    tag::helpkw,         tk::ctr::HelpKw,

--- a/src/Control/Walker/CmdLine/Grammar.hpp
+++ b/src/Control/Walker/CmdLine/Grammar.hpp
@@ -80,6 +80,16 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::trace,
                                       tag::trace > {};
 
+  //! Match switch on version output
+  struct version :
+         tk::grm::process_cmd_switch< use, kw::version,
+                                      tag::version > {};
+
+  //! Match switch on license output
+  struct license :
+         tk::grm::process_cmd_switch< use, kw::license,
+                                      tag::license > {};
+
   //! command line keywords
   struct keywords :
          pegtl::sor< verbose,
@@ -90,6 +100,8 @@ namespace cmd {
                      virtualization,
                      quiescence,
                      trace,
+                     version,
+                     license,
                      io< kw::control, tag::control >,
                      io< kw::pdf, tag::pdf >,
                      io< kw::stat, tag::stat > > {};

--- a/src/Control/Walker/CmdLine/Parser.cpp
+++ b/src/Control/Walker/CmdLine/Parser.cpp
@@ -10,18 +10,12 @@
 */
 // *****************************************************************************
 
-#include <map>
-#include <ostream>
-#include <string>
-#include <type_traits>
-
 #include "NoWarning/pegtl.hpp"
 #include "NoWarning/charm.hpp"
 
 #include "Print.hpp"
 #include "QuinoaConfig.hpp"
 #include "Exception.hpp"
-#include "HelpFactory.hpp"
 #include "Keywords.hpp"
 #include "Walker/Types.hpp"
 #include "Walker/CmdLine/Parser.hpp"
@@ -105,9 +99,26 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   if (!helpkw.keyword.empty())
     print.helpkw< tk::QUIET >( tk::walker_executable(), helpkw );
 
+  // Print out version information if it was requested
+  const auto version = cmdline.get< tag::version >();
+  if (version)
+    print.version< tk::QUIET >( tk::walker_executable(),
+                                tk::quinoa_version(),
+                                tk::git_commit(),
+                                tk::copyright() );
+
+  // Print out license information if it was requested
+  const auto license = cmdline.get< tag::license >();
+  if (license)
+    print.license< tk::QUIET >( tk::walker_executable(), tk::license() );
+
   // Immediately exit if any help was output or was called without any argument
-  // with zero exit code
-  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty()) CkExit();
+  // or version or license info was requested with zero exit code
+  if (argc == 1 || helpcmd || helpctr || !helpkw.keyword.empty() || version ||
+      license)
+  {
+    CkExit();
+  }
 
   // Make sure mandatory arguments are set
   auto alias = kw::control().alias();

--- a/src/Main/QuinoaConfig.cpp.in
+++ b/src/Main/QuinoaConfig.cpp.in
@@ -27,6 +27,7 @@ namespace tk {
 #define FILECONV_EXECUTABLE          "@FILECONV_EXECUTABLE@"
 
 #define QUINOA_VERSION               "@MAJOR_VER@.@MINOR_VER@ (C@LACC@)"
+#define COPYRIGHT                    "@COPYRIGHT@"
 #define GIT_COMMIT                   "@GIT_SHA1@"
 #define MPI_COMPILER                 "@MPI_COMPILER@"
 #define COMPILER                     "@COMPILER@"
@@ -46,6 +47,7 @@ std::string fileconv_executable() { return FILECONV_EXECUTABLE; }
 
 std::string quinoa_version() { return QUINOA_VERSION; }
 std::string git_commit() { return GIT_COMMIT; }
+std::string copyright() { return COPYRIGHT; }
 std::string mpi_compiler() { return MPI_COMPILER; }
 std::string compiler() { return COMPILER; }
 std::string build_hostname() { return BUILD_HOSTNAME; }

--- a/src/Main/QuinoaConfig.cpp.in
+++ b/src/Main/QuinoaConfig.cpp.in
@@ -28,6 +28,7 @@ namespace tk {
 
 #define QUINOA_VERSION               "@MAJOR_VER@.@MINOR_VER@ (C@LACC@)"
 #define COPYRIGHT                    "@COPYRIGHT@"
+#define LICENSE                      "@LICENSE@"
 #define GIT_COMMIT                   "@GIT_SHA1@"
 #define MPI_COMPILER                 "@MPI_COMPILER@"
 #define COMPILER                     "@COMPILER@"
@@ -48,6 +49,7 @@ std::string fileconv_executable() { return FILECONV_EXECUTABLE; }
 std::string quinoa_version() { return QUINOA_VERSION; }
 std::string git_commit() { return GIT_COMMIT; }
 std::string copyright() { return COPYRIGHT; }
+std::string license() { return LICENSE; }
 std::string mpi_compiler() { return MPI_COMPILER; }
 std::string compiler() { return COMPILER; }
 std::string build_hostname() { return BUILD_HOSTNAME; }

--- a/src/Main/QuinoaConfig.hpp.in
+++ b/src/Main/QuinoaConfig.hpp.in
@@ -63,6 +63,7 @@ std::string fileconv_executable();
 std::string quinoa_version();
 std::string git_commit();
 std::string copyright();
+std::string license();
 std::string mpi_compiler();
 std::string compiler();
 std::string build_hostname();

--- a/src/Main/QuinoaConfig.hpp.in
+++ b/src/Main/QuinoaConfig.hpp.in
@@ -62,6 +62,7 @@ std::string fileconv_executable();
 
 std::string quinoa_version();
 std::string git_commit();
+std::string copyright();
 std::string mpi_compiler();
 std::string compiler();
 std::string build_hostname();


### PR DESCRIPTION
This set of commits adds command line options, `--version` and `--license`, with aliases `-V` and `-L`, respectively, to display information on version and license. The info is read out of [LICENSE](https://github.com/quinoacomputing/quinoa/blob/develop/LICENSE) and processed into QuinoaConfig.[ch]pp, generated during configuring the build with cmake.

This takes care of #6 and #79.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/322)
<!-- Reviewable:end -->
