### PR TITLE
Replace splitting algorithm in splitLines()

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(Base
             Writer.cpp
             Table.cpp
             Vector.cpp
+            StrConvUtil.cpp
             ChareStateCollector.cpp
 )
 

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -33,6 +33,7 @@
 #include "Exception.hpp"
 #include "Has.hpp"
 #include "ChareState.hpp"
+#include "StrConvUtil.hpp"
 
 namespace tk {
 
@@ -799,47 +800,6 @@ class Print {
     std::stringstream m_null;   //!< Default verbose stream
     std::ostream& m_stream;     //!< Verbose stream
     std::ostream& m_qstream;    //!< Quiet stream
-
-  private:
-    //! \brief Clean up whitespaces and format a long string into multiple lines
-    //! \param[in] str String to format
-    //! \param[in] name String to insert before string to output
-    //! \param[in] indent String to use as identation
-    //! \param[in] width Width in characters to insert newlines for output
-    //! \see http://stackoverflow.com/a/6892562
-    //! \see http://stackoverflow.com/a/8362145
-    // TODO A line longer than 'width' will cause a hang!
-    std::string splitLines( std::string str,
-                            std::string indent,
-                            const std::string& name = "",
-                            std::size_t width = 80 ) const {
-      // remove form feeds, line feeds, carriage returns, horizontal tabs,
-      // vertical tabs, see http://en.cppreference.com/w/cpp/string/byte/isspace
-      str.erase(
-        std::remove_if( str.begin(), str.end(),
-                        []( char x ){ return std::isspace( x ) && x != ' '; } ),
-        str.end() );
-      // remove duplicate spaces
-      str.erase(
-        std::unique( str.begin(), str.end(),
-                     []( char a, char b ){ return a == b && a == ' '; } ),
-        str.end() );
-      // format str to 'width'-character-long lines with indent
-      str.insert( 0, indent + name );
-      std::size_t currIndex = width - 1;
-      while ( currIndex < str.length() ) {
-        const std::string whitespace = " ";
-        currIndex = str.find_last_of( whitespace, currIndex + 1 );
-        if ( currIndex == std::string::npos ) break;
-        currIndex = str.find_last_not_of( whitespace, currIndex );
-        if ( currIndex == std::string::npos ) break;
-        auto sizeToElim =
-          str.find_first_not_of( whitespace, currIndex + 1 ) - currIndex - 1;
-        str.replace( currIndex + 1, sizeToElim , "\n" + indent );
-        currIndex += width + indent.length() + 1;
-      }
-      return str;
-    }
 };
 
 } // tk::

--- a/src/Base/StrConvUtil.cpp
+++ b/src/Base/StrConvUtil.cpp
@@ -1,0 +1,66 @@
+// *****************************************************************************
+/*!
+  \file      src/Base/StrConvUtil.cpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     String conversion utilities
+  \details   Various string conversion utilities.
+*/
+// *****************************************************************************
+
+#include <string>
+#include <sstream>
+#include <algorithm>
+
+#include "StrConvUtil.hpp"
+
+std::string
+tk::splitLines( std::string str,
+                std::string indent,
+                const std::string& name,
+                std::size_t width )
+// *****************************************************************************
+//  Clean up whitespaces and format a long string into multiple lines
+//! \param[in] str String to format
+//! \param[in] name String to insert before string to output
+//! \param[in] indent String to use as identation
+//! \param[in] width Width in characters to insert newlines for output
+//! \see http://stackoverflow.com/a/6892562
+//! \see http://stackoverflow.com/a/8362145
+//! \see https://stackoverflow.com/a/6894764
+// *****************************************************************************
+{
+  // remove form feeds, line feeds, carriage returns, horizontal tabs,
+  // vertical tabs, see http://en.cppreference.com/w/cpp/string/byte/isspace
+  str.erase(
+    std::remove_if( str.begin(), str.end(),
+                    []( char x ){ return std::isspace( x ) && x != ' '; } ),
+    str.end() );
+
+  // remove duplicate spaces
+  str.erase(
+    std::unique( str.begin(), str.end(),
+                 []( char a, char b ){ return a == b && a == ' '; } ),
+    str.end() );
+
+  // format str to 'width'-character-long lines with indent
+  std::istringstream in(str);
+  std::ostringstream os;
+
+  os << indent << name;
+  auto current = indent.size();
+  std::string word;
+
+  while (in >> word) {
+    if (current + word.size() > width) {
+      os << '\n' << indent;
+      current = indent.size();
+    }
+    os << word << ' ';
+    current += word.size() + 1;
+  }
+
+  return os.str();
+}

--- a/src/Base/StrConvUtil.hpp
+++ b/src/Base/StrConvUtil.hpp
@@ -13,6 +13,7 @@
 #define StrConvUtil_h
 
 #include <sstream>
+#include <string>
 
 namespace tk {
 
@@ -66,6 +67,13 @@ std::basic_string< Ch, Tr >
 operator<< ( std::basic_string< Ch, Tr >&& lhs, const T& e ) {
   return lhs << e;
 }
+
+//!  Clean up whitespaces and format a long string into multiple lines
+std::string
+splitLines( std::string str,
+            std::string indent,
+            const std::string& name = "",
+            std::size_t width = 80 );
 
 } // tk::
 


### PR DESCRIPTION
This is simpler and does not hang if a word is longer than `width`. Takes care of #9. Also moved this out of Print to a free function in `StrConvUtil.[hc]pp`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/327)
<!-- Reviewable:end -->
