### PR TITLE
Tweaks to LB/migration

### DIFF
--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -3488,7 +3488,8 @@ struct nonblocking_info {
   { return "Select non-blocking migration"; }
   static std::string longDescription() { return
     R"(This keyword is used to select non-blocking, instead of the default
-       blocking, migration.)";
+       blocking, migration. WARNING: This feature is experimental, not well
+       tested, and may not always work as expected.)";
   }
   using alias = Alias< n >;
 };

--- a/tests/regression/inciter/transport/CylAdvect/CMakeLists.txt
+++ b/tests/regression/inciter/transport/CylAdvect/CMakeLists.txt
@@ -51,7 +51,7 @@ add_regression_test(cyl_advect_dgp1_lbfreq5_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v
-                         -l 5 -n +balancer RandCentLB +LBDebug 1
+                         -l 5 +balancer RandCentLB +LBDebug 1
                     BIN_BASELINE cyl_advect_dgp1_pe4_u0.0.std.exo.0
                                  cyl_advect_dgp1_pe4_u0.0.std.exo.1
                                  cyl_advect_dgp1_pe4_u0.0.std.exo.2

--- a/tests/regression/inciter/transport/GaussHump/CMakeLists.txt
+++ b/tests/regression/inciter/transport/GaussHump/CMakeLists.txt
@@ -189,8 +189,7 @@ add_regression_test(gauss_hump_pdg_u0.8 ${INCITER_EXECUTABLE}
                     BIN_DIFF_PROG_CONF exodiff.cfg
                     TEXT_BASELINE diag_pdg.std
                     TEXT_RESULT diag
-                    TEXT_DIFF_PROG_CONF gauss_hump_diag.ndiff.cfg
-                    LABELS migration)
+                    TEXT_DIFF_PROG_CONF gauss_hump_diag.ndiff.cfg)
 
 
 # Parallel + virtualization + migration


### PR DESCRIPTION
This is based on recent discussion with the Charm++ developers.

Changes (all minor):

- Add keyword doc to command line argument `-n` to signal that non-blocking migration is experimental.
- Turn our single non-blocking migration test into a blocking-migration test so it does not randomly deadlock CI until we fix non-blocking migration.
- Remove a test label _migration_ from a test that does not exercise migration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/333)
<!-- Reviewable:end -->
