### PR TITLE
Enable quiescence detection for migration tests

### DIFF
--- a/cmake/add_regression_test.cmake
+++ b/cmake/add_regression_test.cmake
@@ -263,11 +263,8 @@ function(ADD_REGRESSION_TEST test_name executable)
   # Construct and echo configuration for test being added
   set(msg "Add regression test ${test_name} for ${executable}")
 
-  # Run all non-migrating regression tests with quiescence detection
-  list(FIND TEST_LABELS migration i)
-  if (${i} EQUAL -1)
-    list(APPEND ARG_ARGS "-q")
-  endif()
+  # Run all regression tests with quiescence detection
+  list(APPEND ARG_ARGS "-q")
 
   if (ARG_ARGS)
     string(REPLACE ";" " " ARGUMENTS "${ARG_ARGS}")

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -3488,7 +3488,8 @@ struct nonblocking_info {
   { return "Select non-blocking migration"; }
   static std::string longDescription() { return
     R"(This keyword is used to select non-blocking, instead of the default
-       blocking, migration.)";
+       blocking, migration. WARNING: This feature is experimental, not well
+       tested, and may not always work as expected.)";
   }
   using alias = Alias< n >;
 };

--- a/tests/regression/inciter/compflow/Euler/SedovBlastwave/CMakeLists.txt
+++ b/tests/regression/inciter/compflow/Euler/SedovBlastwave/CMakeLists.txt
@@ -71,7 +71,7 @@ add_regression_test(compflow_euler_sedovblastwave_pdg_u0.9_migr ${INCITER_EXECUT
                     NUMPES 4
                     INPUTFILES sedov_blastwave_pdg.q unitsquare_01_3.6k.exo
                     ARGS -c sedov_blastwave_pdg.q -i unitsquare_01_3.6k.exo -v -u 0.9
-                         +balancer RandCentLB +LBDebug 1
+                         +balancer RandCentLB +LBDebug 1 +LBPeriod 0.001
                     BIN_BASELINE sedov_blastwave_pdg_pe4_u0.9.std.exo.0
                                  sedov_blastwave_pdg_pe4_u0.9.std.exo.1
                                  sedov_blastwave_pdg_pe4_u0.9.std.exo.2

--- a/tests/regression/inciter/compflow/Euler/VorticalFlow/CMakeLists.txt
+++ b/tests/regression/inciter/compflow/Euler/VorticalFlow/CMakeLists.txt
@@ -175,7 +175,7 @@ add_regression_test(compflow_euler_vorticalflow_diagcg_u0.9_migr
                     NUMPES 4
                     INPUTFILES vortical_flow_diagcg.q unitcube_1k.exo
                     ARGS -c vortical_flow_diagcg.q -i unitcube_1k.exo -v -u 0.9
-                         +balancer RandCentLB +LBDebug 1 +cs
+                         +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE vortical_flow_diagcg_pe4_u0.9.std.exo.0
                                  vortical_flow_diagcg_pe4_u0.9.std.exo.1
                                  vortical_flow_diagcg_pe4_u0.9.std.exo.2

--- a/tests/regression/inciter/mesh_refinement/dtref/CMakeLists.txt
+++ b/tests/regression/inciter/mesh_refinement/dtref/CMakeLists.txt
@@ -133,7 +133,7 @@ add_regression_test(amr_dtref_u_compflow_nleg_diagcg_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES nleg_diagcg_amr.q unitcube_1k.exo
                     ARGS -c nleg_diagcg_amr.q -i unitcube_1k.exo -v
-                         +balancer RandCentLB +LBDebug 1 +cs
+                         +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE nleg_diagcg_pe4_u.std.e-s.0.4.0
                                  nleg_diagcg_pe4_u.std.e-s.0.4.1
                                  nleg_diagcg_pe4_u.std.e-s.0.4.2
@@ -205,7 +205,7 @@ add_regression_test(amr_dtref_u_compflow_nleg_reord_diagcg ${INCITER_EXECUTABLE}
                      NUMPES 4
                      INPUTFILES nleg_reord_diagcg_amr.q unitcube_1k.exo
                      ARGS -c nleg_reord_diagcg_amr.q -i unitcube_1k.exo -v
-                          +balancer RandCentLB +LBDebug 1 +cs
+                          +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                      BIN_BASELINE nleg_diagcg_pe4_u.std.e-s.0.4.0
                                   nleg_diagcg_pe4_u.std.e-s.0.4.1
                                   nleg_diagcg_pe4_u.std.e-s.0.4.2
@@ -311,7 +311,7 @@ add_regression_test(amr_dtref_u_trans_gauss_hump_dg_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES gauss_hump.q unitcube_01_112_ss3.exo
                     ARGS -c gauss_hump.q -i unitcube_01_112_ss3.exo -v
-                         +balancer RandCentLB +LBDebug 1 +cs
+                         +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.0
                                  gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.1
                                  gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.2
@@ -348,7 +348,7 @@ add_regression_test(amr_dtref_u_trans_reord_gauss_hump_dg_migr
                     NUMPES 4
                     INPUTFILES gauss_hump_reord.q unitcube_01_112_ss3.exo
                     ARGS -c gauss_hump_reord.q -i unitcube_01_112_ss3.exo -v
-                         +balancer RandCentLB +LBDebug 1 +cs
+                         +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.0
                                  gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.1
                                  gauss_hump_u_trans_pe4_u0.0.std.e-s.0.4.2
@@ -474,7 +474,7 @@ add_regression_test(amr_dtref_u_trans_diagcg_u0.8_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES slot_cyl_amr_diagcg.q unitsquare_01_955.exo
                     ARGS -c slot_cyl_amr_diagcg.q -i unitsquare_01_955.exo -v
-                         -u 0.8 +balancer RandCentLB +LBDebug 1 +cs
+                         -u 0.8 +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE slot_cyl_diagcg_pe4_u_u0.8.std.e-s.0.19.0
                                  slot_cyl_diagcg_pe4_u_u0.8.std.e-s.0.19.1
                                  slot_cyl_diagcg_pe4_u_u0.8.std.e-s.0.19.2
@@ -682,7 +682,7 @@ add_regression_test(amr_dtref_u_trans_gauss_hump_dg_u0.8_migr
                     NUMPES 4
                     INPUTFILES gauss_hump.q unitcube_01_112_ss3.exo
                     ARGS -c gauss_hump.q -i unitcube_01_112_ss3.exo -v -u 0.8
-                         +balancer RandCentLB +LBDebug 1 +cs
+                         +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE gauss_hump_u_trans_pe4_u0.8.std.e-s.0.18.0
                                  gauss_hump_u_trans_pe4_u0.8.std.e-s.0.18.1
                                  gauss_hump_u_trans_pe4_u0.8.std.e-s.0.18.2

--- a/tests/regression/inciter/transport/CylAdvect/CMakeLists.txt
+++ b/tests/regression/inciter/transport/CylAdvect/CMakeLists.txt
@@ -51,7 +51,7 @@ add_regression_test(cyl_advect_dgp1_lbfreq5_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v
-                         -l 5 +balancer RandCentLB +LBDebug 1
+                         -l 5 +balancer RandCentLB +LBDebug 1 +LBPeriod 0.001
                     BIN_BASELINE cyl_advect_dgp1_pe4_u0.0.std.exo.0
                                  cyl_advect_dgp1_pe4_u0.0.std.exo.1
                                  cyl_advect_dgp1_pe4_u0.0.std.exo.2
@@ -165,7 +165,7 @@ add_regression_test(cyl_advect_dgp1_u0.90_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v -u 0.90
-                         +balancer RandCentLB +LBDebug 1
+                         +balancer RandCentLB +LBDebug 1 +LBPeriod 0.001
                     BIN_BASELINE cyl_advect_dgp1_pe4_u0.90.std.exo.0
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.1
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.2
@@ -257,7 +257,7 @@ add_regression_test(cyl_advect_dgp1_u0.90_lbfreq5_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES cyl_advect_dgp1.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1.q -i unitsquare_01_3.6k.exo -v -u 0.90
-                         +balancer RandCentLB +LBDebug 1 -l 5
+                         +balancer RandCentLB +LBDebug 1 -l 5 +LBPeriod 0.001
                     BIN_BASELINE cyl_advect_dgp1_pe4_u0.90.std.exo.0
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.1
                                  cyl_advect_dgp1_pe4_u0.90.std.exo.2
@@ -349,7 +349,7 @@ add_regression_test(cyl_advect_dgp1_weno_u0.90_lbfreq5_migr ${INCITER_EXECUTABLE
                     NUMPES 4
                     INPUTFILES cyl_advect_dgp1_weno.q unitsquare_01_3.6k.exo
                     ARGS -c cyl_advect_dgp1_weno.q -i unitsquare_01_3.6k.exo -v -u 0.90
-                         +balancer RandCentLB +LBDebug 1 -l 5
+                         +balancer RandCentLB +LBDebug 1 -l 5 +LBPeriod 0.001
                     BIN_BASELINE cyl_advect_dgp1_weno_pe4_u0.90.std.exo.0
                                  cyl_advect_dgp1_weno_pe4_u0.90.std.exo.1
                                  cyl_advect_dgp1_weno_pe4_u0.90.std.exo.2

--- a/tests/regression/inciter/transport/GaussHump/CMakeLists.txt
+++ b/tests/regression/inciter/transport/GaussHump/CMakeLists.txt
@@ -198,7 +198,7 @@ add_regression_test(gauss_hump_dg_u0.9_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES gauss_hump.q unitsquare_01_3.6k.exo
                     ARGS -c gauss_hump.q -i unitsquare_01_3.6k.exo -v -u 0.9
-                         +balancer RandCentLB +LBDebug 1
+                         +balancer RandCentLB +LBDebug 1 +LBPeriod 0.001
                     BIN_BASELINE gauss_hump_pe4_u0.9.std.exo.0
                                  gauss_hump_pe4_u0.9.std.exo.1
                                  gauss_hump_pe4_u0.9.std.exo.2
@@ -290,7 +290,7 @@ add_regression_test(gauss_hump_pdg_u0.8_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES gauss_hump_pdg.q unitsquare_01_3.6k.exo
                     ARGS -c gauss_hump_pdg.q -i unitsquare_01_3.6k.exo -v -u 0.8
-                         +balancer GreedyRefineLB +LBDebug 1
+                         +balancer GreedyRefineLB +LBDebug 1 +LBPeriod 0.001
                     BIN_BASELINE gauss_hump_pdg_pe4_u0.8.std.exo.0
                                  gauss_hump_pdg_pe4_u0.8.std.exo.1
                                  gauss_hump_pdg_pe4_u0.8.std.exo.2

--- a/tests/regression/inciter/transport/SlotCyl/asynclogic/CMakeLists.txt
+++ b/tests/regression/inciter/transport/SlotCyl/asynclogic/CMakeLists.txt
@@ -19,7 +19,7 @@
 #   migr: 1: enable migration using RandCentLB, 0: no migration
 function(add_async_test scheme virt npes ppn migr)
   if (migr)
-    set(migr_cmd "+balancer RandCentLB +LBDebug 1 +cs")
+    set(migr_cmd "+balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001")
     set(migr_append_name "_migr")
     set(migr_label "migration")
   endif()

--- a/tests/regression/inciter/transport/SlotCyl/cfl/CMakeLists.txt
+++ b/tests/regression/inciter/transport/SlotCyl/cfl/CMakeLists.txt
@@ -94,7 +94,7 @@ add_regression_test(cfl_u0.9_migr ${INCITER_EXECUTABLE}
                     NUMPES 4
                     INPUTFILES slot_cyl_cfl_diagcg.q unitsquare_01_3.6k.exo
                     ARGS -c slot_cyl_cfl_diagcg.q -i unitsquare_01_3.6k.exo
-                         -v -u 0.9 +balancer RandCentLB +LBDebug 1 +cs
+                         -v -u 0.9 +balancer RandCentLB +LBDebug 1 +cs +LBPeriod 0.001
                     BIN_BASELINE slot_cyl_cfl_diagcg_pe4_u0.9.std.exo.0
                                  slot_cyl_cfl_diagcg_pe4_u0.9.std.exo.1
                                  slot_cyl_cfl_diagcg_pe4_u0.9.std.exo.2


### PR DESCRIPTION
This is possible if `+LBPeriod` is small. Tested it locally in infinite loop -- appears to work fine, so attempting to enable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/334)
<!-- Reviewable:end -->
