### PR TITLE
Indexing vector of DG solution DOFs

### DIFF
--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -163,28 +163,28 @@ class MultiMat {
         tk::real rhob(0.0);
         for (std::size_t k=0; k<nmat; ++k)
         {
-          rhob += unk(e, densityIdx(nmat, k)*rdof, m_offset);
+          rhob += unk(e, densityDofIdx(nmat, k, rdof, 0), m_offset);
         }
 
         // cell-average velocity
         std::array< tk::real, 3 >
-          vel{{ unk(e, momentumIdx(nmat, 0)*rdof, m_offset)/rhob,
-                unk(e, momentumIdx(nmat, 1)*rdof, m_offset)/rhob,
-                unk(e, momentumIdx(nmat, 2)*rdof, m_offset)/rhob }};
+          vel{{ unk(e, momentumDofIdx(nmat, 0, rdof, 0), m_offset)/rhob,
+                unk(e, momentumDofIdx(nmat, 1, rdof, 0), m_offset)/rhob,
+                unk(e, momentumDofIdx(nmat, 2, rdof, 0), m_offset)/rhob }};
 
         for (std::size_t idir=0; idir<3; ++idir)
         {
-          prim(e, velocityIdx(nmat, idir)*rdof, m_offset) = vel[idir];
+          prim(e, velocityDofIdx(nmat, idir, rdof, 0), m_offset) = vel[idir];
         }
 
         // cell-average material pressure
         for (std::size_t k=0; k<nmat; ++k)
         {
-          tk::real rhomat = unk(e, densityIdx(nmat, k)*rdof, m_offset)
-            / unk(e, volfracIdx(nmat, k)*rdof, m_offset);
-          tk::real rhoemat = unk(e, energyIdx(nmat, k)*rdof, m_offset)
-            / unk(e, volfracIdx(nmat, k)*rdof, m_offset);
-          prim(e, pressureIdx(nmat, k)*rdof, m_offset) =
+          tk::real rhomat = unk(e, densityDofIdx(nmat, k, rdof, 0), m_offset)
+            / unk(e, volfracDofIdx(nmat, k, rdof, 0), m_offset);
+          tk::real rhoemat = unk(e, energyDofIdx(nmat, k, rdof, 0), m_offset)
+            / unk(e, volfracDofIdx(nmat, k, rdof, 0), m_offset);
+          prim(e, pressureDofIdx(nmat, k, rdof, 0), m_offset) =
             eos_pressure< tag::multimat >( m_system, rhomat, vel[0], vel[1],
               vel[2], rhoemat, k );
         }
@@ -630,14 +630,14 @@ class MultiMat {
         g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[0];
 
       std::array< std::array< tk::real, 4 >, 3 > v;
-      v[0] = U.extract( momentumIdx(nmat, 0)*rdof, m_offset, N );
-      v[1] = U.extract( momentumIdx(nmat, 1)*rdof, m_offset, N );
-      v[2] = U.extract( momentumIdx(nmat, 2)*rdof, m_offset, N );
+      v[0] = U.extract( momentumDofIdx(nmat, 0, rdof, 0), m_offset, N );
+      v[1] = U.extract( momentumDofIdx(nmat, 1, rdof, 0), m_offset, N );
+      v[2] = U.extract( momentumDofIdx(nmat, 2, rdof, 0), m_offset, N );
 
       std::vector< std::array< tk::real, 4 > > ar;
       ar.resize(nmat);
       for (std::size_t k=0; k<nmat; ++k)
-        ar[k] = U.extract( densityIdx(nmat, k)*rdof, m_offset, N );
+        ar[k] = U.extract( densityDofIdx(nmat, k, rdof, 0), m_offset, N );
 
       std::array< tk::real, 4 > r{{ 0.0, 0.0, 0.0, 0.0 }};
       for (std::size_t i=0; i<r.size(); ++i) {

--- a/src/PDE/MultiMat/MultiMatIndexing.hpp
+++ b/src/PDE/MultiMat/MultiMatIndexing.hpp
@@ -61,6 +61,77 @@ inline std::size_t velocityIdx( std::size_t nmat, std::size_t idir )
 inline std::size_t pressureIdx( std::size_t /*nmat*/, std::size_t kmat )
 { return kmat; }
 
+//! \brief Get the index of the required DOF of material volume fraction from
+//!   the DG solution vector
+//! \param[in] nmat Number of materials
+//! \param[in] kmat Index of required material
+//! \return Index of the required material volume fraction
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t volfracDofIdx( std::size_t nmat, std::size_t kmat,
+  std::size_t ndof, std::size_t idof )
+{ return volfracIdx(nmat, kmat)*ndof+idof; }
+
+//! \brief Get the index of the required DOF of material continuity equation
+//!   from the DG solution vector
+//! \param[in] nmat Number of materials
+//! \param[in] kmat Index of required material
+//! \return Index of the required material continuity equation
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t densityDofIdx( std::size_t nmat, std::size_t kmat,
+  std::size_t ndof, std::size_t idof )
+{ return densityIdx(nmat, kmat)*ndof+idof; }
+
+//! \brief Get the index of the required DOF of momentum equation component from
+//!   the DG solution vector
+//! \param[in] nmat Number of materials
+//! \param[in] idir Required component direction;
+//!   0: X-component,
+//!   1: Y-component,
+//!   2: Z-component.
+//! \return Index of the required momentum equation component
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t momentumDofIdx( std::size_t nmat, std::size_t idir,
+  std::size_t ndof, std::size_t idof )
+{ return momentumIdx(nmat, idir)*ndof+idof; }
+
+//! \brief Get the index of the required DOF of material total energy equation
+//!   from the DG solution vector
+//! \param[in] nmat Number of materials
+//! \param[in] kmat Index of required material
+//! \return Index of the required material total energy equation
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t energyDofIdx( std::size_t nmat, std::size_t kmat,
+  std::size_t ndof, std::size_t idof )
+{ return energyIdx(nmat, kmat)*ndof+idof; }
+
+//! \brief Get the index of the required DOF of velocity component from the DG
+//!   vector of primitives
+//! \param[in] nmat Number of materials
+//! \param[in] idir Required component direction;
+//!   0: X-component,
+//!   1: Y-component,
+//!   2: Z-component.
+//! \return Index of the required velocity component from vector of primitives
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t velocityDofIdx( std::size_t nmat, std::size_t idir,
+  std::size_t ndof, std::size_t idof )
+{ return velocityIdx(nmat, idir)*ndof+idof; }
+
+//! \brief Get the index of the required DOF of material pressure from the DG
+//!   vector of primitives
+//! \param[in] kmat Index of required material
+//! \return Index of the required material pressure from vector of primitives
+//! \details This function is used to get the index of the required DOF in the
+//!   solution vector, which is of type tk::Fields.
+inline std::size_t pressureDofIdx( std::size_t nmat, std::size_t kmat,
+  std::size_t ndof, std::size_t idof )
+{ return pressureIdx(nmat, kmat)*ndof+idof; }
+
 } //inciter::
 
 #endif // MultiMatIndexing_h

--- a/src/PDE/MultiMat/MultiMatIndexing.hpp
+++ b/src/PDE/MultiMat/MultiMatIndexing.hpp
@@ -65,6 +65,8 @@ inline std::size_t pressureIdx( std::size_t /*nmat*/, std::size_t kmat )
 //!   the DG solution vector
 //! \param[in] nmat Number of materials
 //! \param[in] kmat Index of required material
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required material volume fraction
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.
@@ -76,6 +78,8 @@ inline std::size_t volfracDofIdx( std::size_t nmat, std::size_t kmat,
 //!   from the DG solution vector
 //! \param[in] nmat Number of materials
 //! \param[in] kmat Index of required material
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required material continuity equation
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.
@@ -90,6 +94,8 @@ inline std::size_t densityDofIdx( std::size_t nmat, std::size_t kmat,
 //!   0: X-component,
 //!   1: Y-component,
 //!   2: Z-component.
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required momentum equation component
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.
@@ -101,6 +107,8 @@ inline std::size_t momentumDofIdx( std::size_t nmat, std::size_t idir,
 //!   from the DG solution vector
 //! \param[in] nmat Number of materials
 //! \param[in] kmat Index of required material
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required material total energy equation
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.
@@ -115,6 +123,8 @@ inline std::size_t energyDofIdx( std::size_t nmat, std::size_t kmat,
 //!   0: X-component,
 //!   1: Y-component,
 //!   2: Z-component.
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required velocity component from vector of primitives
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.
@@ -124,7 +134,10 @@ inline std::size_t velocityDofIdx( std::size_t nmat, std::size_t idir,
 
 //! \brief Get the index of the required DOF of material pressure from the DG
 //!   vector of primitives
+//! \param[in] nmat Number of materials
 //! \param[in] kmat Index of required material
+//! \param[in] ndof Number of solution DOFs stored in DG solution vector
+//! \param[in] idof Index of required solution DOF from DG solution vector
 //! \return Index of the required material pressure from vector of primitives
 //! \details This function is used to get the index of the required DOF in the
 //!   solution vector, which is of type tk::Fields.

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
@@ -236,13 +236,13 @@ MultiMatProblemInterfaceAdvection::fieldOutput(
 
   for (std::size_t k=0; k<nmat; ++k)
   {
-    al.push_back( U.extract( volfracIdx(nmat, k)*rdof, offset ) );
-    ar.push_back( U.extract( densityIdx(nmat, k)*rdof, offset ) );
-    ae.push_back( U.extract( energyIdx(nmat, k)*rdof, offset ) );
+    al.push_back( U.extract( volfracDofIdx(nmat, k, rdof, 0), offset ) );
+    ar.push_back( U.extract( densityDofIdx(nmat, k, rdof, 0), offset ) );
+    ae.push_back( U.extract( energyDofIdx(nmat, k, rdof, 0), offset ) );
   }
-  const auto ru  = U.extract( momentumIdx(nmat, 0)*rdof, offset );
-  const auto rv  = U.extract( momentumIdx(nmat, 1)*rdof, offset );
-  const auto rw  = U.extract( momentumIdx(nmat, 2)*rdof, offset );
+  const auto ru  = U.extract( momentumDofIdx(nmat, 0, rdof, 0), offset );
+  const auto rv  = U.extract( momentumDofIdx(nmat, 1, rdof, 0), offset );
+  const auto rw  = U.extract( momentumDofIdx(nmat, 2, rdof, 0), offset );
 
   //// mesh node coordinates
   //const auto& x = coord[0];

--- a/src/PDE/MultiMat/Problem/SodShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.cpp
@@ -212,13 +212,13 @@ MultiMatProblemSodShocktube::fieldOutput(
 
   for (std::size_t k=0; k<nmat; ++k)
   {
-    al.push_back( U.extract( volfracIdx(nmat, k)*rdof, offset ) );
-    ar.push_back( U.extract( densityIdx(nmat, k)*rdof, offset ) );
-    ae.push_back( U.extract( energyIdx(nmat, k)*rdof, offset ) );
+    al.push_back( U.extract( volfracDofIdx(nmat, k, rdof, 0), offset ) );
+    ar.push_back( U.extract( densityDofIdx(nmat, k, rdof, 0), offset ) );
+    ae.push_back( U.extract( energyDofIdx(nmat, k, rdof, 0), offset ) );
   }
-  const auto ru  = U.extract( momentumIdx(nmat, 0)*rdof, offset );
-  const auto rv  = U.extract( momentumIdx(nmat, 1)*rdof, offset );
-  const auto rw  = U.extract( momentumIdx(nmat, 2)*rdof, offset );
+  const auto ru  = U.extract( momentumDofIdx(nmat, 0, rdof, 0), offset );
+  const auto rv  = U.extract( momentumDofIdx(nmat, 1, rdof, 0), offset );
+  const auto rw  = U.extract( momentumDofIdx(nmat, 2, rdof, 0), offset );
 
   // mesh node coordinates
   //const auto& x = coord[0];

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
@@ -206,13 +206,13 @@ MultiMatProblemWaterAirShocktube::fieldOutput(
 
   for (std::size_t k=0; k<nmat; ++k)
   {
-    al.push_back( U.extract( volfracIdx(nmat, k)*rdof, offset ) );
-    ar.push_back( U.extract( densityIdx(nmat, k)*rdof, offset ) );
-    ae.push_back( U.extract( energyIdx(nmat, k)*rdof, offset ) );
+    al.push_back( U.extract( volfracDofIdx(nmat, k, rdof, 0), offset ) );
+    ar.push_back( U.extract( densityDofIdx(nmat, k, rdof, 0), offset ) );
+    ae.push_back( U.extract( energyDofIdx(nmat, k, rdof, 0), offset ) );
   }
-  const auto ru  = U.extract( momentumIdx(nmat, 0)*rdof, offset );
-  const auto rv  = U.extract( momentumIdx(nmat, 1)*rdof, offset );
-  const auto rw  = U.extract( momentumIdx(nmat, 2)*rdof, offset );
+  const auto ru  = U.extract( momentumDofIdx(nmat, 0, rdof, 0), offset );
+  const auto rv  = U.extract( momentumDofIdx(nmat, 1, rdof, 0), offset );
+  const auto rw  = U.extract( momentumDofIdx(nmat, 2, rdof, 0), offset );
 
   // mesh node coordinates
   //const auto& x = coord[0];


### PR DESCRIPTION
This commit adds a new interface to index into the vector of DG solution DOFs. This vector is of type ```tk::Fields```, and its second index has the dimension ```ncomp*rdof```. This changes code such as ```volfracIdx(nmat, k)*rdof+idof``` to ```volfracDofIdx(nmat, k, rdof, idof)```.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/351)
<!-- Reviewable:end -->
