### PR TITLE
Do not collect field output if not written

### DIFF
--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -476,26 +476,34 @@ ALECG::writeFields( CkCallback c ) const
 //! \param[in] c Function to continue with after the write
 // *****************************************************************************
 {
-  auto d = Disc();
+  if (g_inputdeck.get< tag::cmd, tag::benchmark >()) {
 
-  // Query and collect field names from PDEs integrated
-  std::vector< std::string > nodefieldnames;
-  for (const auto& eq : g_cgpde) {
-    auto n = eq.fieldNames();
-    nodefieldnames.insert( end(nodefieldnames), begin(n), end(n) );
+    c.send();
+
+  } else {
+
+    auto d = Disc();
+
+    // Query and collect field names from PDEs integrated
+    std::vector< std::string > nodefieldnames;
+    for (const auto& eq : g_cgpde) {
+      auto n = eq.fieldNames();
+      nodefieldnames.insert( end(nodefieldnames), begin(n), end(n) );
+    }
+
+    // Collect node field solution
+    auto u = m_u;
+    std::vector< std::vector< tk::real > > nodefields;
+    for (const auto& eq : g_cgpde) {
+      auto o = eq.fieldOutput( d->T(), d->meshvol(), d->Coord(), d->V(), u );
+      nodefields.insert( end(nodefields), begin(o), end(o) );
+    }
+
+    // Send mesh and fields data (solution dump) for output to file
+    d->write( d->Inpoel(), d->Coord(), {}, tk::remap(m_bnode,d->Lid()), {}, {},
+              nodefieldnames, {}, nodefields, c );
+
   }
-
-  // Collect node field solution
-  auto u = m_u;
-  std::vector< std::vector< tk::real > > nodefields;
-  for (const auto& eq : g_cgpde) {
-    auto o = eq.fieldOutput( d->T(), d->meshvol(), d->Coord(), d->V(), u );
-    nodefields.insert( end(nodefields), begin(o), end(o) );
-  }
-
-  // Send mesh and fields data (solution dump) for output to file
-  d->write( d->Inpoel(), d->Coord(), {}, tk::remap(m_bnode,d->Lid()), {}, {},
-            nodefieldnames, {}, nodefields, c );
 }
 
 void

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1125,50 +1125,58 @@ DG::writeFields( CkCallback c ) const
 //! \param[in] c Function to continue with after the write
 // *****************************************************************************
 {
-  auto d = Disc();
+  if (g_inputdeck.get< tag::cmd, tag::benchmark >()) {
 
-  const auto& esuel = m_fd.Esuel();
+    c.send();
 
-  // Copy mesh form Discretization object and chop off ghosts for dump
-  auto inpoel = d->Inpoel();
-  inpoel.resize( esuel.size() );
-  auto coord = d->Coord();
-  for (std::size_t i=0; i<3; ++i) coord[i].resize( m_ncoord );
+  } else {
 
-  // Query fields names from all PDEs integrated
-  std::vector< std::string > elemfieldnames;
-  for (const auto& eq : g_dgpde) {
-    auto n = eq.fieldNames();
-    elemfieldnames.insert( end(elemfieldnames), begin(n), end(n) );
+    auto d = Disc();
+
+    const auto& esuel = m_fd.Esuel();
+
+    // Copy mesh form Discretization object and chop off ghosts for dump
+    auto inpoel = d->Inpoel();
+    inpoel.resize( esuel.size() );
+    auto coord = d->Coord();
+    for (std::size_t i=0; i<3; ++i) coord[i].resize( m_ncoord );
+
+    // Query fields names from all PDEs integrated
+    std::vector< std::string > elemfieldnames;
+    for (const auto& eq : g_dgpde) {
+      auto n = eq.fieldNames();
+      elemfieldnames.insert( end(elemfieldnames), begin(n), end(n) );
+    }
+
+    // Collect element field solution
+    std::vector< std::vector< tk::real > > elemfields;
+    auto u = m_u;
+    for (const auto& eq : g_dgpde) {
+      auto o = eq.fieldOutput( d->T(), m_geoElem, u );
+
+      // cut off ghost elements
+      for (auto& f : o) f.resize( esuel.size()/4 );
+      elemfields.insert( end(elemfields), begin(o), end(o) );
+    }
+
+    // Add adaptive indicator array to element-centered field output
+    std::vector<tk::real> ndof( begin(m_ndof), end(m_ndof) );
+    ndof.resize( esuel.size()/4 );  // cut off ghosts
+    elemfields.push_back( ndof );
+
+    // // Collect node field solution
+    // std::vector< std::vector< tk::real > > nodefields;
+    // for (const auto& eq : g_dgpde) {
+    //   auto fields =
+    //     eq.avgElemToNode( d->Inpoel(), d->Coord(), m_geoElem, m_u );
+    //   nodefields.insert( end(nodefields), begin(fields), end(fields) );
+    // }
+
+    // Output chare mesh and fields metadata to file
+    d->write( inpoel, coord, m_fd.Bface(), {}, m_fd.Triinpoel(), elemfieldnames,
+              {}, elemfields, {}, c );
+
   }
-
-  // Collect element field solution
-  std::vector< std::vector< tk::real > > elemfields;
-  auto u = m_u;
-  for (const auto& eq : g_dgpde) {
-    auto o = eq.fieldOutput( d->T(), m_geoElem, u );
-
-    // cut off ghost elements
-    for (auto& f : o) f.resize( esuel.size()/4 );
-    elemfields.insert( end(elemfields), begin(o), end(o) );
-  }
-
-  // Add adaptive indicator array to element-centered field output
-  std::vector<tk::real> ndof( begin(m_ndof), end(m_ndof) );
-  ndof.resize( esuel.size()/4 );  // cut off ghosts
-  elemfields.push_back( ndof );
-
-  // // Collect node field solution
-  // std::vector< std::vector< tk::real > > nodefields;
-  // for (const auto& eq : g_dgpde) {
-  //   auto fields =
-  //     eq.avgElemToNode( d->Inpoel(), d->Coord(), m_geoElem, m_u );
-  //   nodefields.insert( end(nodefields), begin(fields), end(fields) );
-  // }
-
-  // Output chare mesh and fields metadata to file
-  d->write( inpoel, coord, m_fd.Bface(), {}, m_fd.Triinpoel(), elemfieldnames,
-            {}, elemfields, {}, c );
 }
 
 void

--- a/src/Inciter/DiagCG.cpp
+++ b/src/Inciter/DiagCG.cpp
@@ -575,71 +575,79 @@ DiagCG::writeFields( CkCallback c ) const
 //! \param[in] c Function to continue with after the write
 // *****************************************************************************
 {
-  auto d = Disc();
+  if (g_inputdeck.get< tag::cmd, tag::benchmark >()) {
 
-  // Query and collect field names from PDEs integrated
-  std::vector< std::string > nodefieldnames;
-  for (const auto& eq : g_cgpde) {
-    auto n = eq.fieldNames();
-    nodefieldnames.insert( end(nodefieldnames), begin(n), end(n) );
+    c.send();
+
+  } else {
+
+    auto d = Disc();
+
+    // Query and collect field names from PDEs integrated
+    std::vector< std::string > nodefieldnames;
+    for (const auto& eq : g_cgpde) {
+      auto n = eq.fieldNames();
+      nodefieldnames.insert( end(nodefieldnames), begin(n), end(n) );
+    }
+
+    // Collect node field solution
+    auto u = m_u;
+    std::vector< std::vector< tk::real > > nodefields;
+    for (const auto& eq : g_cgpde) {
+      auto o = eq.fieldOutput( d->T(), d->meshvol(), d->Coord(), d->V(), u );
+      nodefields.insert( end(nodefields), begin(o), end(o) );
+    }
+
+    std::vector< std::string > elemfieldnames;
+    std::vector< std::vector< tk::real > > elemfields;
+
+    // Query refinement data
+    auto dtref = g_inputdeck.get< tag::amr, tag::dtref >();
+
+    std::tuple< std::vector< std::string >,
+                std::vector< std::vector< tk::real > >,
+                std::vector< std::string >,
+                std::vector< std::vector< tk::real > > > r;
+    if (dtref) r = d->Ref()->refinementFields();
+
+    const auto& refinement_elemfieldnames = std::get< 0 >( r );
+    const auto& refinement_elemfields = std::get< 1 >( r );
+    const auto& refinement_nodefieldnames = std::get< 2 >( r );
+    const auto& refinement_nodefields = std::get< 3 >( r );
+
+    nodefieldnames.insert( end(nodefieldnames),
+      begin(refinement_nodefieldnames), end(refinement_nodefieldnames) );
+    nodefields.insert( end(nodefields),
+      begin(refinement_nodefields), end(refinement_nodefields) );
+
+    elemfieldnames.insert( end(elemfieldnames),
+      begin(refinement_elemfieldnames), end(refinement_elemfieldnames) );
+    elemfields.insert( end(elemfields),
+      begin(refinement_elemfields), end(refinement_elemfields) );
+
+    // Collect FCT field data (for debugging)
+    auto f = d->FCT()->fields();
+
+    const auto& fct_elemfieldnames = std::get< 0 >( f );
+    const auto& fct_elemfields = std::get< 1 >( f );
+    const auto& fct_nodefieldnames = std::get< 2 >( f );
+    const auto& fct_nodefields = std::get< 3 >( f );
+
+    nodefieldnames.insert( end(nodefieldnames),
+      begin(fct_nodefieldnames), end(fct_nodefieldnames) );
+    nodefields.insert( end(nodefields),
+      begin(fct_nodefields), end(fct_nodefields) );
+
+    elemfieldnames.insert( end(elemfieldnames),
+      begin(fct_elemfieldnames), end(fct_elemfieldnames) );
+    elemfields.insert( end(elemfields),
+      begin(fct_elemfields), end(fct_elemfields) );
+
+    // Send mesh and fields data (solution dump) for output to file
+    d->write( d->Inpoel(), d->Coord(), {}, tk::remap(m_bnode,d->Lid()), {},
+              elemfieldnames, nodefieldnames, elemfields, nodefields, c );
+
   }
-
-  // Collect node field solution
-  auto u = m_u;
-  std::vector< std::vector< tk::real > > nodefields;
-  for (const auto& eq : g_cgpde) {
-    auto o = eq.fieldOutput( d->T(), d->meshvol(), d->Coord(), d->V(), u );
-    nodefields.insert( end(nodefields), begin(o), end(o) );
-  }
-
-  std::vector< std::string > elemfieldnames;
-  std::vector< std::vector< tk::real > > elemfields;
-
-  // Query refinement data
-  auto dtref = g_inputdeck.get< tag::amr, tag::dtref >();
-
-  std::tuple< std::vector< std::string >,
-              std::vector< std::vector< tk::real > >,
-              std::vector< std::string >,
-              std::vector< std::vector< tk::real > > > r;
-  if (dtref) r = d->Ref()->refinementFields();
-
-  const auto& refinement_elemfieldnames = std::get< 0 >( r );
-  const auto& refinement_elemfields = std::get< 1 >( r );
-  const auto& refinement_nodefieldnames = std::get< 2 >( r );
-  const auto& refinement_nodefields = std::get< 3 >( r );
-
-  nodefieldnames.insert( end(nodefieldnames),
-    begin(refinement_nodefieldnames), end(refinement_nodefieldnames) );
-  nodefields.insert( end(nodefields),
-    begin(refinement_nodefields), end(refinement_nodefields) );
-
-  elemfieldnames.insert( end(elemfieldnames),
-    begin(refinement_elemfieldnames), end(refinement_elemfieldnames) );
-  elemfields.insert( end(elemfields),
-    begin(refinement_elemfields), end(refinement_elemfields) );
-
-  // Collect FCT field data (for debugging)
-  auto f = d->FCT()->fields();
-
-  const auto& fct_elemfieldnames = std::get< 0 >( f );
-  const auto& fct_elemfields = std::get< 1 >( f );
-  const auto& fct_nodefieldnames = std::get< 2 >( f );
-  const auto& fct_nodefields = std::get< 3 >( f );
-
-  nodefieldnames.insert( end(nodefieldnames),
-    begin(fct_nodefieldnames), end(fct_nodefieldnames) );
-  nodefields.insert( end(nodefields),
-    begin(fct_nodefields), end(fct_nodefields) );
-
-  elemfieldnames.insert( end(elemfieldnames),
-    begin(fct_elemfieldnames), end(fct_elemfieldnames) );
-  elemfields.insert( end(elemfields),
-    begin(fct_elemfields), end(fct_elemfields) );
-
-  // Send mesh and fields data (solution dump) for output to file
-  d->write( d->Inpoel(), d->Coord(), {}, tk::remap(m_bnode,d->Lid()), {},
-            elemfieldnames, nodefieldnames, elemfields, nodefields, c );
 }
 
 void


### PR DESCRIPTION
Previously, in benchmark mode, we did not write large-file field-output to disk. Now we don't even collect it. This resolves #369 .

Show a largeish diff, but the changes are simple: `[DiagCG,ALECG,DG]::writeFields()` no longer collects field output in benchmark mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/370)
<!-- Reviewable:end -->
