### PR TITLE
Uniformly loop over all PDE types and BCs when matching configured BCs and side sets in mesh file used

### DIFF
--- a/src/Base/TaggedTuple.hpp
+++ b/src/Base/TaggedTuple.hpp
@@ -57,9 +57,11 @@ class TaggedTuple{
     //! List of member types
     using Data = typename Pair::first_type;
 
+  public:
     //! List of keys
     using Keys = typename Pair::second_type;
 
+  private:
     //! Tuple of member types
     using Tuple = brigand::as_tuple< Data >;
 

--- a/src/Control/CommonGrammar.hpp
+++ b/src/Control/CommonGrammar.hpp
@@ -1629,11 +1629,6 @@ namespace grm {
   struct discrparam :
            control< use< keyword >, pegtl::digit, tag::discr, Tag > {};
 
-  //! Match boundary control parameter
-  template< template< class > class use, typename keyword, typename Tag >
-  struct bcparam :
-           control< use< keyword >, pegtl::digit, tag::bc, Tag > {};
-
   //! Match component control parameter
   template< typename keyword, typename Tag >
   struct component :

--- a/src/Control/Inciter/InputDeck/Grammar.hpp
+++ b/src/Control/Inciter/InputDeck/Grammar.hpp
@@ -83,9 +83,10 @@ namespace grm {
     template< typename Input, typename Stack >
     static void apply( const Input& in, Stack& stack ) {
       using inciter::deck::neq;
+      using tag::param;
 
       // Error out if no dependent variable has been selected
-      auto& depvar = stack.template get< tag::param, eq, tag::depvar >();
+      auto& depvar = stack.template get< param, eq, tag::depvar >();
       if (depvar.empty() || depvar.size() != neq.get< eq >())
         Message< Stack, ERROR, MsgKey::NODEPVAR >( stack, in );
 
@@ -95,32 +96,32 @@ namespace grm {
         ncomp.push_back( 1 );
 
       // If physics type is not given, default to 'advection'
-      auto& physics = stack.template get< tag::param, eq, tag::physics >();
+      auto& physics = stack.template get< param, eq, tag::physics >();
       if (physics.empty() || physics.size() != neq.get< eq >())
         physics.push_back( inciter::ctr::PhysicsType::ADVECTION );
 
       // If physics type is advection-diffusion, check for correct number of
       // advection velocity, shear, and diffusion coefficients
       if (physics.back() == inciter::ctr::PhysicsType::ADVDIFF) {
-        auto& u0 = stack.template get< tag::param, eq, tag::u0 >();
+        auto& u0 = stack.template get< param, eq, tag::u0 >();
         if (u0.back().size() != ncomp.back())  // must define 1 component
           Message< Stack, ERROR, MsgKey::WRONGSIZE >( stack, in );
-        auto& diff = stack.template get< tag::param, eq, tag::diffusivity >();
+        auto& diff = stack.template get< param, eq, tag::diffusivity >();
         if (diff.back().size() != 3*ncomp.back())  // must define 3 components
           Message< Stack, ERROR, MsgKey::WRONGSIZE >( stack, in );
-        auto& lambda = stack.template get< tag::param, eq, tag::lambda >();
+        auto& lambda = stack.template get< param, eq, tag::lambda >();
         if (lambda.back().size() != 2*ncomp.back()) // must define 2 shear comps
           Message< Stack, ERROR, MsgKey::WRONGSIZE >( stack, in );
       }
       // If problem type is not given, error out
-      auto& problem = stack.template get< tag::param, eq, tag::problem >();
+      auto& problem = stack.template get< param, eq, tag::problem >();
       if (problem.empty() || problem.size() != neq.get< eq >())
         Message< Stack, ERROR, MsgKey::NOPROBLEM >( stack, in );
       // Error check Dirichlet boundary condition block for all transport eq
       // configurations
-      for (const auto& s : stack.template get< tag::param, eq, tag::bcdir >())
-        if (s.empty())
-          Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
+      const auto& bc = stack.template get< param, eq, tag::bc, tag::bcdir >();
+      for (const auto& s : bc)
+        if (s.empty()) Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
     }
   };
 
@@ -137,14 +138,15 @@ namespace grm {
     template< typename Input, typename Stack >
     static void apply( const Input& in, Stack& stack ) {
       using inciter::deck::neq;
+      using tag::param;
 
       // Error out if no dependent variable has been selected
-      auto& depvar = stack.template get< tag::param, eq, tag::depvar >();
+      auto& depvar = stack.template get< param, eq, tag::depvar >();
       if (depvar.empty() || depvar.size() != neq.get< eq >())
         Message< Stack, ERROR, MsgKey::NODEPVAR >( stack, in );
 
       // If physics type is not given, default to 'euler'
-      auto& physics = stack.template get< tag::param, eq, tag::physics >();
+      auto& physics = stack.template get< param, eq, tag::physics >();
       if (physics.empty() || physics.size() != neq.get< eq >()) {
         physics.push_back( inciter::ctr::PhysicsType::EULER );
       }
@@ -153,13 +155,13 @@ namespace grm {
       stack.template get< tag::component, eq >().push_back( 5 );
 
       // Set default to sysfct (on/off) if not specified
-      auto& sysfct = stack.template get< tag::param, eq, tag::sysfct >();
+      auto& sysfct = stack.template get< param, eq, tag::sysfct >();
       if (sysfct.empty() || sysfct.size() != neq.get< eq >())
         sysfct.push_back( 1 );
 
       // Verify that sysfctvar variables are within bounds (if specified) and
       // defaults if not
-      auto& sysfctvar = stack.template get< tag::param, eq, tag::sysfctvar >();
+      auto& sysfctvar = stack.template get< param, eq, tag::sysfctvar >();
       // If sysfctvar is not specified, use all variables for system FCT
       if (sysfctvar.empty() || sysfctvar.back().empty()) {
         sysfctvar.push_back( {0,1,2,3,4} );
@@ -174,13 +176,13 @@ namespace grm {
       }
 
       // Verify correct number of multi-material properties configured
-      const auto& gamma = stack.template get< tag::param, eq, tag::gamma >();
+      const auto& gamma = stack.template get< param, eq, tag::gamma >();
       if (gamma.empty() || gamma.back().size() != 1)
         Message< Stack, ERROR, MsgKey::EOSGAMMA >( stack, in );
 
       // If specific heat is not given, set defaults
       using cv_t = kw::mat_cv::info::expect::type;
-      auto& cv = stack.template get< tag::param, eq, tag::cv >();
+      auto& cv = stack.template get< param, eq, tag::cv >();
       // As a default, the specific heat of air (717.5 J/Kg-K) is used
       if (cv.empty() || cv.size() != neq.get< eq >())
         cv.push_back( std::vector< cv_t >( 1, 717.5 ) );
@@ -190,7 +192,7 @@ namespace grm {
 
       // If stiffness coefficient is not given, set defaults
       using pstiff_t = kw::mat_pstiff::info::expect::type;
-      auto& pstiff = stack.template get< tag::param, eq, tag::pstiff >();
+      auto& pstiff = stack.template get< param, eq, tag::pstiff >();
       if (pstiff.empty() || pstiff.size() != neq.get< eq >())
         pstiff.push_back( std::vector< pstiff_t >( 1, 0.0 ) );
       // If stiffness coefficient vector is wrong size, error out
@@ -198,26 +200,26 @@ namespace grm {
         Message< Stack, ERROR, MsgKey::EOSPSTIFF >( stack, in );
 
       // If problem type is not given, default to 'user_defined'
-      auto& problem = stack.template get< tag::param, eq, tag::problem >();
+      auto& problem = stack.template get< param, eq, tag::problem >();
       if (problem.empty() || problem.size() != neq.get< eq >())
         problem.push_back( inciter::ctr::ProblemType::USER_DEFINED );
       else if (problem.back() == inciter::ctr::ProblemType::VORTICAL_FLOW) {
-        const auto& alpha = stack.template get< tag::param, eq, tag::alpha >();
-        const auto& beta = stack.template get< tag::param, eq, tag::beta >();
-        const auto& p0 = stack.template get< tag::param, eq, tag::p0 >();
+        const auto& alpha = stack.template get< param, eq, tag::alpha >();
+        const auto& beta = stack.template get< param, eq, tag::beta >();
+        const auto& p0 = stack.template get< param, eq, tag::p0 >();
         if ( alpha.size() != problem.size() ||
              beta.size() != problem.size() ||
              p0.size() != problem.size() )
           Message< Stack, ERROR, MsgKey::VORTICAL_UNFINISHED >( stack, in );
       }
       else if (problem.back() == inciter::ctr::ProblemType::NL_ENERGY_GROWTH) {
-        const auto& alpha = stack.template get< tag::param, eq, tag::alpha >();
-        const auto& betax = stack.template get< tag::param, eq, tag::betax >();
-        const auto& betay = stack.template get< tag::param, eq, tag::betay >();
-        const auto& betaz = stack.template get< tag::param, eq, tag::betaz >();
-        const auto& kappa = stack.template get< tag::param, eq, tag::kappa >();
-        const auto& r0 = stack.template get< tag::param, eq, tag::r0 >();
-        const auto& ce = stack.template get< tag::param, eq, tag::ce >();
+        const auto& alpha = stack.template get< param, eq, tag::alpha >();
+        const auto& betax = stack.template get< param, eq, tag::betax >();
+        const auto& betay = stack.template get< param, eq, tag::betay >();
+        const auto& betaz = stack.template get< param, eq, tag::betaz >();
+        const auto& kappa = stack.template get< param, eq, tag::kappa >();
+        const auto& r0 = stack.template get< param, eq, tag::r0 >();
+        const auto& ce = stack.template get< param, eq, tag::ce >();
         if ( alpha.size() != problem.size() ||
              betax.size() != problem.size() ||
              betay.size() != problem.size() ||
@@ -228,13 +230,13 @@ namespace grm {
           Message< Stack, ERROR, MsgKey::ENERGY_UNFINISHED >( stack, in);
       }
       else if (problem.back() == inciter::ctr::ProblemType::RAYLEIGH_TAYLOR) {
-        const auto& alpha = stack.template get< tag::param, eq, tag::alpha >();
-        const auto& betax = stack.template get< tag::param, eq, tag::betax >();
-        const auto& betay = stack.template get< tag::param, eq, tag::betay >();
-        const auto& betaz = stack.template get< tag::param, eq, tag::betaz >();
-        const auto& kappa = stack.template get< tag::param, eq, tag::kappa >();
-        const auto& p0 = stack.template get< tag::param, eq, tag::p0 >();
-        const auto& r0 = stack.template get< tag::param, eq, tag::r0 >();
+        const auto& alpha = stack.template get< param, eq, tag::alpha >();
+        const auto& betax = stack.template get< param, eq, tag::betax >();
+        const auto& betay = stack.template get< param, eq, tag::betay >();
+        const auto& betaz = stack.template get< param, eq, tag::betaz >();
+        const auto& kappa = stack.template get< param, eq, tag::kappa >();
+        const auto& p0 = stack.template get< param, eq, tag::p0 >();
+        const auto& r0 = stack.template get< param, eq, tag::r0 >();
         if ( alpha.size() != problem.size() ||
              betax.size() != problem.size() ||
              betay.size() != problem.size() ||
@@ -247,19 +249,19 @@ namespace grm {
 
       // Error check Dirichlet boundary condition block for all compflow
       // configurations
-      for (const auto& s : stack.template get< tag::param, eq, tag::bcdir >())
-        if (s.empty())
-          Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
+      const auto& bc = stack.template get< param, eq, tag::bc, tag::bcdir >();
+      for (const auto& s : bc)
+        if (s.empty()) Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
 
       // Put in default farfield pressure if not specified by user
       // if outlet BC is configured for this compflow system
       auto& bcsubsonicoutlet =
-          stack.template get< tag::param, eq, tag::bcsubsonicoutlet >();
+          stack.template get< param, eq, tag::bc, tag::bcsubsonicoutlet >();
       if (!bcsubsonicoutlet.empty() ||
           bcsubsonicoutlet.size() != neq.get< eq >())
       {
         auto& fp =
-          stack.template get< tag::param, eq, tag::farfield_pressure >();
+          stack.template get< param, eq, tag::farfield_pressure >();
         if (fp.size() != bcsubsonicoutlet.size()) fp.push_back( 1.0 );
       }
     }
@@ -278,14 +280,15 @@ namespace grm {
     template< typename Input, typename Stack >
     static void apply( const Input& in, Stack& stack ) {
       using inciter::deck::neq;
+      using tag::param;
 
       // Error out if no dependent variable has been selected
-      auto& depvar = stack.template get< tag::param, eq, tag::depvar >();
+      auto& depvar = stack.template get< param, eq, tag::depvar >();
       if (depvar.empty() || depvar.size() != neq.get< eq >())
         Message< Stack, ERROR, MsgKey::NODEPVAR >( stack, in );
 
       // If physics type is not given, default to 'veleq'
-      auto& physics = stack.template get< tag::param, eq, tag::physics >();
+      auto& physics = stack.template get< param, eq, tag::physics >();
       if (physics.empty() || physics.size() != neq.get< eq >())
         physics.push_back( inciter::ctr::PhysicsType::VELEQ );
 
@@ -294,7 +297,7 @@ namespace grm {
       flux = inciter::ctr::FluxType::AUSM;
 
       // Set number of scalar components based on number of materials
-      auto& nmat = stack.template get< tag::param, eq, tag::nmat >();
+      auto& nmat = stack.template get< param, eq, tag::nmat >();
       auto& ncomp = stack.template get< tag::component, eq >();
       if (physics.back() == inciter::ctr::PhysicsType::VELEQ) {
         // physics = veleq: m-material compressible flow
@@ -310,24 +313,24 @@ namespace grm {
       }
 
       // Verify correct number of multi-material properties configured
-      auto& gamma = stack.template get< tag::param, eq, tag::gamma >();
+      auto& gamma = stack.template get< param, eq, tag::gamma >();
       if (gamma.empty() || gamma.back().size() != nmat.back())
         Message< Stack, ERROR, MsgKey::EOSGAMMA >( stack, in );
 
       // If pressure relaxation is not specified, default to 'false'
-      auto& prelax = stack.template get< tag::param, eq, tag::prelax >();
+      auto& prelax = stack.template get< param, eq, tag::prelax >();
       if (prelax.empty() || prelax.size() != neq.get< eq >())
         prelax.push_back( 0 );
 
       // If pressure relaxation time-scale is not specified, default to 1.0
-      auto& prelax_ts = stack.template get< tag::param, eq,
+      auto& prelax_ts = stack.template get< param, eq,
                                             tag::prelax_timescale >();
       if (prelax_ts.empty() || prelax_ts.size() != neq.get< eq >())
         prelax_ts.push_back( 1.0 );
 
       // If specific heats are not given, set defaults
       using cv_t = kw::mat_cv::info::expect::type;
-      auto& cv = stack.template get< tag::param, eq, tag::cv >();
+      auto& cv = stack.template get< param, eq, tag::cv >();
       // As a default, the specific heat of air (717.5 J/Kg-K) is used
       if (cv.empty())
         cv.push_back( std::vector< cv_t >( nmat.back(), 717.5 ) );
@@ -337,7 +340,7 @@ namespace grm {
 
       // If stiffness coefficients are not given, set defaults
       using pstiff_t = kw::mat_pstiff::info::expect::type;
-      auto& pstiff = stack.template get< tag::param, eq, tag::pstiff >();
+      auto& pstiff = stack.template get< param, eq, tag::pstiff >();
       if (pstiff.empty())
         pstiff.push_back( std::vector< pstiff_t >( nmat.back(), 0.0 ) );
       // If stiffness coefficient vector is wrong size, error out
@@ -345,13 +348,13 @@ namespace grm {
         Message< Stack, ERROR, MsgKey::EOSPSTIFF >( stack, in );
 
       // If problem type is not given, default to 'user_defined'
-      auto& problem = stack.template get< tag::param, eq, tag::problem >();
+      auto& problem = stack.template get< param, eq, tag::problem >();
       if (problem.empty() || problem.size() != neq.get< eq >())
         problem.push_back( inciter::ctr::ProblemType::USER_DEFINED );
       else if (problem.back() == inciter::ctr::ProblemType::VORTICAL_FLOW) {
-        const auto& alpha = stack.template get< tag::param, eq, tag::alpha >();
-        const auto& beta = stack.template get< tag::param, eq, tag::beta >();
-        const auto& p0 = stack.template get< tag::param, eq, tag::p0 >();
+        const auto& alpha = stack.template get< param, eq, tag::alpha >();
+        const auto& beta = stack.template get< param, eq, tag::beta >();
+        const auto& p0 = stack.template get< param, eq, tag::p0 >();
         if ( alpha.size() != problem.size() ||
              beta.size() != problem.size() ||
              p0.size() != problem.size() )
@@ -360,9 +363,9 @@ namespace grm {
 
       // Error check Dirichlet boundary condition block for all multimat
       // configurations
-      for (const auto& s : stack.template get< tag::param, eq, tag::bcdir >())
-        if (s.empty())
-          Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
+      const auto& bc = stack.template get< param, eq, tag::bc, tag::bcdir >();
+      for (const auto& s : bc)
+        if (s.empty()) Message< Stack, ERROR, MsgKey::BC_EMPTY >( stack, in );
     }
   };
 
@@ -632,11 +635,11 @@ namespace deck {
                                     param > {};
 
   //! put in PDE parameter for equation matching keyword
-  template< typename eq, typename keyword, typename p,
+  template< typename eq, typename keyword, typename param,
             class kw_type = tk::grm::number >
   struct parameter :
          tk::grm::process< use< keyword >,
-                           tk::grm::Store_back< tag::param, eq, p >,
+                           tk::grm::Store_back< tag::param, eq, param >,
                            kw_type > {};
 
   //! put in PDE bool parameter for equation matching keyword into vector< int >
@@ -659,6 +662,7 @@ namespace deck {
                                         tk::grm::start_vector,
                                         tk::grm::check_vector,
                                         eq,
+                                        tag::bc,
                                         param > > > {};
 
   //! Farfield boundary conditions block
@@ -675,6 +679,7 @@ namespace deck {
                                         tk::grm::start_vector,
                                         tk::grm::check_vector,
                                         eq,
+                                        tag::bc,
                                         param > > > {};
 
   //! edgelist ... end block
@@ -797,17 +802,26 @@ namespace deck {
                            parameter_bool< tag::compflow,
                                            kw::sysfct,
                                            tag::sysfct >,
-                           parameter< tag::compflow, kw::npar, tag::npar,
-                                      pegtl::digit >,
-                           parameter< tag::compflow, kw::pde_alpha, tag::alpha >,
-                           parameter< tag::compflow, kw::pde_p0, tag::p0 >,
-                           parameter< tag::compflow, kw::pde_betax, tag::betax >,
-                           parameter< tag::compflow, kw::pde_betay, tag::betay >,
-                           parameter< tag::compflow, kw::pde_betaz, tag::betaz >,
-                           parameter< tag::compflow, kw::pde_beta, tag::beta >,
-                           parameter< tag::compflow, kw::pde_r0, tag::r0 >,
-                           parameter< tag::compflow, kw::pde_ce, tag::ce >,
-                           parameter< tag::compflow, kw::pde_kappa, tag::kappa >,
+                           parameter< tag::compflow, kw::npar,
+                                      tag::npar, pegtl::digit >,
+                           parameter< tag::compflow, kw::pde_alpha,
+                                      tag::alpha >,
+                           parameter< tag::compflow, kw::pde_p0,
+                                      tag::p0 >,
+                           parameter< tag::compflow, kw::pde_betax,
+                                      tag::betax >,
+                           parameter< tag::compflow, kw::pde_betay,
+                                      tag::betay >,
+                           parameter< tag::compflow, kw::pde_betaz,
+                                      tag::betaz >,
+                           parameter< tag::compflow, kw::pde_beta,
+                                      tag::beta >,
+                           parameter< tag::compflow, kw::pde_r0,
+                                      tag::r0 >,
+                           parameter< tag::compflow, kw::pde_ce,
+                                      tag::ce >,
+                           parameter< tag::compflow, kw::pde_kappa,
+                                      tag::kappa >,
                            bc< kw::bc_dirichlet, tag::compflow, tag::bcdir >,
                            bc< kw::bc_sym, tag::compflow, tag::bcsym >,
                            bc< kw::bc_inlet, tag::compflow, tag::bcinlet >,

--- a/src/Control/Inciter/Types.hpp
+++ b/src/Control/Inciter/Types.hpp
@@ -133,6 +133,24 @@ using diagnostics = tk::TaggedTuple< brigand::list<
   tag::error,       std::vector< tk::ctr::ErrorType > //!< Errors to compute
 > >;
 
+//! Boundary condition configuration
+using bc = tk::TaggedTuple< brigand::list<
+    tag::bcdir,             std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcsym,             std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcinlet,           std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcoutlet,          std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcextrapolate,     std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcsubsonicoutlet,  std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+  , tag::bcextrapolate,     std::vector< std::vector<
+                              kw::sideset::info::expect::type > >
+> >;
+
 //! Transport equation parameters storage
 using TransportPDEParameters = tk::TaggedTuple< brigand::list<
     tag::depvar,        std::vector< char >
@@ -144,16 +162,7 @@ using TransportPDEParameters = tk::TaggedTuple< brigand::list<
                         kw::pde_lambda::info::expect::type > >
   , tag::u0,            std::vector< std::vector<
                         kw::pde_u0::info::expect::type > >
-  , tag::bcdir,         std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
-  , tag::bcsym,         std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
-  , tag::bcinlet,       std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
-  , tag::bcoutlet,      std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
-  , tag::bcextrapolate, std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
+  , tag::bc,            bc
 > >;
 
 //! Compressible flow equation parameters storage
@@ -161,19 +170,9 @@ using CompFlowPDEParameters = tk::TaggedTuple< brigand::list<
     tag::depvar,        std::vector< char >
   , tag::physics,       std::vector< PhysicsType >
   , tag::problem,       std::vector< ProblemType >
-  , tag::bcdir,         std::vector< std::vector<
-                          kw::sideset::info::expect::type > >
-  , tag::bcsym,         std::vector< std::vector<
-                          kw::sideset::info::expect::type > >
-  , tag::bcinlet,       std::vector< std::vector<
-                          kw::sideset::info::expect::type > >
-  , tag::bcsubsonicoutlet,
-                        std::vector< std::vector<
-                          kw::sideset::info::expect::type > >
-  , tag::farfield_pressure,
-                        std::vector< kw::farfield_pressure::info::expect::type >
-  , tag::bcextrapolate, std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
+  , tag::bc,            bc
+  , tag::farfield_pressure, std::vector<
+                              kw::farfield_pressure::info::expect::type >
   //! System FCT character
   , tag::sysfct,        std::vector< int >
   //! Indices of system-FCT scalar components considered as a system
@@ -221,16 +220,7 @@ using MultiMatPDEParameters = tk::TaggedTuple< brigand::list<
     tag::depvar,        std::vector< char >
   , tag::physics,       std::vector< PhysicsType >
   , tag::problem,       std::vector< ProblemType >
-  , tag::bcdir,         std::vector< std::vector<
-                       kw::sideset::info::expect::type > >
-  , tag::bcsym,         std::vector< std::vector<
-                       kw::sideset::info::expect::type > >
-  , tag::bcinlet,       std::vector< std::vector<
-                        kw::sideset::info::expect::type > >
-  , tag::bcoutlet,      std::vector< std::vector<
-                        kw::sideset::info::expect::type > >
-  , tag::bcextrapolate, std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
+  , tag::bc,            bc
     //! Parameter vector (for specific, e.g., verification problems)
   , tag::alpha,         std::vector< kw::pde_alpha::info::expect::type >
     //! Parameter vector (for specific, e.g., verification problems)

--- a/src/Inciter/Transporter.cpp
+++ b/src/Inciter/Transporter.cpp
@@ -22,6 +22,8 @@
 #include <limits>
 #include <cmath>
 
+#include <brigand/algorithms/for_each.hpp>
+
 #include "Macro.hpp"
 #include "Transporter.hpp"
 #include "Fields.hpp"
@@ -31,11 +33,13 @@
 #include "ContainerUtil.hpp"
 #include "LoadDistributor.hpp"
 #include "MeshReader.hpp"
+#include "Inciter/Types.hpp"
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "NodeDiagnostics.hpp"
 #include "ElemDiagnostics.hpp"
 #include "DiagWriter.hpp"
 #include "Callback.hpp"
+#include "CartesianProduct.hpp"
 
 #include "NoWarning/inciter.decl.h"
 #include "NoWarning/partitioner.decl.h"
@@ -287,6 +291,47 @@ Transporter::info()
   m_print.endsubsection();
 }
 
+bool
+Transporter::matchBCs( std::map< int, std::vector< std::size_t > >& bnd )
+// *****************************************************************************
+ // Verify boundary condition (BC) side sets used exist in mesh file
+ //! \details This function does two things: (1) it verifies that the side
+ //!   sets to which boundary conditions (BC) are assigned by the user in the
+ //!   input file all exist among the side sets read from the input mesh
+ //!   file and errors out if at least one does not, and (2) it matches the
+ //!   side set ids at which the user has configured BCs to side set ids read
+ //!   from the mesh file and removes those face and node lists associated
+ //!   to side sets that the user did not set BCs on (as they will not need
+ //!   processing further since they will not be used).
+ //! \param[in,out] bnd Node or face lists mapped to side set ids
+ //! \return True if BCs have been set on sidesets found
+// *****************************************************************************
+ {
+   // Query side set ids at which BCs assigned for all BC types for all PDEs
+   using PDEsBCs =
+     tk::cartesian_product< ctr::parameters::Keys, ctr::bc::Keys >;
+   std::unordered_set< int > userbc;
+   brigand::for_each< PDEsBCs >( UserBC( g_inputdeck, userbc ) );
+
+   // Find user-configured side set ids among side sets read from mesh file
+   std::unordered_set< int > sidesets_as_bc;
+   for (auto i : userbc) {   // for all side sets at which BCs are assigned
+     if (bnd.find(i) != end(bnd))  // user BC found among side sets in file
+       sidesets_as_bc.insert( i );  // store side set id configured as BC
+     else {
+       Throw( "Boundary conditions specified on side set " +
+         std::to_string(i) + " which does not exist in mesh file" );
+     }
+   }
+
+   // Remove sidesets not configured as BCs (will not process those further)
+   tk::erase_if( bnd, [&]( auto& item ) {
+     return sidesets_as_bc.find( item.first ) == end(sidesets_as_bc);
+   });
+
+   return !bnd.empty();
+ }
+
 void
 Transporter::createPartitioner()
 // *****************************************************************************
@@ -314,15 +359,15 @@ Transporter::createPartitioner()
   if (centering == tk::Centering::ELEM) {
 
     // Verify boundarty condition (BC) side sets used exist in mesh file
-    bcs_set = matchBCs( g_dgpde, bface );
+    bcs_set = matchBCs( bface );
 
   } else if (centering == tk::Centering::NODE) {
 
     // Read node lists on side sets
     bnode = mr.readSidesetNodes();
     // Verify boundarty condition (BC) side sets used exist in mesh file
-    bcs_set = matchBCs( g_cgpde, bnode );
-    bcs_set = bcs_set || matchBCs( g_cgpde, bface );
+    bcs_set = matchBCs( bnode );
+    bcs_set = bcs_set || matchBCs( bface );
   }
 
   // Warn on no BCs

--- a/src/Inciter/Transporter.hpp
+++ b/src/Inciter/Transporter.hpp
@@ -281,42 +281,26 @@ class Transporter : public CBase_Transporter {
       var.insert( end(var), begin(o), end(o) );
     }
 
-    //! Verify boundary condition (BC) side sets used exist in mesh file
-    //! \details This function does two things: (1) it verifies that the side
-    //!   sets to which boundary conditions (BC) are assigned by the user in the
-    //!   input file all exist among the side sets read from the input mesh
-    //!   file and errors out if at least one does not, and (2) it matches the
-    //!   side set ids at which the user has configured BCs to side set ids read
-    //!   from the mesh file and removes those face and node lists associated
-    //!   to side sets that the user did not set BCs on (as they will not need
-    //!   processing further since they will not be used).
-    //! \tparam Eq Equation type, e.g., CG, DG, used to solve PDEs
-    //! \param[in] pde List of PDE system solved
-    //! \param[in,out] bnd Node or face lists mapped to side set ids
-    //! \return True if BCs have been set on sidesets found
-    template< class Eq >
-    bool matchBCs( const std::vector< Eq >& pde,
-                   std::map< int, std::vector< std::size_t > >& bnd )
-    {
-      // Query side set ids at which BCs assigned for all PDEs
-      std::unordered_set< int > userbc;
-      for (const auto& eq : pde) eq.side( userbc );
-      // Find user-configured side set ids among side sets read from mesh file
-      std::unordered_set< int > sidesets_as_bc;
-      for (auto i : userbc) {   // for all side sets at which BCs are assigned
-        if (bnd.find(i) != end(bnd))  // user BC found among side sets in file
-          sidesets_as_bc.insert( i );  // store side set id configured as BC
-        else {
-          Throw( "Boundary conditions specified on side set " +
-            std::to_string(i) + " which does not exist in mesh file" );
-        }
+    //! Function object for querying the side set ids the user configured
+    //! \details Used to query and collect the side set ids the user has
+    //!   configured for all PDE types querying all BC types. Used on a
+    //!   Carteisan product of 2 type lists: PDE types and BC types.
+    struct UserBC {
+      const ctr::InputDeck& inputdeck;
+      std::unordered_set< int >& userbc;
+      explicit UserBC( const ctr::InputDeck& i, std::unordered_set< int >& u )
+        : inputdeck(i), userbc(u) {}
+      template< typename U > void operator()( brigand::type_<U> ) {
+        using tag::param;
+        using eq = typename brigand::front< U >;
+        using bc = typename brigand::back< U >;
+        for (const auto& s : inputdeck.get< param, eq, tag::bc, bc >())
+          for (const auto& i : s) userbc.insert( std::stoi(i) );
       }
-      // Remove sidesets not configured as BCs (will not process those further)
-      tk::erase_if( bnd, [&]( auto& item ) {
-        return sidesets_as_bc.find( item.first ) == end(sidesets_as_bc);
-      });
-      return !bnd.empty();
-    }
+    };
+
+    //! Verify boundary condition (BC) side sets used exist in mesh file
+    bool matchBCs( std::map< int, std::vector< std::size_t > >& bnd );
 };
 
 } // inciter::

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -101,10 +101,6 @@ class CGPDE {
                  const tk::Fields& U ) const
     { return self->dt( coord, inpoel, U ); }
 
-    //! \brief Public interface for collecting all side set IDs the user has
-    //!   configured for all components of a PDE system
-    void side( std::unordered_set< int >& conf ) const { self->side( conf ); }
-
     //! \brief Public interface for querying Dirichlet boundary condition values
     //!  set by the user on a given side set for all components in a PDE system
     std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
@@ -178,7 +174,6 @@ class CGPDE {
       virtual tk::real dt( const std::array< std::vector< tk::real >, 3 >&,
                            const std::vector< std::size_t >&,
                            const tk::Fields& ) const = 0;
-      virtual void side( std::unordered_set< int >& conf ) const = 0;
       virtual
       std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
       dirbc( tk::real,
@@ -226,8 +221,6 @@ class CGPDE {
                    const std::vector< std::size_t >& inpoel,
                    const tk::Fields& U ) const override
       { return data.dt( coord, inpoel, U ); }
-      void side( std::unordered_set< int >& conf ) const override
-      { data.side( conf ); }
       std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
       dirbc( tk::real t,
              tk::real deltat,

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -343,12 +343,6 @@ class CompFlow {
       return v;
     }
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    void side( std::unordered_set< int >& conf ) const
-    { m_problem.side( conf ); }
-
     //! \brief Query Dirichlet boundary condition value on a given side set for
     //!    all components in this PDE system
     //! \param[in] t Physical time
@@ -369,7 +363,7 @@ class CompFlow {
       using tag::param; using tag::compflow; using tag::bcdir;
       using NodeBC = std::vector< std::pair< bool, tk::real > >;
       std::map< std::size_t, NodeBC > bc;
-      const auto& ubc = g_inputdeck.get< param, compflow, bcdir >();
+      const auto& ubc = g_inputdeck.get< param, compflow, tag::bc, bcdir >();
       if (!ubc.empty()) {
         Assert( ubc.size() > 0, "Indexing out of Dirichlet BC eq-vector" );
         const auto& x = coord[0];
@@ -417,7 +411,7 @@ class CompFlow {
                 std::unordered_set< std::size_t >& nodes ) const
     {
       using tag::param; using tag::compflow; using tag::bcsym;
-      const auto& bc = g_inputdeck.get< param, compflow, bcsym >();
+      const auto& bc = g_inputdeck.get< param, compflow, tag::bc, bcsym >();
       if (!bc.empty() && bc.size() > m_system) {
         const auto& ss = bc[ m_system ];// side sets with sym bcs specified
         for (const auto& s : ss) {

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -71,7 +71,7 @@ class CompFlow {
     std::vector< bcconf_t >
     config( ncomp_t c ) {
       std::vector< bcconf_t > bc;
-      const auto& v = g_inputdeck.get< tag::param, eq, bctag >();
+      const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, bctag >();
       if (v.size() > c) bc = v[c];
       return bc;
     }
@@ -562,12 +562,6 @@ class CompFlow {
       return v;
     }
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    void side( std::unordered_set< int >& conf ) const
-    { m_problem.side( conf ); }
-
     //! Return field names to be output to file
     //! \return Vector of strings labelling fields output in file
     std::vector< std::string > fieldNames() const
@@ -837,8 +831,8 @@ class CompFlow {
                     tk::real, tk::real, tk::real, tk::real,
                     const std::array< tk::real, 3 >& )
     {
-      auto fp =
-        g_inputdeck.get< tag::param, eq, tag::farfield_pressure >()[ system ];
+      using tag::param; using tag::bc; using tag::farfield_pressure;
+      auto fp = g_inputdeck.get< param, eq, farfield_pressure >()[ system ];
 
       auto ur = ul;
       auto u_l = ul[1] / ul[0];

--- a/src/PDE/CompFlow/Problem.hpp
+++ b/src/PDE/CompFlow/Problem.hpp
@@ -34,9 +34,6 @@
     - Must define the static function _src()_, used for adding source terms to
       the righ hand side.
 
-    - Must define the function _side()_,  used to query all side set IDs
-      the user has configured for all components.
-
     - Must define the function _dirbc()_,  used to query Dirichlet
       boundary condition value on a given side set for all components in the PDE
       system.

--- a/src/PDE/CompFlow/Problem/GaussHumpCompflow.cpp
+++ b/src/PDE/CompFlow/Problem/GaussHumpCompflow.cpp
@@ -108,37 +108,6 @@ CompFlowProblemGaussHump::src( ncomp_t, ncomp_t, tk::real,
   return {{ 0.0, 0.0, 0.0, 0.0, 0.0 }};
 }
 
-void
-CompFlowProblemGaussHump::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcinlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsubsonicoutlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemGaussHump::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/GaussHumpCompflow.hpp
+++ b/src/PDE/CompFlow/Problem/GaussHumpCompflow.hpp
@@ -48,10 +48,6 @@ class CompFlowProblemGaussHump {
     static tk::SrcFn::result_type
     src( ncomp_t system, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/NLEnergyGrowth.cpp
+++ b/src/PDE/CompFlow/Problem/NLEnergyGrowth.cpp
@@ -190,21 +190,6 @@ CompFlowProblemNLEnergyGrowth::src( ncomp_t system, ncomp_t ncomp, tk::real x,
   return r;
 }
 
-void
-CompFlowProblemNLEnergyGrowth::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemNLEnergyGrowth::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/NLEnergyGrowth.hpp
+++ b/src/PDE/CompFlow/Problem/NLEnergyGrowth.hpp
@@ -60,10 +60,6 @@ class CompFlowProblemNLEnergyGrowth {
     src( ncomp_t system, ncomp_t ncomp, tk::real x, tk::real y, tk::real z,
          tk::real t );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/RayleighTaylor.cpp
+++ b/src/PDE/CompFlow/Problem/RayleighTaylor.cpp
@@ -177,21 +177,6 @@ CompFlowProblemRayleighTaylor::src( ncomp_t system, ncomp_t ncomp, tk::real x,
   return r;
 }
 
-void
-CompFlowProblemRayleighTaylor::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemRayleighTaylor::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/RayleighTaylor.hpp
+++ b/src/PDE/CompFlow/Problem/RayleighTaylor.hpp
@@ -52,10 +52,6 @@ class CompFlowProblemRayleighTaylor {
     src( ncomp_t system, ncomp_t ncomp, tk::real x, tk::real y, tk::real z,
          tk::real t );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/SedovBlastwave.cpp
+++ b/src/PDE/CompFlow/Problem/SedovBlastwave.cpp
@@ -113,23 +113,6 @@ CompFlowProblemSedovBlastwave::src( ncomp_t, ncomp_t, tk::real,
   return {{ 0.0, 0.0, 0.0, 0.0, 0.0 }};
 }
 
-void
-CompFlowProblemSedovBlastwave::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemSedovBlastwave::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/SedovBlastwave.hpp
+++ b/src/PDE/CompFlow/Problem/SedovBlastwave.hpp
@@ -48,10 +48,6 @@ class CompFlowProblemSedovBlastwave {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/SodShocktube.cpp
+++ b/src/PDE/CompFlow/Problem/SodShocktube.cpp
@@ -114,26 +114,6 @@ CompFlowProblemSodShocktube::src( ncomp_t, ncomp_t, tk::real,
   return {{ 0.0, 0.0, 0.0, 0.0, 0.0 }};
 }
 
-void
-CompFlowProblemSodShocktube::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcdir >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemSodShocktube::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/SodShocktube.hpp
+++ b/src/PDE/CompFlow/Problem/SodShocktube.hpp
@@ -50,10 +50,6 @@ class CompFlowProblemSodShocktube {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/TaylorGreen.cpp
+++ b/src/PDE/CompFlow/Problem/TaylorGreen.cpp
@@ -88,21 +88,6 @@ CompFlowProblemTaylorGreen::src( ncomp_t, ncomp_t, tk::real x,
                    cos(3.0*M_PI*y)*cos(M_PI*x) ) }};
 }
 
-void
-CompFlowProblemTaylorGreen::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemTaylorGreen::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/TaylorGreen.hpp
+++ b/src/PDE/CompFlow/Problem/TaylorGreen.hpp
@@ -54,10 +54,6 @@ class CompFlowProblemTaylorGreen {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real x, tk::real y, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/CompFlow/Problem/UserDefined.cpp
+++ b/src/PDE/CompFlow/Problem/UserDefined.cpp
@@ -68,20 +68,6 @@ CompFlowProblemUserDefined::src( ncomp_t, ncomp_t, tk::real,
   return {{ 0.0, 0.0, 0.0, 0.0, 0.0 }};
 }
 
-void
-CompFlowProblemUserDefined::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    conf.insert( std::stoi(s[0]) );
-}
-
 std::vector< std::string >
 CompFlowProblemUserDefined::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/UserDefined.hpp
+++ b/src/PDE/CompFlow/Problem/UserDefined.hpp
@@ -51,10 +51,6 @@ class CompFlowProblemUserDefined {
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field output going to file
     std::vector< std::vector< tk::real > >
     fieldOutput( ncomp_t,

--- a/src/PDE/CompFlow/Problem/VorticalFlow.cpp
+++ b/src/PDE/CompFlow/Problem/VorticalFlow.cpp
@@ -115,21 +115,6 @@ CompFlowProblemVorticalFlow::src( ncomp_t system, ncomp_t ncomp, tk::real x,
   return r;
 }
 
-void
-CompFlowProblemVorticalFlow::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::compflow; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, compflow, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 CompFlowProblemVorticalFlow::fieldNames( ncomp_t ) const
 // *****************************************************************************

--- a/src/PDE/CompFlow/Problem/VorticalFlow.hpp
+++ b/src/PDE/CompFlow/Problem/VorticalFlow.hpp
@@ -54,10 +54,6 @@ class CompFlowProblemVorticalFlow {
     src( ncomp_t system, ncomp_t ncomp, tk::real x, tk::real y, tk::real z,
          tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Return field names to be output to file
     std::vector< std::string > fieldNames( ncomp_t ) const;
 

--- a/src/PDE/ConfigureTransport.cpp
+++ b/src/PDE/ConfigureTransport.cpp
@@ -67,6 +67,9 @@ infoTransport( std::map< ctr::PDEType, tk::ctr::ncomp_t >& cnt )
 //! \return vector of string pairs describing the PDE configuration
 // *****************************************************************************
 {
+  using tag::param;
+  using tag::transport;
+
   auto c = ++cnt[ ctr::PDEType::TRANSPORT ];       // count eqs
   --c;  // used to index vectors starting with 0
 
@@ -75,60 +78,60 @@ infoTransport( std::map< ctr::PDEType, tk::ctr::ncomp_t >& cnt )
   nfo.emplace_back( ctr::PDE().name( ctr::PDEType::TRANSPORT ), "" );
 
   nfo.emplace_back( "dependent variable", std::string( 1,
-    g_inputdeck.get< tag::param, tag::transport, tag::depvar >()[c] ) );
+    g_inputdeck.get< param, transport, tag::depvar >()[c] ) );
 
   nfo.emplace_back( "problem", ctr::Problem().name(
-    g_inputdeck.get< tag::param, tag::transport, tag::problem >()[c] ) );
+    g_inputdeck.get< param, transport, tag::problem >()[c] ) );
 
   nfo.emplace_back( "start offset in unknowns array", std::to_string(
-    g_inputdeck.get< tag::component >().offset< tag::transport >(c) ) );
+    g_inputdeck.get< tag::component >().offset< transport >(c) ) );
 
-  auto ncomp = g_inputdeck.get< tag::component >().get< tag::transport >()[c];
+  auto ncomp = g_inputdeck.get< tag::component >().get< transport >()[c];
   nfo.emplace_back( "number of components", std::to_string( ncomp ) );
 
   const auto& diff =
-     g_inputdeck.get< tag::param, tag::transport, tag::diffusivity >();
+     g_inputdeck.get< param, transport, tag::diffusivity >();
   if (diff.size() > c)
     nfo.emplace_back( "coeff diffusivity [" + std::to_string( ncomp ) + "]",
                        parameters( diff[c] ) );
 
-  const auto& u0 = g_inputdeck.get< tag::param, tag::transport, tag::u0 >();
+  const auto& u0 = g_inputdeck.get< param, transport, tag::u0 >();
   if (u0.size() > c)
     nfo.emplace_back( "coeff u0 [" + std::to_string( ncomp ) + "]",
                        parameters( u0[c] ) );
 
   const auto& lambda =
-    g_inputdeck.get< tag::param, tag::transport, tag::lambda >();
+    g_inputdeck.get< param, transport, tag::lambda >();
   if (lambda.size() > c)
     nfo.emplace_back( "coeff lambda [" + std::to_string( ncomp ) + "]",
       parameters( lambda[c] ) );
 
   const auto& bcdir =
-    g_inputdeck.get< tag::param, tag::transport, tag::bcdir >();
+    g_inputdeck.get< param, transport, tag::bc, tag::bcdir >();
   if (bcdir.size() > c)
     nfo.emplace_back( "Dirichlet boundary [" + std::to_string( ncomp ) + "]",
       parameters( bcdir[c] ) );
 
   const auto& bcsym =
-    g_inputdeck.get< tag::param, tag::transport, tag::bcsym >();
+    g_inputdeck.get< param, transport, tag::bc, tag::bcsym >();
   if (bcsym.size() > c)
     nfo.emplace_back( "Symmetry boundary [" + std::to_string( ncomp ) + "]",
       parameters( bcsym[c] ) );
 
   const auto& bcinlet =
-    g_inputdeck.get< tag::param, tag::transport, tag::bcinlet >();
+    g_inputdeck.get< param, transport, tag::bc, tag::bcinlet >();
   if (bcinlet.size() > c)
     nfo.emplace_back( "Inlet boundary [" + std::to_string( ncomp ) + "]",
       parameters( bcinlet[c] ) );
 
   const auto& bcoutlet =
-    g_inputdeck.get< tag::param, tag::transport, tag::bcoutlet >();
+    g_inputdeck.get< param, transport, tag::bc, tag::bcoutlet >();
   if (bcoutlet.size() > c)
     nfo.emplace_back( "Outlet boundary [" + std::to_string( ncomp ) + "]",
       parameters( bcoutlet[c] ) );
 
   const auto& bcextrapolate =
-    g_inputdeck.get< tag::param, tag::transport, tag::bcextrapolate >();
+    g_inputdeck.get< param, transport, tag::bc, tag::bcextrapolate >();
   if (bcextrapolate.size() > c)
     nfo.emplace_back( "Symmetry boundary [" + std::to_string( ncomp ) + "]",
       parameters( bcextrapolate[c] ) );

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -157,10 +157,6 @@ class DGPDE {
                  const std::size_t nielem ) const
     { return self->dt( coord, inpoel, fd, geoFace, geoElem, ndofel, U, P, nielem ); }
 
-    //! \brief Public interface for collecting all side set IDs the user has
-    //!   configured for all components of a PDE system
-    void side( std::unordered_set< int >& conf ) const { self->side( conf ); }
-
     //! Public interface to returning field output labels
     std::vector< std::string > fieldNames() const { return self->fieldNames(); }
 
@@ -252,7 +248,6 @@ class DGPDE {
                            const tk::Fields&,
                            const tk::Fields&,
                            const std::size_t ) const = 0;
-      virtual void side( std::unordered_set< int >& conf ) const = 0;
       virtual std::vector< std::string > fieldNames() const = 0;
       virtual std::vector< std::string > names() const = 0;
       virtual std::vector< std::vector< tk::real > > fieldOutput(
@@ -335,8 +330,6 @@ class DGPDE {
                    const tk::Fields& P,
                    const std::size_t nielem ) const override
       { return data.dt( coord, inpoel, fd, geoFace, geoElem, ndofel, U, P, nielem ); }
-      void side( std::unordered_set< int >& conf ) const override
-      { data.side( conf ); }
       std::vector< std::string > fieldNames() const override
       { return data.fieldNames(); }
       std::vector< std::string > names() const override

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -74,7 +74,7 @@ class MultiMat {
     std::vector< bcconf_t >
     config( ncomp_t c ) {
       std::vector< bcconf_t > bc;
-      const auto& v = g_inputdeck.get< tag::param, eq, bctag >();
+      const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, bctag >();
       if (v.size() > c) bc = v[c];
       return bc;
     }
@@ -677,12 +677,6 @@ class MultiMat {
                       []( tk::real s, tk::real& d ){ return d /= s; } );
       return v;
     }
-
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    void side( std::unordered_set< int >& conf ) const
-    { Problem::side( conf ); }
 
     //! Return field names to be output to file
     //! \return Vector of strings labelling fields output in file

--- a/src/PDE/MultiMat/Problem.hpp
+++ b/src/PDE/MultiMat/Problem.hpp
@@ -34,9 +34,6 @@
     - Must define the static function _src()_, used for adding source terms to
       the righ hand side.
 
-    - Must define the static function _side()_,  used to query all side set IDs
-      the user has configured for all components.
-
     - Must define the static function _dirbc()_,  used to query Dirichlet
       boundary condition value on a given side set for all components in the PDE
       system.

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
@@ -152,26 +152,6 @@ MultiMatProblemInterfaceAdvection::src( ncomp_t, ncomp_t ncomp, tk::real,
   return s;
 }
 
-void
-MultiMatProblemInterfaceAdvection::side( std::unordered_set< int >& conf )
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcdir >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 MultiMatProblemInterfaceAdvection::fieldNames( ncomp_t )
 // *****************************************************************************

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.hpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.hpp
@@ -65,10 +65,6 @@ class MultiMatProblemInterfaceAdvection {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t ncomp, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    static void side( std::unordered_set< int >& conf );
-
     //! Return field names to be output to file
     static std::vector< std::string > fieldNames( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/SodShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.cpp
@@ -136,23 +136,6 @@ MultiMatProblemSodShocktube::src( ncomp_t, ncomp_t ncomp, tk::real,
   return s;
 }
 
-void
-MultiMatProblemSodShocktube::side( std::unordered_set< int >& conf )
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 MultiMatProblemSodShocktube::fieldNames( ncomp_t )
 // *****************************************************************************

--- a/src/PDE/MultiMat/Problem/SodShocktube.hpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.hpp
@@ -51,10 +51,6 @@ class MultiMatProblemSodShocktube {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t ncomp, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    static void side( std::unordered_set< int >& conf );
-
     //! Return field names to be output to file
     static std::vector< std::string > fieldNames( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/UserDefined.hpp
+++ b/src/PDE/MultiMat/Problem/UserDefined.hpp
@@ -89,15 +89,6 @@ class MultiMatProblemUserDefined {
       return n;
     }
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    static void side( std::unordered_set< int >& conf ) {
-      using tag::param; using tag::compflow; using tag::bcdir;
-      for (const auto& s : g_inputdeck.get< param, compflow, bcdir >())
-        conf.insert( std::stoi(s[0]) );
-    }
-
     //! Return field output going to file
     //! \param[in] offset System offset specifying the position of the system of
     //!   PDEs among other systems

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
@@ -138,23 +138,6 @@ MultiMatProblemWaterAirShocktube::src( ncomp_t, ncomp_t ncomp, tk::real,
   return s;
 }
 
-void
-MultiMatProblemWaterAirShocktube::side( std::unordered_set< int >& conf )
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcsym >())
-    for (const auto& i : s) conf.insert( std::stoi(i) );
-}
-
 std::vector< std::string >
 MultiMatProblemWaterAirShocktube::fieldNames( ncomp_t )
 // *****************************************************************************

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.hpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.hpp
@@ -52,10 +52,6 @@ class MultiMatProblemWaterAirShocktube {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    static void side( std::unordered_set< int >& conf );
-
     //! Return field names to be output to file
     static std::vector< std::string > fieldNames( ncomp_t );
 

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -292,12 +292,6 @@ class Transport {
       return mindt;
     }
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    void side( std::unordered_set< int >& conf ) const
-    { m_problem.side( conf ); }
-
     //! \brief Query Dirichlet boundary condition value on a given side set for
     //!    all components in this PDE system
     //! \param[in] t Physical time
@@ -318,7 +312,7 @@ class Transport {
       using tag::param; using tag::transport; using tag::bcdir;
       using NodeBC = std::vector< std::pair< bool, tk::real > >;
       std::map< std::size_t, NodeBC > bc;
-      const auto& ubc = g_inputdeck.get< param, transport, bcdir >();
+      const auto& ubc = g_inputdeck.get< param, transport, tag::bc, bcdir >();
       if (!ubc.empty()) {
         Assert( ubc.size() > m_system, "Indexing out of Dirichlet BC eq-vector" );
         const auto& x = coord[0];

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -69,7 +69,7 @@ class Transport {
     std::vector< bcconf_t >
     config( ncomp_t c ) {
       std::vector< bcconf_t > bc;
-      const auto& v = g_inputdeck.get< tag::param, eq, bctag >();
+      const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, bctag >();
       if (v.size() > c) bc = v[c];
       return bc;
     }
@@ -315,12 +315,6 @@ class Transport {
       tk::real mindt = std::numeric_limits< tk::real >::max();
       return mindt;
     }
-
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    //! \param[in,out] conf Set of unique side set IDs to add to
-    void side( std::unordered_set< int >& conf ) const
-    { m_problem.side( conf ); }
 
     //! Return field names to be output to file
     //! \return Vector of strings labelling fields output in file

--- a/src/PDE/Transport/Problem.hpp
+++ b/src/PDE/Transport/Problem.hpp
@@ -30,9 +30,6 @@
     - Must define the function _solinc()_, used to evaluate the
       increment from t to t+dt of the analytic solution (if defined).
 
-    - Must define the function _side()_,  used to query all side set IDs
-      the user has configured for all components.
-  
     - Must define the static function _prescribedVelocity()_, used to query the
       prescribed velocity at a point.
 */

--- a/src/PDE/Transport/Problem/CylAdvect.cpp
+++ b/src/PDE/Transport/Problem/CylAdvect.cpp
@@ -83,33 +83,6 @@ const
   return st2;
 }
 
-void
-TransportProblemCylAdvect::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcinlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcoutlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::array< tk::real, 3 > >
 TransportProblemCylAdvect::prescribedVelocity( ncomp_t, ncomp_t ncomp, tk::real,
                                                tk::real, tk::real )

--- a/src/PDE/Transport/Problem/CylAdvect.hpp
+++ b/src/PDE/Transport/Problem/CylAdvect.hpp
@@ -47,10 +47,6 @@ class TransportProblemCylAdvect {
     //! Do error checking on PDE parameters
     void errchk( ncomp_t, ncomp_t ) const {}
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Assign prescribed velocity at a point
     static std::vector< std::array< tk::real, 3 > >
     prescribedVelocity( ncomp_t, ncomp_t ncomp, tk::real, tk::real, tk::real );

--- a/src/PDE/Transport/Problem/GaussHump.cpp
+++ b/src/PDE/Transport/Problem/GaussHump.cpp
@@ -79,33 +79,6 @@ const
   return st2;
 }
 
-void
-TransportProblemGaussHump::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param;
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcinlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcoutlet >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcextrapolate >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-
-  for (const auto& s : g_inputdeck.get< param, eq, tag::bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::array< tk::real, 3 > >
 TransportProblemGaussHump::prescribedVelocity( ncomp_t, ncomp_t ncomp, tk::real,
                                                tk::real, tk::real )

--- a/src/PDE/Transport/Problem/GaussHump.hpp
+++ b/src/PDE/Transport/Problem/GaussHump.hpp
@@ -47,10 +47,6 @@ class TransportProblemGaussHump {
     //! Do error checking on PDE parameters
     void errchk( ncomp_t, ncomp_t ) const {}
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Assign prescribed velocity at a point
     static std::vector< std::array< tk::real, 3 > >
     prescribedVelocity( ncomp_t,

--- a/src/PDE/Transport/Problem/ShearDiff.cpp
+++ b/src/PDE/Transport/Problem/ShearDiff.cpp
@@ -116,21 +116,6 @@ TransportProblemShearDiff::errchk( ncomp_t system, ncomp_t ncomp ) const
     "Wrong number of advection-diffusion PDE parameters 'diffusivity'" );
 }
 
-void
-TransportProblemShearDiff::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::array< tk::real, 3 > >
 TransportProblemShearDiff::prescribedVelocity( ncomp_t system, ncomp_t ncomp,
                                               tk::real, tk::real y, tk::real z )

--- a/src/PDE/Transport/Problem/ShearDiff.hpp
+++ b/src/PDE/Transport/Problem/ShearDiff.hpp
@@ -81,10 +81,6 @@ class TransportProblemShearDiff {
     //! Do error checking on PDE parameters
     void errchk( ncomp_t system, ncomp_t ncomp ) const;
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Assign prescribed shear velocity at a point
     static std::vector< std::array< tk::real, 3 > >
     prescribedVelocity( ncomp_t system,

--- a/src/PDE/Transport/Problem/SlotCyl.cpp
+++ b/src/PDE/Transport/Problem/SlotCyl.cpp
@@ -134,21 +134,6 @@ const
   return st2;
 }
 
-void
-TransportProblemSlotCyl::side( std::unordered_set< int >& conf ) const
-// *****************************************************************************
-//  Query all side set IDs the user has configured for all components in this
-//  PDE system
-//! \param[in,out] conf Set of unique side set IDs to add to
-// *****************************************************************************
-{
-  using tag::param; using tag::bcdir;
-
-  for (const auto& s : g_inputdeck.get< param, eq, bcdir >())
-    for (const auto& i : s)
-      conf.insert( std::stoi(i) );
-}
-
 std::vector< std::array< tk::real, 3 > >
 TransportProblemSlotCyl::prescribedVelocity( ncomp_t, ncomp_t ncomp,
                                              tk::real x, tk::real y, tk::real )

--- a/src/PDE/Transport/Problem/SlotCyl.hpp
+++ b/src/PDE/Transport/Problem/SlotCyl.hpp
@@ -52,10 +52,6 @@ class TransportProblemSlotCyl {
     //! Do error checking on PDE parameters
     void errchk( ncomp_t, ncomp_t ) const {}
 
-    //! \brief Query all side set IDs the user has configured for all components
-    //!   in this PDE system
-    void side( std::unordered_set< int >& conf ) const;
-
     //! Assign prescribed velocity at a point
     static std::vector< std::array< tk::real, 3 > >
     prescribedVelocity( ncomp_t,


### PR DESCRIPTION
In Control/Inciter/Types.hpp all the boundary condition (BC) types, behind which the parser stores the side set ids used to set boundary conditions, are now grouped together and this single group is reused in all PDE types.  This also means that all types boundary conditions now have storage for all PDE types and all of their BC types if the corresponding grammar block chooses to parse them.

Transporter::matchBCs() now loops over the Cartesian product of all PDE types and all BCs types, querying the BCs the user configured during parsing and matching side ids that exist in the mesh file used, and thus compiles a unique set of side set ids, which is then processed further later. Previously, this match step was done by calling the member function, side(), in each PDE type and in turn each Problem they were templated on. However, while specifying Problem::side(), as previously was done, allows Problem-specific querying of the BC side sets, this has turned out to be more of a bug than a feature, because it allowed forgetting the querying of a particular BC type for a given Problem (and PDE type), and resulted in situations where, e.g., new BC was added with storage, grammar, code for using it, yet query code was easily forgotten (down in the depth of the Problem class) and thus even though the input mesh did have the side set and the parser did correctly parse the BC configuration, Transporter::matchBCs() could still ignore the BC because its query code was easily forgotten. This resulted in the PDE and the Problem type being blind to the correctly configured BC type. See also #347.

The above scenario is now made impossible by executing the BC query code, matching the user configuration parsed and the side sets found in the input mesh file, for every PDE type, e.g., Transport, CompFlow, MultiMat, and for their every BC type, Dirichlet, symmetry, etc.

The implementation of Transporter::matchBCs() now has also been moved to the Transporter.cpp, since it does not have to be templated on the equation type, as it now loops over all equations and all BC types.

This, of course, removes all the error-prone side() member functions from all Problem and the calling PDE types.

Also use type aliases for code shortening at some places.

This resolves #347.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/372)
<!-- Reviewable:end -->
