### PR TITLE
Save screen output as log into a file

### DIFF
--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -18,14 +18,11 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
-#include <list>
 #include <cmath>
 #include <array>
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
-
-#include <brigand/algorithms/for_each.hpp>
 
 #include "NoWarning/format.hpp"
 
@@ -34,6 +31,7 @@
 #include "Has.hpp"
 #include "ChareState.hpp"
 #include "StrConvUtil.hpp"
+#include "TeeBuf.hpp"
 
 namespace tk {
 
@@ -48,25 +46,35 @@ class Print {
 
   public:
     //! Constructor: Quiet output by default, only stuff written to qstr shown.
-    //! Instantiate with str = std::cout for verbose output. Any member function
-    //! can be called by overriding the default stream via the template
-    //! argument, Style, a C-style enum. Note: By default, str == std::clog.
-    //! This is used to initialize str to a local stringstream into which all
-    //! verbose output goes by default, i.e., it will not be shown. This
-    //! solution is chosen instead of trickery with null-streams, as
-    //! boost:formatted output into null-streams caused invalid reads in
-    //! valgrind. This way quiet output (formatted or not) simply goes into a
-    //! local stringstream. In other words, the default argument to str,
-    //! std::clog, is only used to detect whether client code passed a default
-    //! argument or not: if it did not, the string stream is used for verbose
-    //! output, if it did, the specified stream is used for the verbose output.
+    //! \details Instantiate with str = std::cout for verbose output. Any
+    //  member function can be called by overriding the default stream via the
+    //  template argument, Style, a C-style enum. Note: By default, str ==
+    //  std::clog.  This is used to initialize str to a local stringstream into
+    //  which all verbose output goes by default, i.e., it will not be shown.
+    //  This solution is chosen instead of trickery with null-streams, as
+    //  boost:formatted output into null-streams caused invalid reads in
+    //  valgrind. This way quiet output (formatted or not) simply goes into a
+    //  local stringstream. In other words, the default argument to str,
+    //  std::clog, is only used to detect whether client code passed a default
+    //  argument or not: if it did not, the string stream is used for verbose
+    //  output, if it did, the specified stream is used for the verbose output.
+    //! \param[in] screen Screen output filename. If an empty string is passed,
+    //!   it is assumed that client code does not want to save the stream into
+    //!   a file.
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
-    explicit Print( std::ostream& str = std::clog,
+    explicit Print( const std::string& screen = {},
+                    std::ostream& str = std::clog,
+                    std::ios_base::openmode mode = std::ios_base::out,
                     std::ostream& qstr = std::cout ) :
       m_null(),
       m_stream( str.rdbuf() == std::clog.rdbuf() ? m_null : str ),
-      m_qstream( qstr ) {}
+      m_qstream( qstr ),
+      m_file( screen, mode ),
+      m_tee(m_file.rdbuf(), screen.empty() ? m_file.rdbuf() : m_stream.rdbuf()),
+      m_ssa( screen.empty() ? m_file : m_stream, &m_tee ) {}
 
     //! Save pointer to stream. This function, used in conjunction with reset(),
     //! can be used to pass streams around. This is not possible in general,
@@ -333,7 +341,8 @@ class Print {
     void diagend( const std::string& msg ) const
     { stream<s>() << m_diag_end_fmt % msg << std::flush; }
 
-    //! ...
+    //! Print chare state collected
+    //! \param[in] state State map to print
     template< Style s = VERBOSE >
     void charestate( const std::unordered_map< int,
                         std::vector< ChareState > >& state ) const
@@ -480,7 +489,7 @@ class Print {
     }
 
     //! \brief Formatted print of verbose help on a single command-line
-    //!   parameter or control file keywords
+    //!   parameter or control file keyword
     //! \param[in] executable Name of executable to output help for
     //! \param[in] kw Keyword help struct on which help is to be printed
     template< Style s = VERBOSE, class HelpKw >
@@ -800,6 +809,11 @@ class Print {
     std::stringstream m_null;   //!< Default verbose stream
     std::ostream& m_stream;     //!< Verbose stream
     std::ostream& m_qstream;    //!< Quiet stream
+
+  private:
+    std::ofstream m_file;       //!< File stream to save verbose stream in
+    tk::teebuf m_tee;           //!< Used to tie m_stream and m_file
+    tk::scoped_streambuf_assignment m_ssa;
 };
 
 } // tk::

--- a/src/Base/TeeBuf.hpp
+++ b/src/Base/TeeBuf.hpp
@@ -1,0 +1,119 @@
+// *****************************************************************************
+/*!
+  \file      src/Base/TeeBuf.hpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Tee stream buffer
+  \details   Tee stream buffer that can be used to duplicate a stream. Example:
+    \code{.cpp}
+      // createa a file
+      std::ofstream file( "data.txt" );
+      // tbuf will write to both file and cout
+      teebuf tbuf( file.rdbuf(), std::cout.rdbuf() );
+      // replace cout's streambuf with tbuf
+      scoped_streambuf_assignment ssa( std::cout, &tbuf );
+      // write to both std::cout and data.txt
+      std::cout << "Hello World" << std::endl;
+   \endcode
+*/
+// *****************************************************************************
+#ifndef Tee_h
+#define Tee_h
+
+#include <iostream>
+#include <streambuf>
+#include <fstream>
+#include <memory>
+
+namespace tk {
+
+template< class charT, class traits = std::char_traits<charT> >
+class basic_teebuf : public std::basic_streambuf< charT, traits > {
+
+  public:
+    using char_type = charT;
+    using int_type = typename traits::int_type;
+    using pos_type = typename traits::pos_type;
+    using off_type = typename traits::off_type;
+    using traits_type = traits;
+    using streambuf_type = std::basic_streambuf< charT, traits >;
+
+  private:
+    streambuf_type* m_sbuf1;
+    streambuf_type* m_sbuf2;
+    std::unique_ptr< char_type[] > m_buffer;
+
+    enum { BUFFER_SIZE = 4096 / sizeof( char_type ) };
+
+  public:
+    basic_teebuf( streambuf_type *sbuf1, streambuf_type *sbuf2 )
+      : m_sbuf1( sbuf1 ), m_sbuf2( sbuf2 ),
+        m_buffer( std::make_unique< char_type[] >( BUFFER_SIZE ) )
+    { this->setp( m_buffer.get(), m_buffer.get() + BUFFER_SIZE ); }
+
+    ~basic_teebuf() {
+      this->pubsync();
+    }
+
+  protected:
+    virtual int_type overflow( int_type c = traits_type::eof() ) {
+      // empty our buffer into m_sbuf1 and m_sbuf2
+      std::streamsize n =
+        static_cast< std::streamsize >( this->pptr() - this->pbase() );
+      std::streamsize size1 = m_sbuf1->sputn( this->pbase(), n );
+      std::streamsize size2 = m_sbuf2->sputn( this->pbase(), n );
+      if ( size1 != n || size2 != n ) return traits_type::eof();
+
+      // reset our buffer
+      this->setp( m_buffer.get(), m_buffer.get() + BUFFER_SIZE );
+
+      // write the passed character if necessary
+      if ( !traits_type::eq_int_type(c, traits_type::eof()) ) {
+        traits_type::assign( *this->pptr(), traits_type::to_char_type(c) );
+        this->pbump(1);
+      }
+
+      return traits_type::not_eof(c);
+    }
+
+    virtual int sync() {
+      // flush our buffer into m_sbuf1 and m_sbuf2
+      int_type c = this->overflow(traits_type::eof());
+
+      // checking return for eof.
+      if (traits_type::eq_int_type(c, traits_type::eof()))
+          return -1;
+
+      // flush m_sbuf1 and m_sbuf2
+      if (m_sbuf1->pubsync() == -1 || m_sbuf2->pubsync() == -1)
+          return -1;
+
+      return 0;
+    }
+};
+
+using teebuf = basic_teebuf< char >;
+using wteebuf = basic_teebuf< wchar_t >;
+
+template< class charT, class traits = std::char_traits< charT > >
+struct scoped_basic_streambuf_assignment {
+  using stream_type = std::basic_ios< charT, traits >;
+  using streambuf_type = std::basic_streambuf< charT, traits >;
+
+  stream_type& m_s;
+  streambuf_type* m_orig_sb;
+
+  scoped_basic_streambuf_assignment( stream_type &s, streambuf_type *new_sb )
+    : m_s(s) { m_orig_sb = m_s.rdbuf( new_sb ); }
+
+  ~scoped_basic_streambuf_assignment() { m_s.rdbuf( m_orig_sb ); }
+};
+
+using scoped_streambuf_assignment = scoped_basic_streambuf_assignment<char>;
+using scoped_wstreambuf_assignment = scoped_basic_streambuf_assignment<wchar_t>;
+
+} // tk::
+
+#endif // TeeBuf_h

--- a/src/Control/FileConv/Types.hpp
+++ b/src/Control/FileConv/Types.hpp
@@ -26,8 +26,8 @@ using namespace tao;
 
 //! IO parameters storage
 using ios = tk::TaggedTuple< brigand::list<
-    tag::input,           std::string     //!< Input filename
-  , tag::output,          std::string     //!< Output filename
+    tag::input,  std::string   //!< Input filename
+  , tag::output, std::string   //!< Output filename
 > >;
 
 //! PEGTL location/position type to use throughout all of MeshConv's parsers

--- a/src/Control/Inciter/Types.hpp
+++ b/src/Control/Inciter/Types.hpp
@@ -46,17 +46,17 @@ using selects = tk::TaggedTuple< brigand::list<
 
 //! Adaptive-mesh refinement options
 using amr = tk::TaggedTuple< brigand::list<
-    tag::amr,     bool                             //!< AMR on/off
-  , tag::t0ref,   bool                             //!< AMR before t<0 on/off
-  , tag::dtref,   bool                             //!< AMR during t>0 on/off
-  , tag::dtref_uniform, bool                       //!< Force dtref uniform-only
+    tag::amr,     bool                            //!< AMR on/off
+  , tag::t0ref,   bool                            //!< AMR before t<0 on/off
+  , tag::dtref,   bool                            //!< AMR during t>0 on/off
+  , tag::dtref_uniform, bool                      //!< Force dtref uniform-only
   , tag::dtfreq,  kw::amr_dtfreq::info::expect::type //!< Refinement frequency
-  , tag::init,    std::vector< AMRInitialType >    //!< List of initial AMR types
-  , tag::refvar,  std::vector< std::string >       //!< List of refinement vars
-  , tag::id,      std::vector< std::size_t >       //!< List of refvar indices
-  , tag::error,   AMRErrorType                     //!< Error estimator for AMR
-  , tag::tolref,  tk::real                         //!< Refine tolerance
-  , tag::tolderef, tk::real                        //!< De-refine tolerance
+  , tag::init,    std::vector< AMRInitialType >   //!< List of initial AMR types
+  , tag::refvar,  std::vector< std::string >      //!< List of refinement vars
+  , tag::id,      std::vector< std::size_t >      //!< List of refvar indices
+  , tag::error,   AMRErrorType                    //!< Error estimator for AMR
+  , tag::tolref,  tk::real                        //!< Refine tolerance
+  , tag::tolderef, tk::real                       //!< De-refine tolerance
   //! List of edges-node pairs
   , tag::edge,    std::vector< kw::amr_edgelist::info::expect::type >
   //! Refinement tagging edges with end-point coordinates lower than x coord
@@ -119,12 +119,13 @@ using intervals = tk::TaggedTuple< brigand::list<
 
 //! IO parameters storage
 using ios = tk::TaggedTuple< brigand::list<
-    tag::control,     kw::control::info::expect::type //!< Control filename
-  , tag::input,       std::string                     //!< Input filename
-  , tag::output,      std::string                     //!< Output filename
-  , tag::diag,        std::string                     //!< Diagnostics filename
-  , tag::part,        std::string                     //!< Particles filename
-  , tag::restart,     std::string                     //!< Restart dirname
+    tag::control,   kw::control::info::expect::type //!< Control filename
+  , tag::input,     kw::input::info::expect::type   //!< Input filename
+  , tag::output,    kw::output::info::expect::type  //!< Output filename
+    //! Diagnostics filename
+  , tag::diag,      kw::diagnostics_cmd::info::expect::type
+  , tag::part,      std::string                     //!< Particles filename
+  , tag::restart,   std::string                     //!< Restart dirname
 > >;
 
 //! Error/diagnostics output configuration

--- a/src/Control/MeshConv/Types.hpp
+++ b/src/Control/MeshConv/Types.hpp
@@ -26,7 +26,7 @@ using namespace tao;
 
 //! IO parameters storage
 using ios = tk::TaggedTuple< brigand::list<
-    tag::input, std::string    //!< Input filename
+    tag::input,  std::string   //!< Input filename
   , tag::output, std::string   //!< Output filename
 > >;
 

--- a/src/Control/RNGTest/CmdLine/Grammar.hpp
+++ b/src/Control/RNGTest/CmdLine/Grammar.hpp
@@ -40,12 +40,13 @@ namespace cmd {
          tk::grm::process_cmd_switch< use, kw::charestate,
                                       tag::chare > {};
 
-  //! \brief Match and set control (i.e., input deck) file name
-  struct control :
-         tk::grm::process_cmd< use, kw::control,
-                               tk::grm::Store< tag::io, tag::control >,
+  //! \brief Match and set io parameter
+  template< typename keyword, typename io_tag >
+  struct io :
+         tk::grm::process_cmd< use, keyword,
+                               tk::grm::Store< tag::io, io_tag >,
                                pegtl::any,
-                               tag::io, tag::control > {};
+                               tag::io, io_tag > {};
 
   //! \brief Match help on control file keywords
   struct helpctr :
@@ -88,14 +89,14 @@ namespace cmd {
   struct keywords :
          pegtl::sor< verbose,
                      charestate,
-                     control,
                      help,
                      helpctr,
                      helpkw,
                      quiescence,
                      trace,
                      version,
-                     license > {};
+                     license,
+                     io< kw::control, tag::control > > {};
 
   //! \brief Grammar entry point: parse keywords until end of string
   struct read_string :

--- a/src/Control/RNGTest/Types.hpp
+++ b/src/Control/RNGTest/Types.hpp
@@ -38,7 +38,7 @@ using selects = tk::TaggedTuple< brigand::list<
 
 //! IO parameters storage
 using ios = tk::TaggedTuple< brigand::list<
-    tag::control,   std::string                  //!< Control filename
+    tag::control,  std::string   //!< Control filename
 > >;
 
 //! Parameters storage

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -12,20 +12,22 @@
 #ifndef Tags_h
 #define Tags_h
 
+#include <string>
+
 //! Tags used as unique-type labels for compile-time code-generation
 namespace tag {
 
 struct low {};
 struct high {};
-struct io {};
-struct quiescence {};
-struct trace {};
-struct version {};
-struct license {};
-struct input {};
-struct output {};
-struct restart {};
-struct diag {};
+struct io { static std::string name() { return "io"; } };
+struct quiescence { static std::string name() { return "quiescence"; } };
+struct trace { static std::string name() { return "trace"; } };
+struct version { static std::string name() { return "version"; } };
+struct license { static std::string name() { return "license"; } };
+struct input { static std::string name() { return "input"; } };
+struct output { static std::string name() { return "output"; } };
+struct restart { static std::string name() { return "restart"; } };
+struct diag { static std::string name() { return "diag"; } };
 struct evalLB {};
 struct seed {};
 struct uniform_method {};

--- a/src/Control/Walker/Types.hpp
+++ b/src/Control/Walker/Types.hpp
@@ -76,12 +76,12 @@ using intervals = tk::TaggedTuple< brigand::list<
 
 //! IO parameters storage
 using ios = tk::TaggedTuple< brigand::list<
-    tag::control,   kw::control::info::expect::type   //!< Control filename
-  , tag::input,     std::string                       //!< Input filename
-  , tag::output,    std::string                       //!< Output filename
-  , tag::pdf,       kw::pdf::info::expect::type       //!< PDF filename
-  , tag::stat,      kw::stat::info::expect::type      //!< Statistics filename
-  , tag::pdfnames,  std::vector< std::string >        //!< PDF identifiers
+    tag::control,   kw::control::info::expect::type //!< Control filename
+  , tag::input,     std::string                     //!< Input filename
+  , tag::output,    std::string                     //!< Output filename
+  , tag::pdf,       kw::pdf::info::expect::type     //!< PDF filename
+  , tag::stat,      kw::stat::info::expect::type    //!< Statistics filename
+  , tag::pdfnames,  std::vector< std::string >      //!< PDF identifiers
 > >;
 
 //! Data for initialization (SDE initial conditions)

--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -531,7 +531,9 @@ Discretization::status()
     auto grind_time = duration_cast< ms >( clock::now() - m_prevstatus ).count();
     m_prevstatus = clock::now();
 
-    tk::Print print( verbose ? std::cout : std::clog );
+    tk::Print print( tk::inciter_executable() + "_screen.log",
+                     verbose ? std::cout : std::clog,
+                     std::ios_base::app );
  
     // Output one-liner
     print << std::setfill(' ') << std::setw(8) << m_it << "  "

--- a/src/Inciter/Transporter.hpp
+++ b/src/Inciter/Transporter.hpp
@@ -131,28 +131,28 @@ class Transporter : public CBase_Transporter {
     void responded();
 
     //! Non-reduction target for receiving progress report on partitioning mesh
-    void pepartitioned() { m_progMesh.inc< PART >(); }
+    void pepartitioned() { m_progMesh.inc< PART >( printer() ); }
     //! Non-reduction target for receiving progress report on distributing mesh
-    void pedistributed() { m_progMesh.inc< DIST >(); }
+    void pedistributed() { m_progMesh.inc< DIST >( printer() ); }
     //! Non-reduction target for receiving progress report on finding bnd nodes
-    void chbnd() { m_progMesh.inc< BND >(); }
+    void chbnd() { m_progMesh.inc< BND >( printer() ); }
     //! Non-reduction target for receiving progress report on node ID comm map
-    void chcomm() { m_progMesh.inc< COMM >(); }
+    void chcomm() { m_progMesh.inc< COMM >( printer() ); }
     //! Non-reduction target for receiving progress report on node ID mask
-    void chmask() { m_progMesh.inc< MASK >(); }
+    void chmask() { m_progMesh.inc< MASK >( printer() ); }
     //! Non-reduction target for receiving progress report on reordering mesh
-    void chreordered() { m_progMesh.inc< REORD >(); }
+    void chreordered() { m_progMesh.inc< REORD >( printer() ); }
 
     //! Non-reduction target for receiving progress report on creating workers
-    void chcreated() { m_progWork.inc< CREATE >(); }
+    void chcreated() { m_progWork.inc< CREATE >( printer() ); }
     //! Non-reduction target for receiving progress report on finding bnd faces
-    void chbndface() { m_progWork.inc< BNDFACE >(); }
+    void chbndface() { m_progWork.inc< BNDFACE >( printer() ); }
     //! Non-reduction target for receiving progress report on face communication
-    void chcomfac() { m_progWork.inc< COMFAC >(); }
+    void chcomfac() { m_progWork.inc< COMFAC >( printer() ); }
     //! Non-reduction target for receiving progress report on sending ghost data
-    void chghost() { m_progWork.inc< GHOST >(); }
+    void chghost() { m_progWork.inc< GHOST >( printer() ); }
     //! Non-reduction target for receiving progress report on face adjacency
-    void chadj() { m_progWork.inc< ADJ >(); }
+    void chadj() { m_progWork.inc< ADJ >( printer() ); }
 
     //! Reduction target indicating that the communication maps have been setup
     void comfinal( int initial );
@@ -224,7 +224,6 @@ class Transporter : public CBase_Transporter {
     //@}
 
   private:
-    InciterPrint m_print;                //!< Pretty printer
     int m_nchare;                        //!< Number of worker chares
     std::size_t m_ncit;                  //!< Number of mesh ref corr iter
     std::size_t m_nt0refit;              //!< Number of (t<0) mesh ref iters
@@ -262,10 +261,10 @@ class Transporter : public CBase_Transporter {
     void diagHeader();
 
     //! Echo configuration to screen
-    void info();
+    void info( const InciterPrint& print );
 
     //! Print out time integration header to screen
-    void inthead();
+    void inthead( const InciterPrint& print );
 
     //! Echo diagnostics on mesh statistics
     void stat();
@@ -279,6 +278,14 @@ class Transporter : public CBase_Transporter {
     void varnames( const Eq& eq, std::vector< std::string >& var ) {
       auto o = eq.names();
       var.insert( end(var), begin(o), end(o) );
+    }
+
+    //! Create pretty printer specialized to Inciter
+    //! \return Pretty printer
+    InciterPrint printer() const { return
+      InciterPrint( tk::inciter_executable() + "_screen.log",
+        g_inputdeck.get< tag::cmd, tag::verbose >() ? std::cout : std::clog,
+        std::ios_base::app );
     }
 
     //! Function object for querying the side set ids the user configured

--- a/src/Main/FileConv.cpp
+++ b/src/Main/FileConv.cpp
@@ -80,15 +80,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create FileConv driver
       m_driver( tk::Main< fileconv::FileConvDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
 			  tk::HeaderType::FILECONV,
-			  tk::fileconv_executable(),
-			  m_print ) ),
+			  tk::fileconv_executable() ) ),
       m_timer(1),       // Start new timer measuring the total runtime
       m_timestamp()
     {
@@ -116,7 +113,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize() {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::fileconv_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ) );
     }
 
@@ -130,7 +128,7 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::fileconv_executable(), msg );
     }
 
     //! Add a time stamp contributing to final timers output
@@ -147,7 +145,6 @@ class Main : public CBase_Main {
     int m_signal;                               //!< Used to set signal handlers
     fileconv::ctr::CmdLine m_cmdline;           //!< Command line
     fileconv::CmdLineParser m_cmdParser;        //!< Command line parser
-    tk::Print m_print;                          //!< Pretty printer
     fileconv::FileConvDriver m_driver;          //!< Driver
     std::vector< tk::Timer > m_timer;           //!< Timers
 

--- a/src/Main/FileConvDriver.cpp
+++ b/src/Main/FileConvDriver.cpp
@@ -24,8 +24,7 @@ using fileconv::FileConvDriver;
 
 extern CProxy_Main mainProxy;
 
-FileConvDriver::FileConvDriver( const tk::Print&,
-                                const ctr::CmdLine& cmdline )
+FileConvDriver::FileConvDriver( const ctr::CmdLine& cmdline )
   : m_input(), m_output()
 // *****************************************************************************
 //  Constructor

--- a/src/Main/FileConvDriver.hpp
+++ b/src/Main/FileConvDriver.hpp
@@ -16,8 +16,6 @@
 
 #include "FileConv/CmdLine/CmdLine.hpp"
 
-namespace tk { class Print; }
-
 //! File converter declarations and definitions
 namespace fileconv {
 
@@ -26,14 +24,12 @@ class FileConvDriver {
 
   public:
     //! Constructor
-    explicit FileConvDriver( const tk::Print&,
-                             const ctr::CmdLine& cmdline );
+    explicit FileConvDriver( const ctr::CmdLine& cmdline );
 
     //! Execute
     void execute() const;
 
   private:
-
     std::string m_input;                //!< Input file name
     std::string m_output;               //!< Output file name
 };

--- a/src/Main/Inciter.cpp
+++ b/src/Main/Inciter.cpp
@@ -184,15 +184,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create Inciter driver
       m_driver( tk::Main< inciter::InciterDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
                           tk::HeaderType::INCITER,
-                          tk::inciter_executable(),
-                          m_print ) ),
+                          tk::inciter_executable() ) ),
       // Start new timer measuring the total runtime
       m_timer(1),
       m_timestamp()
@@ -220,14 +217,12 @@ class Main : public CBase_Main {
                    reinterpret_cast<CkArgMsg*>(msg)->argv,
                    tk::Print(),
                    m_cmdline ),
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       m_driver( tk::Main< inciter::InciterDriver >
                         ( reinterpret_cast<CkArgMsg*>(msg)->argc,
                           reinterpret_cast<CkArgMsg*>(msg)->argv,
                           m_cmdline,
                           tk::HeaderType::INCITER,
-                          tk::inciter_executable(),
-                          m_print ) ),
+                          tk::inciter_executable() ) ),
       m_timer(1),
       m_timestamp()
     {
@@ -246,7 +241,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize() {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::inciter_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ) );
     }
 
@@ -260,7 +256,7 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::inciter_executable(), msg );
     }
 
     /** @name Charm++ pack/unpack serializer member functions */
@@ -282,7 +278,6 @@ class Main : public CBase_Main {
     int m_signal;                               //!< Used to set signal handlers
     inciter::ctr::CmdLine m_cmdline;            //!< Command line
     inciter::CmdLineParser m_cmdParser;         //!< Command line parser
-    inciter::InciterPrint m_print;              //!< Pretty printer
     inciter::InciterDriver m_driver;            //!< Driver
     std::vector< tk::Timer > m_timer;           //!< Timers
     //! Time stamps in h:m:s with labels

--- a/src/Main/InciterDriver.cpp
+++ b/src/Main/InciterDriver.cpp
@@ -29,17 +29,19 @@ extern ctr::InputDeck g_inputdeck_defaults;
 
 using inciter::InciterDriver;
 
-InciterDriver::InciterDriver( const InciterPrint& print,
-                              const ctr::CmdLine& cmdline ) :
-  m_print( print )
+InciterDriver::InciterDriver( const ctr::CmdLine& cmdline )
 // *****************************************************************************
 //  Constructor
-//! \param[in] print Pretty printer
 //! \param[in] cmdline Command line object storing data parsed from the command
 //!   line arguments
 // *****************************************************************************
 {
   // All global-scope data to be migrated to all PEs initialized here (if any)
+
+  // Create pretty printer
+  InciterPrint print( tk::inciter_executable() + "_screen.log",
+                      cmdline.get< tag::verbose >() ? std::cout : std::clog,
+                      std::ios_base::app );
 
   print.item( "Non-blocking migration, -" + *kw::nonblocking::alias(),
                cmdline.get< tag::nonblocking >() ? "on" : "off" );
@@ -63,11 +65,11 @@ InciterDriver::InciterDriver( const InciterPrint& print,
                std::to_string(cmdline.get< tag::rsfreq >()) );
 
   // Parse input deck into g_inputdeck
-  m_print.item( "Control file", cmdline.get< tag::io, tag::control >() );
+  print.item( "Control file", cmdline.get< tag::io, tag::control >() );
   g_inputdeck = g_inputdeck_defaults;   // overwrite with defaults if restarted
-  InputDeckParser inputdeckParser( m_print, cmdline, g_inputdeck );
-  m_print.item( "Parsed control file", "success" );  
-  m_print.endpart();
+  InputDeckParser inputdeckParser( print, cmdline, g_inputdeck );
+  print.item( "Parsed control file", "success" );
+  print.endpart();
 }
 
 void

--- a/src/Main/InciterDriver.hpp
+++ b/src/Main/InciterDriver.hpp
@@ -23,14 +23,10 @@ class InciterDriver {
 
   public:
     //! Constructor
-    explicit InciterDriver( const InciterPrint& print,
-                            const ctr::CmdLine& cmdline );
+    explicit InciterDriver( const ctr::CmdLine& cmdline );
 
     //! Execute driver
     void execute() const;
-
-  private:
-    const InciterPrint& m_print;        //!< Pretty printer
 };
 
 } // inciter::

--- a/src/Main/InciterPrint.cpp
+++ b/src/Main/InciterPrint.cpp
@@ -66,7 +66,7 @@ InciterPrint::pdes( const std::string& t, const std::vector< std::vector<
 }
 
 void InciterPrint::refvar( const std::vector< std::string >& rvar,
-                           const std::vector< std::size_t >& refidx )
+                           const std::vector< std::size_t >& refidx ) const
 // *****************************************************************************
 // Print mesh refinement variables and their indices in the unknown vector
 //! \param[in] rvar Refinement variable name list
@@ -85,7 +85,7 @@ void InciterPrint::refvar( const std::vector< std::string >& rvar,
   item( name, c );
 }
 
-void InciterPrint::edgeref( const std::vector< std::size_t >& edgenodes )
+void InciterPrint::edgeref( const std::vector< std::size_t >& edgenodes ) const
 // *****************************************************************************
 // Print initial mesh refinement edge-node pairs
 // *****************************************************************************
@@ -99,7 +99,7 @@ void InciterPrint::edgeref( const std::vector< std::size_t >& edgenodes )
    item( name, c );
 }
 
-void InciterPrint::eqlegend()
+void InciterPrint::eqlegend() const
 // *****************************************************************************
 // Print PDE factory legend
 // *****************************************************************************

--- a/src/Main/InciterPrint.hpp
+++ b/src/Main/InciterPrint.hpp
@@ -35,12 +35,17 @@ class InciterPrint : public tk::Print {
 
   public:
     //! Constructor
+    //! \param[in] screen Screen output filename
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
     //! \see tk::RNGPrint::RNGPrint and tk::Print::Print
-    explicit InciterPrint( std::ostream& str = std::clog,
+    explicit InciterPrint( const std::string& screen,
+                           std::ostream& str = std::clog,
+                           std::ios_base::openmode mode = std::ios_base::out,
                            std::ostream& qstr = std::cout ) :
-      Print( str, qstr ) {}
+      Print( screen, str, mode, qstr ) {}
 
     //! Print control option: 'group : option'
     template< typename Option, typename... tags >
@@ -96,7 +101,7 @@ class InciterPrint : public tk::Print {
     };
 
     //! Print PDE factory legend
-    void eqlegend();
+    void eqlegend() const;
 
     //! Print equation list with policies
     //! \param[in] t Section title
@@ -137,10 +142,10 @@ class InciterPrint : public tk::Print {
 
     //! Print mesh refinement variables and their indices in the unknown vector
     void refvar( const std::vector< std::string >& rvar,
-                 const std::vector< std::size_t >& refidx );
+                 const std::vector< std::size_t >& refidx ) const;
 
     //! Print initial mesh refinement edge-node pairs
-    void edgeref( const std::vector< std::size_t >& edgenodes );
+    void edgeref( const std::vector< std::size_t >& edgenodes ) const;
 
   private:
     //! Return partial differential equation name

--- a/src/Main/Init.hpp
+++ b/src/Main/Init.hpp
@@ -65,16 +65,19 @@ void echoRunEnv( const Print& print, int argc, char** argv,
 //! \param[in] header Header type enum indicating which executable header to
 //!   print
 //! \param[in] executable Name of the executable
-//! \param[in] print Pretty printer to use
 //! \return Instantiated driver object which can then be used to execute()
 //!   whatever it is intended to drive
-template< class Driver, class Printer, class CmdLine >
+template< class Driver, class CmdLine >
 Driver Main( int argc, char* argv[],
              const CmdLine& cmdline,
              HeaderType header,
-             const std::string& executable,
-             const Printer& print )
+             const std::string& executable )
 {
+  // Create pretty printer
+  tk::Print
+    print( executable + "_screen.log",
+           cmdline.template get< tag::verbose >() ? std::cout : std::clog );
+
   // Echo program header
   echoHeader( print, header );
 
@@ -89,7 +92,7 @@ Driver Main( int argc, char* argv[],
               cmdline.template get< tag::trace >() );
 
   // Create and return driver
-  return Driver( print, cmdline );
+  return Driver( cmdline );
 }
 
 //! Generic Main Charm++ module constructor for all executables
@@ -125,12 +128,12 @@ void MainCtor( MainProxy& mp,
 //! \tparam CmdLine Executable-specific tagged tuple storing the rusult of the
 //!    command line parser
 //! \param[in] cmdline Command line grammar stack for the executable
-//! \param[in] print Pretty printer
+//! \param[in] executable Name of the executable
 //! \param[in] msg Charm++ reduction message containing the chare state
 //!   aggregated from all PEs
 template< class CmdLine >
 void dumpstate( const CmdLine& cmdline,
-                const tk::Print& print,
+                const std::string& executable,
                 CkReductionMsg* msg )
 {
   try {
@@ -148,8 +151,12 @@ void dumpstate( const CmdLine& cmdline,
 
     // pretty-print collected chare state (only if user requested it or
     // quiescence was detected which is and indication of a logic error)
-    if (cmdline.template get< tag::chare >() || error)
+    if (cmdline.template get< tag::chare >() || error) {
+      tk::Print print( executable + "_screen.log",
+        cmdline.template get< tag::verbose >() ? std::cout : std::clog,
+        std::ios_base::app );
       print.charestate( state );
+    }
 
     // exit differently depending on how we were called
     if (error)
@@ -163,9 +170,9 @@ void dumpstate( const CmdLine& cmdline,
 //! Generic finalize function for different executables
 //! \param[in] cmdline Command line grammar stack for the executable
 //! \param[in] timer Vector of timers, held by the main chare
-//! \param[in] print Pretty printer
 //! \param[in,out] state Chare state collector proxy
 //! \param[in,out] timestamp Vector of time stamps in h:m:s with labels
+//! \param[in] executable Name of the executable
 //! \param[in] dumpstateTarget Pre-created Charm++ callback to use as the
 //!   target function for dumping chare state
 //! \param[in] clean True if we should exit with a zero exit code, false to
@@ -173,27 +180,32 @@ void dumpstate( const CmdLine& cmdline,
 template< class CmdLine >
 void finalize( const CmdLine& cmdline,
                const std::vector< tk::Timer >& timer,
-               const tk::Print& print,
                tk::CProxy_ChareStateCollector& state,
                std::vector< std::pair< std::string,
                                        tk::Timer::Watch > >& timestamp,
+               const std::string& executable,
                const CkCallback& dumpstateTarget,
                bool clean = true )
 {
   try {
 
-   if (!timer.empty()) {
-     timestamp.emplace_back( "Total runtime", timer[0].hms() );
-     print.time( "Timers (h:m:s)", timestamp );
-     print.endpart();
-     // if quiescence detection is on or user requested it, collect chare state
-     if ( cmdline.template get< tag::chare >() ||
-          cmdline.template get< tag::quiescence >() ) {
-       state.collect( /* error = */ false, dumpstateTarget );
-     }
-     // tell the Charm++ runtime system to exit with zero exit code
-     if (clean) CkExit(); else CkAbort("Failed");
-   }
+    if (!timer.empty()) {
+      timestamp.emplace_back( "Total runtime", timer[0].hms() );
+       tk::Print print( executable + "_screen.log",
+         cmdline.template get< tag::verbose >() ? std::cout : std::clog,
+         std::ios_base::app );
+      print.time( "Timers (h:m:s)", timestamp );
+      print.endpart();
+    }
+
+    // if quiescence detection is on or user requested it, collect chare state
+    if ( cmdline.template get< tag::chare >() ||
+         cmdline.template get< tag::quiescence >() ) {
+      state.collect( /* error = */ false, dumpstateTarget );
+    }
+
+    // tell the Charm++ runtime system to exit with the correct exit code
+    if (clean) CkExit(); else CkAbort("Failed");
 
   } catch (...) { tk::processExceptionCharm(); }
 }

--- a/src/Main/LBSwitch.cpp
+++ b/src/Main/LBSwitch.cpp
@@ -17,17 +17,12 @@
 
 using tk::LBSwitch;
 
-LBSwitch::LBSwitch( bool verbose )
+LBSwitch::LBSwitch()
 // *****************************************************************************
 //  Constructor: turn on automatic load balancing
-//! \param[in] verbose True if user selected verbose mode
 // *****************************************************************************
 {
   TurnManualLBOff();
-
-  if (CkMyPe() == 0)
-    Print( verbose ? std::cout : std::clog ).
-      diag( "Load balancing on (if enabled in Charm++)" );
 }
 
 void
@@ -43,8 +38,7 @@ LBSwitch::off()
 {
   TurnManualLBOn();
 
-  if (CkMyPe() == 0)
-    Print( std::cout ).diag( "Load balancing off" );
+  if (CkMyPe() == 0) Print( "", std::cout ).diag( "Load balancing off" );
 }
 
 #include "NoWarning/lbswitch.def.h"

--- a/src/Main/LBSwitch.hpp
+++ b/src/Main/LBSwitch.hpp
@@ -25,7 +25,7 @@ class LBSwitch : public CBase_LBSwitch {
 
   public:
     //! Constructor: turn on automatic load balancing
-    explicit LBSwitch( bool verbose );
+    explicit LBSwitch();
 
     #if defined(__clang__)
       #pragma clang diagnostic push

--- a/src/Main/MeshConv.cpp
+++ b/src/Main/MeshConv.cpp
@@ -80,15 +80,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create MeshConv driver
       m_driver( tk::Main< meshconv::MeshConvDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
                           tk::HeaderType::MESHCONV,
-                          tk::meshconv_executable(),
-                          m_print ) ),
+                          tk::meshconv_executable() ) ),
       m_timer(1),       // Start new timer measuring the total runtime
       m_timestamp()
     {
@@ -116,7 +113,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize() {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::meshconv_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ) );
     }
 
@@ -140,14 +138,13 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::meshconv_executable(), msg );
     }
 
   private:
     int m_signal;                               //!< Used to set signal handlers
     meshconv::ctr::CmdLine m_cmdline;           //!< Command line
     meshconv::CmdLineParser m_cmdParser;        //!< Command line parser
-    tk::Print m_print;                          //!< Pretty printer
     meshconv::MeshConvDriver m_driver;          //!< Driver
     std::vector< tk::Timer > m_timer;           //!< Timers
 

--- a/src/Main/MeshConvDriver.cpp
+++ b/src/Main/MeshConvDriver.cpp
@@ -23,12 +23,13 @@ using meshconv::MeshConvDriver;
 
 extern CProxy_Main mainProxy;
 
-MeshConvDriver::MeshConvDriver( const tk::Print& print,
-                                const ctr::CmdLine& cmdline )
-  : m_print( print ),
-    m_reorder( cmdline.get< tag::reorder >() ),
-    m_input(),
-    m_output()
+MeshConvDriver::MeshConvDriver( const ctr::CmdLine& cmdline ) :
+  m_print( tk::meshconv_executable() + "_screen.log",
+           cmdline.get< tag::verbose >() ? std::cout : std::clog,
+           std::ios_base::app ),
+  m_reorder( cmdline.get< tag::reorder >() ),
+  m_input(),
+  m_output()
 // *****************************************************************************
 //  Constructor
 //! \param[in] print Pretty printer

--- a/src/Main/MeshConvDriver.hpp
+++ b/src/Main/MeshConvDriver.hpp
@@ -14,9 +14,8 @@
 
 #include <iosfwd>
 
+#include "Print.hpp"
 #include "MeshConv/CmdLine/CmdLine.hpp"
-
-namespace tk { class Print; }
 
 //! Mesh converter declarations and definitions
 namespace meshconv {
@@ -26,14 +25,13 @@ class MeshConvDriver {
 
   public:
     //! Constructor
-    explicit MeshConvDriver( const tk::Print& print,
-                             const ctr::CmdLine& cmdline );
+    explicit MeshConvDriver( const ctr::CmdLine& cmdline );
 
     //! Execute
     void execute() const;
 
   private:
-    const tk::Print& m_print;           //!< Pretty printer
+    const tk::Print m_print;            //!< Pretty printer
     const bool m_reorder;               //!< Whether to also reorder mesh nodes
     std::string m_input;                //!< Input file name
     std::string m_output;               //!< Output file name

--- a/src/Main/RNGPrint.hpp
+++ b/src/Main/RNGPrint.hpp
@@ -27,11 +27,17 @@ class RNGPrint : public Print {
 
   public:
     //! Constructor
+    //! \param[in] screen Screen output filename
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
     //! \see tk::Print::Print    
-    explicit RNGPrint( std::ostream& str = std::clog,
-                       std::ostream& qstr = std::cout ) : Print( str, qstr ) {}
+    explicit RNGPrint( const std::string& screen,
+                       std::ostream& str = std::clog,
+                       std::ios_base::openmode mode = std::ios_base::out,
+                       std::ostream& qstr = std::cout )
+      : Print( screen, str, mode, qstr ) {}
 
     #ifdef HAS_MKL
     //! Print all fields of MKL RNG parameters

--- a/src/Main/RNGTest.cpp
+++ b/src/Main/RNGTest.cpp
@@ -214,15 +214,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create RNGTest driver
       m_driver( tk::Main< rngtest::RNGTestDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
                           tk::HeaderType::RNGTEST,
-                          tk::rngtest_executable(),
-                          m_print ) ),
+                          tk::rngtest_executable() ) ),
       m_timer(1),       // Start new timer measuring the total runtime
       m_timestamp()
     {
@@ -250,7 +247,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize() {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::rngtest_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ) );
     }
 
@@ -264,14 +262,13 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::rngtest_executable(), msg );
     }
 
   private:
     int m_signal;                               //!< Used to set signal handlers
     rngtest::ctr::CmdLine m_cmdline;            //!< Command line
     rngtest::CmdLineParser m_cmdParser;         //!< Command line parser
-    rngtest::RNGTestPrint m_print;              //!< Pretty printer
     rngtest::RNGTestDriver m_driver;            //!< Driver
     std::vector< tk::Timer > m_timer;           //!< Timers
 

--- a/src/Main/RNGTestDriver.cpp
+++ b/src/Main/RNGTestDriver.cpp
@@ -32,12 +32,12 @@ extern ctr::InputDeck g_inputdeck;
 
 using rngtest::RNGTestDriver;
 
-RNGTestDriver::RNGTestDriver( const RNGTestPrint& print,
-                              const ctr::CmdLine& cmdline ) :
-  m_print( print )
+RNGTestDriver::RNGTestDriver( const ctr::CmdLine& cmdline ) :
+  m_print( tk::rngtest_executable() + "_screen.log",
+           cmdline.get< tag::verbose >() ? std::cout : std::clog,
+           std::ios_base::app )
 // *****************************************************************************
 //  Constructor
-//! \param[in] print Pretty printer
 //! \param[in] cmdline Command line object storing data parsed from the command
 //!   line arguments
 // *****************************************************************************

--- a/src/Main/RNGTestDriver.hpp
+++ b/src/Main/RNGTestDriver.hpp
@@ -33,14 +33,13 @@ class RNGTestDriver {
 
   public:
     //! Constructor
-    explicit RNGTestDriver( const RNGTestPrint& print,
-                            const ctr::CmdLine& cmdline );
+    explicit RNGTestDriver( const ctr::CmdLine& cmdline );
 
     //! Execute driver
     void execute() const;
 
   private:
-    const RNGTestPrint& m_print;
+    const RNGTestPrint m_print;
 };
 
 } // rngtest::

--- a/src/Main/RNGTestPrint.hpp
+++ b/src/Main/RNGTestPrint.hpp
@@ -27,12 +27,17 @@ class RNGTestPrint : public tk::RNGPrint {
 
   public:
     //! Constructor
+    //! \param[in] screen Screen output filename
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
     //! \see tk::RNGPrint::RNGPrint and tk::Print::Print
-    explicit RNGTestPrint( std::ostream& str = std::clog,
+    explicit RNGTestPrint( const std::string& screen,
+                           std::ostream& str = std::clog,
+                           std::ios_base::openmode mode = std::ios_base::out,
                            std::ostream& qstr = std::cout ) :
-      RNGPrint( str, qstr ) {}
+      RNGPrint( screen, str, mode, qstr ) {}
 
     //! Bring vanilla overloads from base into scope in case local overloads fail
     using Print::section;

--- a/src/Main/UnitTest.cpp
+++ b/src/Main/UnitTest.cpp
@@ -146,15 +146,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline, m_helped ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create UnitTest driver
       m_driver( tk::Main< unittest::UnitTestDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
                           tk::HeaderType::UNITTEST,
-                          tk::unittest_executable(),
-                          m_print ) ),
+                          tk::unittest_executable() ) ),
       m_timer(1), // Start new timer measuring the serial+Charm++ runtime
       m_timestamp()
     {
@@ -189,7 +186,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize( bool pass ) {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::unittest_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ),
                     pass );
     }
@@ -204,7 +202,7 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::unittest_executable(), msg );
     }
 
   private:
@@ -212,7 +210,6 @@ class Main : public CBase_Main {
     bool m_helped;      //!< Indicates if help was requested on the command line
     unittest::ctr::CmdLine m_cmdline;                   //!< Command line
     unittest::CmdLineParser m_cmdParser;                //!< Command line parser
-    unittest::UnitTestPrint m_print;                    //!< Pretty printer
     unittest::UnitTestDriver m_driver;                  //!< Driver
     std::vector< tk::Timer > m_timer;                   //!< Timers
 

--- a/src/Main/UnitTestDriver.cpp
+++ b/src/Main/UnitTestDriver.cpp
@@ -10,7 +10,6 @@
 */
 // *****************************************************************************
 
-#include "UnitTestPrint.hpp"
 #include "UnitTestDriver.hpp"
 #include "UnitTest/CmdLine/CmdLine.hpp"
 #include "QuinoaConfig.hpp"
@@ -24,8 +23,7 @@ extern CProxy_TUTSuite g_suiteProxy;
 
 } // unittest::
 
-UnitTestDriver::UnitTestDriver( const UnitTestPrint&,
-                                const ctr::CmdLine& cmdline )
+UnitTestDriver::UnitTestDriver( const ctr::CmdLine& cmdline )
 // *****************************************************************************
 //  Constructor
 //! \param[in] cmdline Command line object storing data parsed from the command

--- a/src/Main/UnitTestDriver.hpp
+++ b/src/Main/UnitTestDriver.hpp
@@ -16,15 +16,12 @@
 
 namespace unittest {
 
-class UnitTestPrint;
-
 //! Unit test suite driver used polymorphically with tk::Driver
 class UnitTestDriver {
 
   public:
     //! Constructor
-    explicit UnitTestDriver( const UnitTestPrint&,
-                             const ctr::CmdLine& cmdline );
+    explicit UnitTestDriver( const ctr::CmdLine& cmdline );
 
     //! Execute driver
     void execute() const {}

--- a/src/Main/UnitTestPrint.hpp
+++ b/src/Main/UnitTestPrint.hpp
@@ -25,12 +25,17 @@ class UnitTestPrint : public tk::Print {
 
   public:
     //! Constructor
+    //! \param[in] screen Screen output filename
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
     //! \see tk::Print::Print
-    explicit UnitTestPrint( std::ostream& str = std::clog,
+    explicit UnitTestPrint( const std::string& screen = {},
+                            std::ostream& str = std::clog,
+                            std::ios_base::openmode mode = std::ios_base::out,
                             std::ostream& qstr = std::cout ) :
-      Print( str, qstr ) {}
+      Print( screen, str, mode, qstr ) {}
 
     //! Print unit tests header (with legend)
     //! \param[in] t Section title
@@ -70,7 +75,7 @@ class UnitTestPrint : public tk::Print {
         std::stringstream ss;
         ss << "[" << ncomplete << "/" << nfail << "] " << status[0] << ":"
            << status[1];
-        (status[2] == "0" ? m_stream : m_qstream) <<
+        m_stream <<
           m_item_widename_value_fmt % m_item_indent % ss.str()
                                     % result( status[2], status[3], status[4] )
           << std::flush;

--- a/src/Main/Walker.cpp
+++ b/src/Main/Walker.cpp
@@ -193,15 +193,12 @@ class Main : public CBase_Main {
       m_cmdline(),
       // Parse command line into m_cmdline using default simple pretty printer
       m_cmdParser( msg->argc, msg->argv, tk::Print(), m_cmdline ),
-      // Create pretty printer initializing output streams based on command line
-      m_print( m_cmdline.get< tag::verbose >() ? std::cout : std::clog ),
       // Create Walker driver
       m_driver( tk::Main< walker::WalkerDriver >
                         ( msg->argc, msg->argv,
                           m_cmdline,
                           tk::HeaderType::WALKER,
-                          tk::walker_executable(),
-                          m_print ) ),
+                          tk::walker_executable() ) ),
       m_timer(1),       // start new timer measuring the total runtime
       m_timestamp()
     {
@@ -230,7 +227,8 @@ class Main : public CBase_Main {
 
     //! Towards normal exit but collect chare state first (if any)
     void finalize() {
-      tk::finalize( m_cmdline, m_timer, m_print, stateProxy, m_timestamp,
+      tk::finalize( m_cmdline, m_timer, stateProxy, m_timestamp,
+                    tk::walker_executable(),
                     CkCallback( CkIndex_Main::dumpstate(nullptr), thisProxy ) );
     }
 
@@ -244,7 +242,7 @@ class Main : public CBase_Main {
 
     //! Dump chare state
     void dumpstate( CkReductionMsg* msg ) {
-      tk::dumpstate( m_cmdline, m_print, msg );
+      tk::dumpstate( m_cmdline, tk::walker_executable(), msg );
     }
 
     //! Add time stamp contributing to final timers output
@@ -258,7 +256,6 @@ class Main : public CBase_Main {
     int m_signal;                               //!< Used to set signal handlers
     walker::ctr::CmdLine m_cmdline;             //!< Command line
     walker::CmdLineParser m_cmdParser;          //!< Command line parser
-    walker::WalkerPrint m_print;                //!< Pretty printer
     walker::WalkerDriver m_driver;              //!< Driver
     std::vector< tk::Timer > m_timer;           //!< Timers
 

--- a/src/Main/WalkerDriver.cpp
+++ b/src/Main/WalkerDriver.cpp
@@ -30,23 +30,25 @@ extern CProxy_Distributor g_DistributorProxy;
 
 using walker::WalkerDriver;
 
-WalkerDriver::WalkerDriver( const WalkerPrint& print,
-                            const ctr::CmdLine& cmdline ) :
-  m_print( print )
+WalkerDriver::WalkerDriver( const ctr::CmdLine& cmdline )
 // *****************************************************************************
 //  Constructor
-//! \param[in] print Pretty printer
 //! \param[in] cmdline Command line object storing data parsed from the command
 //!   line arguments
 // *****************************************************************************
 {
   // All global-scope data to be migrated to all PEs initialized here (if any)
 
+  // Create pretty printer
+  WalkerPrint print( tk::walker_executable() + "_screen.log",
+                     cmdline.get< tag::verbose >() ? std::cout : std::clog,
+                     std::ios_base::app );
+
   // Parse input deck into g_inputdeck
-  m_print.item( "Control file", cmdline.get< tag::io, tag::control >() );  
-  InputDeckParser inputdeckParser( m_print, cmdline, g_inputdeck );
-  m_print.item( "Parsed control file", "success" );  
-  m_print.endpart();
+  print.item( "Control file", cmdline.get< tag::io, tag::control >() );
+  InputDeckParser inputdeckParser( print, cmdline, g_inputdeck );
+  print.item( "Parsed control file", "success" );
+  print.endpart();
 
   // Instantiate Distributor chare on PE 0 which drives the time-integration of
   // differential equations via several integrator chares. We only support a
@@ -56,5 +58,5 @@ WalkerDriver::WalkerDriver( const WalkerPrint& print,
   // individual integrators so they can call back to Distributor. Since this
   // is called inside the main chare constructor, the Charm++ runtime system
   // distributes the handle along with all other global-scope data.
-  g_DistributorProxy = CProxy_Distributor::ckNew( cmdline, 0 );
+  g_DistributorProxy = CProxy_Distributor::ckNew( 0 );
 }

--- a/src/Main/WalkerDriver.hpp
+++ b/src/Main/WalkerDriver.hpp
@@ -17,21 +17,15 @@
 //! Everything that contributes to the walker executable
 namespace walker {
 
-class WalkerPrint;
-
 //! Walker driver used polymorphically with Driver
 class WalkerDriver {
 
   public:
     //! Constructor
-    explicit WalkerDriver( const WalkerPrint& print,
-                           const ctr::CmdLine& cmdline );
+    explicit WalkerDriver( const ctr::CmdLine& cmdline );
 
     //! Execute driver
     void execute() const {}
-
-  private:
-    const WalkerPrint& m_print;        //!< Pretty printer
 };
 
 } // walker::

--- a/src/Main/WalkerPrint.hpp
+++ b/src/Main/WalkerPrint.hpp
@@ -47,12 +47,17 @@ class WalkerPrint : public tk::RNGPrint {
 
   public:
     //! Constructor
+    //! \param[in] screen Screen output filename
     //! \param[in,out] str Verbose stream
+    //! \param[in] mode Open mode for screen output file, see
+    //!   http://en.cppreference.com/w/cpp/io/ios_base/openmode
     //! \param[in,out] qstr Quiet stream
     //! \see tk::RNGPrint::RNGPrint and tk::Print::Print
-    explicit WalkerPrint( std::ostream& str = std::clog,
+    explicit WalkerPrint( const std::string& screen,
+                          std::ostream& str = std::clog,
+                          std::ios_base::openmode mode = std::ios_base::out,
                           std::ostream& qstr = std::cout ) :
-      RNGPrint( str, qstr ) {}
+      RNGPrint( screen, str, mode, qstr ) {}
 
     //! Print section only if differs from its default
     template< typename Option, typename... tags >

--- a/src/Main/lbswitch.ci
+++ b/src/Main/lbswitch.ci
@@ -15,7 +15,7 @@ module lbswitch {
   namespace tk {
 
     group [migratable] LBSwitch {
-      entry LBSwitch( bool verbose );
+      entry LBSwitch();
       initproc void off();
     };
 

--- a/src/PDE/PDEFactory.hpp
+++ b/src/PDE/PDEFactory.hpp
@@ -15,8 +15,6 @@
 #include <map>
 #include <set>
 
-#include <brigand/algorithms/for_each.hpp>
-
 #include "CGPDE.hpp"
 #include "DGPDE.hpp"
 #include "Factory.hpp"

--- a/src/RNGTest/TestU01Suite.cpp
+++ b/src/RNGTest/TestU01Suite.cpp
@@ -18,7 +18,6 @@
 
 #include "NoWarning/format.hpp"
 
-#include "Print.hpp"
 #include "TestU01Suite.hpp"
 #include "TestStack.hpp"
 #include "SmallCrush.hpp"
@@ -40,8 +39,6 @@ extern TestStack g_testStack;
 using rngtest::TestU01Suite;
 
 TestU01Suite::TestU01Suite( ctr::BatteryType suite ) :
-  m_print( rngtest::g_inputdeck.get< tag::cmd, tag::verbose >() ?
-           std::cout : std::clog ),
   m_ctrs(),
   m_tests(),
   m_name(),
@@ -82,7 +79,7 @@ TestU01Suite::npval( std::size_t n )
   m_npval += n;
 
   if ( ++m_ntest == ntest() ) {
-    m_print.battery( ntest(), m_npval );
+    printer().battery( ntest(), m_npval );
     // Collect test names from all tests (one per RNG)
     m_ntest = 0;
     for (std::size_t i=0; i<ntest(); ++i) m_tests[i].names();
@@ -96,24 +93,26 @@ TestU01Suite::names( std::vector< std::string > n )
 //! \param[in] n Vector of test names (there can be more than one from one test)
 // *****************************************************************************
 {
-  m_print.names( n );
+  auto print = printer();
+
+  print.names( n );
 
   if ( ++m_ntest == ntest() ) {
     const auto& rngs = g_inputdeck.get< tag::selected, tag::rng >();
     std::stringstream ss;
     ss << "RNGs tested (" << rngs.size() << ")";
-    m_print.section( ss.str() );
+    print.section( ss.str() );
     #ifdef HAS_MKL
-    m_print.MKLParams( rngs, g_inputdeck.get< tag::param, tag::rngmkl >() );
+    print.MKLParams( rngs, g_inputdeck.get< tag::param, tag::rngmkl >() );
     #endif
-    m_print.RNGSSEParams( rngs, g_inputdeck.get< tag::param, tag::rngsse >() );
-    m_print.Random123Params( rngs,
-                             g_inputdeck.get< tag::param, tag::rng123 >() );
-    m_print.endpart();
-    m_print.part( m_name );
-    m_print.statshead( "Statistics computed",
-                       m_npval*rngs.size(),
-                       m_ctrs.size() );
+    print.RNGSSEParams( rngs, g_inputdeck.get< tag::param, tag::rngsse >() );
+    print.Random123Params( rngs,
+                           g_inputdeck.get< tag::param, tag::rng123 >() );
+    print.endpart();
+    print.part( m_name );
+    print.statshead( "Statistics computed",
+                     m_npval*rngs.size(),
+                     m_ctrs.size() );
 
     // Run battery of RNG tests
     for (const auto& t : m_tests) t.run();
@@ -141,7 +140,7 @@ TestU01Suite::evaluate( std::vector< std::vector< std::string > > status )
 //! \param[in] status Status vectors of strings for a test
 // *****************************************************************************
 {
-  m_print.test( ++m_ncomplete, m_ctrs.size(), m_nfail, status );
+  printer().test( ++m_ncomplete, m_ctrs.size(), m_nfail, status );
 
   // Store information on failed test for final assessment
   for (std::size_t p=0; p<status[1].size(); ++p)
@@ -173,22 +172,24 @@ TestU01Suite::assess()
 // Output final assessment
 // *****************************************************************************
 {
+  auto print = printer();
+
   // Output summary of failed tests for all RNGs tested
   if ( !m_failed.empty() ) {
     const auto& rngs = g_inputdeck.get< tag::selected, tag::rng >();
-    m_print.failed( "Failed statistics", m_npval*rngs.size(), m_failed );
-  } else m_print.note< tk::QUIET >( "All tests passed" );
+    print.failed( "Failed statistics", m_npval*rngs.size(), m_failed );
+  } else print.note< tk::QUIET >( "All tests passed" );
 
   // Cost and quality assessment only for more than one RNG
   if (m_time.size() > 1) {
     // Output measured times per RNG in order of computational cost
-    m_print.cost( "Generator cost",
-                  "Measured times in seconds in increasing order (low is good)",
-                  m_time );
+    print.cost( "Generator cost",
+                "Measured times in seconds in increasing order (low is good)",
+                m_time );
     // Output number of failed tests per RNG in order of decreasing quality
-    m_print.rank( "Generator quality",
-                  "Number of failed tests in increasing order (low is good)",
-                  m_nfail );
+    print.rank( "Generator quality",
+                "Number of failed tests in increasing order (low is good)",
+                m_nfail );
   }
 
   // Quit

--- a/src/RNGTest/TestU01Suite.hpp
+++ b/src/RNGTest/TestU01Suite.hpp
@@ -76,24 +76,6 @@ class TestU01Suite : public CBase_TestU01Suite {
     void time( std::pair< std::string, tk::real > t );
 
  private:
-    //! Add all statistical tests to suite, return suite name
-    //! \return Test suite name
-    template< class Suite >
-    std::string addTests() {
-      const auto rngs = g_inputdeck.get< tag::selected, tag::rng >();
-      ErrChk( !rngs.empty(), "No RNGs selected" );
-      Suite suite;
-      for (const auto& r : rngs) suite.addTests( m_ctrs, r, thisProxy );
-      return suite.name();
-    }
-
-    //! Return number of statistical tests
-    std::size_t ntest() const;
-
-    //! Output final assessment
-    void assess();
-
-    RNGTestPrint m_print;              //!< Pretty printer
     std::vector< std::function< StatTest() > > m_ctrs; //! Tests constructors
     std::vector< StatTest > m_tests;   //!< Constructed statistical tests
     std::string m_name;                //!< Test suite name
@@ -113,6 +95,31 @@ class TestU01Suite : public CBase_TestU01Suite {
         test( std::move(t) ), rng( std::move(r) ), pval( std::move(p) ) {}
     };
     std::vector< Failed > m_failed;    //!< Details of failed tests
+
+    //! Add all statistical tests to suite, return suite name
+    //! \return Test suite name
+    template< class Suite >
+    std::string addTests() {
+      const auto rngs = g_inputdeck.get< tag::selected, tag::rng >();
+      ErrChk( !rngs.empty(), "No RNGs selected" );
+      Suite suite;
+      for (const auto& r : rngs) suite.addTests( m_ctrs, r, thisProxy );
+      return suite.name();
+    }
+
+    //! Return number of statistical tests
+    std::size_t ntest() const;
+
+    //! Output final assessment
+    void assess();
+
+    //! Create pretty printer specialized to RNGTest
+    //! \return Pretty printer
+    RNGTestPrint printer() const { return
+      RNGTestPrint( tk::rngtest_executable() + "_screen.log",
+        g_inputdeck.get< tag::cmd, tag::verbose >() ? std::cout : std::clog,
+        std::ios_base::app );
+    }
 };
 
 } // rngtest::

--- a/src/UnitTest/Assessment.cpp
+++ b/src/UnitTest/Assessment.cpp
@@ -70,8 +70,7 @@ assess( const tk::Print& print,
 // *****************************************************************************
 {
   if (!nfail && !nwarn && !nskip && !nexcp) {
-    print.note< tk::QUIET >
-              ( "All " + std::to_string(ncomplete) + " tests passed" );
+    print.note( "All " + std::to_string(ncomplete) + " tests passed" );
   } else {
     std::string skip, warn, fail, excp;
     if (nwarn) warn = "finished with a warning: " + std::to_string(nwarn);
@@ -81,8 +80,7 @@ assess( const tk::Print& print,
                       "threw exception: " + std::to_string(nexcp);
     if (nfail) fail = std::string(nexcp || nskip || nwarn ?
                       ", " : "") + "failed: " + std::to_string(nfail);
-    print.note< tk::QUIET >
-              ( "Of " + std::to_string(ncomplete) + " tests total: "
+    print.note( "Of " + std::to_string(ncomplete) + " tests total: "
                 + warn + skip + excp + fail );
   }
 

--- a/src/UnitTest/TUTSuite.cpp
+++ b/src/UnitTest/TUTSuite.cpp
@@ -40,8 +40,9 @@ extern int g_maxTestsInGroup;
 using unittest::TUTSuite;
 
 TUTSuite::TUTSuite( const ctr::CmdLine& cmdline ) :
+  m_screen( tk::unittest_executable() + "_screen.log" ),
+  m_verbose( cmdline.get< tag::verbose >() ),
   m_mpirunner(),
-  m_print( cmdline.get< tag::verbose >() ? std::cout : std::clog ),
   m_nrun( 0 ),
   m_ngroup( 0 ),
   m_ncomplete( 0 ),
@@ -55,11 +56,13 @@ TUTSuite::TUTSuite( const ctr::CmdLine& cmdline ) :
 //! \param[in] cmdline Data structure storing data from the command-line parser
 // *****************************************************************************
 {
-  m_print.part( "Factory" );
-
-  // Output registered test groups
   const auto& groups = g_runner.get().list_groups();
-  m_print.list( "Registered test groups", groups );
+
+  { auto print = printer();
+    print.part( "Factory" );
+    // Output registered test groups
+    print.list( "Registered test groups", groups );
+  } // ensure print is destructed (cannot collide with that of evaluate)
 
   // Get group name string passed in by -g
   const auto grp = cmdline.get< tag::group >();
@@ -75,15 +78,17 @@ TUTSuite::TUTSuite( const ctr::CmdLine& cmdline ) :
   // Quit if there is no work to be done
   if (!work) {
 
-    m_print.note( "\nNo test groups to be executed because no test group "
-                  "names match '" + grp + "'.\n" );
+    printer().note( "\nNo test groups to be executed because no test group "
+                    "names match '" + grp + "'.\n" );
     mainProxy.finalize( true );
 
   } else {
 
-    m_print.endpart();
-    m_print.part( "Serial, Charm++, and MPI unit test suites" );
-    m_print.unithead( "Unit tests computed", grp );
+    { auto print = printer();
+      print.endpart();
+      print.part( "Serial, Charm++, and MPI unit test suites" );
+      print.unithead( "Unit tests computed", grp );
+    } // ensure print is destructed (cannot collied with that of evaluate)
 
     // Create MPI unit test runner nodegroup
     m_mpirunner = CProxy_MPIRunner< CProxy_TUTSuite >::ckNew( thisProxy );
@@ -146,15 +151,15 @@ TUTSuite::evaluate( std::vector< std::string > status )
   // Evaluate test
   unittest::evaluate( status, m_ncomplete, m_nwarn, m_nskip, m_nexcp, m_nfail );
 
+  auto print = printer();
+
   // Echo one-liner info on result of test
-  m_print.test( m_ncomplete, m_nfail, status );
+  print.test( m_ncomplete, m_nfail, status );
 
   // Wait for all tests to finish, then quit
   if (m_nrun == m_ngroup*static_cast<std::size_t>(g_maxTestsInGroup) + m_nmigr)
   {
-    auto pass =
-      assess( m_print, m_nfail, m_nwarn, m_nskip, m_nexcp, m_ncomplete );
-    // Quit
+    auto pass = assess(print, m_nfail, m_nwarn, m_nskip, m_nexcp, m_ncomplete);
     mainProxy.finalize( pass );
   }
 }

--- a/src/UnitTest/TUTSuite.hpp
+++ b/src/UnitTest/TUTSuite.hpp
@@ -41,9 +41,10 @@ class TUTSuite : public CBase_TUTSuite {
     void evaluate( std::vector< std::string > status );
 
   private:
+    std::string m_screen;          //!< Screen output log filename
+    bool m_verbose;                //1< True if verbose screen output
     //! MPI unit test runner nodegroup proxy
     CProxy_MPIRunner< CProxy_TUTSuite > m_mpirunner;
-    UnitTestPrint m_print;         //!< Pretty printer
     std::size_t m_nrun;            //!< Number of tests ran (including dummies)
     std::size_t m_ngroup;          //!< Number of test groups
     std::size_t m_ncomplete;       //!< Number of completed tests
@@ -82,6 +83,14 @@ class TUTSuite : public CBase_TUTSuite {
 
     //! Fire up all tests in a test group
     void spawngrp( const std::string& g );
+
+    //! Create pretty printer specialized to UnitTest
+    //! \return Pretty printer
+    UnitTestPrint printer() const { return
+      UnitTestPrint( m_screen,
+                     m_verbose ? std::cout : std::clog,
+                     std::ios_base::app );
+    }
 };
 
 } // unittest::

--- a/src/Walker/Distributor.cpp
+++ b/src/Walker/Distributor.cpp
@@ -50,9 +50,7 @@ extern CProxy_Main mainProxy;
 
 using walker::Distributor;
 
-Distributor::Distributor( const ctr::CmdLine& cmdline ) :
-  __dep(),
-  m_print( cmdline.get< tag::verbose >() ? std::cout : std::clog ),
+Distributor::Distributor() :
   m_output( { false, false } ),
   m_it( 0 ),
   m_npar( 0 ),
@@ -74,7 +72,6 @@ Distributor::Distributor( const ctr::CmdLine& cmdline ) :
   m_moments()
 // *****************************************************************************
 // Constructor
-//! \param[in] cmdline Data structure storing data from the command-line parser
 // *****************************************************************************
 {
   // Compute load distribution given total work (= number of particles) and
@@ -95,8 +92,10 @@ Distributor::Distributor( const ctr::CmdLine& cmdline ) :
   // number of particles the array element (worker) will work on.
   m_npar = static_cast< tk::real >( nchare * chunksize );
 
+  auto print = printer();
+
   // Print out info on what will be done and how
-  info( chunksize, nchare );
+  info( print, chunksize, nchare );
 
   // Output header for statistics output file
   tk::TxtStatWriter sw( !m_nameOrdinary.empty() || !m_nameCentral.empty() ?
@@ -107,9 +106,9 @@ Distributor::Distributor( const ctr::CmdLine& cmdline ) :
   sw.header( m_nameOrdinary, m_nameCentral, m_tables.first );
 
   // Print out time integration header
-  m_print.endsubsection();
-  m_print.diag( "Starting time stepping ..." );
-  header();
+  print.endsubsection();
+  print.diag( "Starting time stepping ..." );
+  header( print );
 
   // Start timer measuring total integration time
   m_timer.emplace_back();
@@ -133,83 +132,86 @@ Distributor::Distributor( const ctr::CmdLine& cmdline ) :
 }
 
 void
-Distributor::info( uint64_t chunksize, std::size_t nchare )
+Distributor::info( const WalkerPrint& print,
+                   uint64_t chunksize,
+                   std::size_t nchare )
 // *****************************************************************************
 //  Print information at startup
+//! \param[in] print Pretty printer object to use for printing
 //! \param[in] chunksize Chunk size, see Base/LoadDistribution.h
 //! \param[in] nchare Total number of Charem++ Integrator chares doing work
 // *****************************************************************************
 {
-  m_print.part( "Factory" );
+  print.part( "Factory" );
 
   // Print out info data layout
-  m_print.list( "Particle properties data layout (CMake: PARTICLE_DATA_LAYOUT)",
-                std::list< std::string >{ tk::Particles::layout() } );
+  print.list( "Particle properties data layout (CMake: PARTICLE_DATA_LAYOUT)",
+              std::list< std::string >{ tk::Particles::layout() } );
 
   // Re-create differential equations stack for output
   DiffEqStack stack;
 
   // Print out information on factory
-  m_print.eqlist( "Registered differential equations",
-                  stack.factory(), stack.ntypes() );
-  m_print.endpart();
+  print.eqlist( "Registered differential equations",
+                stack.factory(), stack.ntypes() );
+  print.endpart();
 
   // Instantiate tables to sample and output to statistics file
   m_tables = stack.tables();
 
   // Print out information on problem
-  m_print.part( "Problem" );
+  print.part( "Problem" );
 
   // Print out info on problem title
   if ( !g_inputdeck.get< tag::title >().empty() )
-    m_print.title( g_inputdeck.get< tag::title >() );
+    print.title( g_inputdeck.get< tag::title >() );
 
   // Print out info on settings of selected differential equations
-  m_print.diffeqs( "Differential equations integrated", stack.info() );
+  print.diffeqs( "Differential equations integrated", stack.info() );
 
   // Print out info on RNGs selected
   // ...
 
   // Print I/O filenames
-  m_print.section( "Output filenames" );
+  print.section( "Output filenames" );
   if (!g_inputdeck.get< tag::stat >().empty())
-    m_print.item( "Statistics", g_inputdeck.get< tag::cmd, tag::io, tag::stat >() );
+    print.item( "Statistics", g_inputdeck.get< tag::cmd, tag::io, tag::stat >() );
   if (!g_inputdeck.get< tag::pdf >().empty())
-    m_print.item( "PDF", g_inputdeck.get< tag::cmd, tag::io, tag::pdf >() );
+    print.item( "PDF", g_inputdeck.get< tag::cmd, tag::io, tag::pdf >() );
 
   // Print discretization parameters
-  m_print.section( "Discretization parameters" );
-  m_print.item( "Number of time steps",
-                g_inputdeck.get< tag::discr, tag::nstep >() );
-  m_print.item( "Terminate time",
-                g_inputdeck.get< tag::discr, tag::term >() );
-  m_print.item( "Initial time step size",
-                g_inputdeck.get< tag::discr, tag::dt >() );
+  print.section( "Discretization parameters" );
+  print.item( "Number of time steps",
+              g_inputdeck.get< tag::discr, tag::nstep >() );
+  print.item( "Terminate time",
+              g_inputdeck.get< tag::discr, tag::term >() );
+  print.item( "Initial time step size",
+              g_inputdeck.get< tag::discr, tag::dt >() );
 
   // Print output intervals
-  m_print.section( "Output intervals" );
-  m_print.item( "TTY", g_inputdeck.get< tag::interval, tag::tty>() );
+  print.section( "Output intervals" );
+  print.item( "TTY", g_inputdeck.get< tag::interval, tag::tty>() );
   if (!g_inputdeck.get< tag::stat >().empty())
-    m_print.item( "Statistics", g_inputdeck.get< tag::interval, tag::stat >() );
+    print.item( "Statistics", g_inputdeck.get< tag::interval, tag::stat >() );
   if (!g_inputdeck.get< tag::pdf >().empty())
-    m_print.item( "PDF", g_inputdeck.get< tag::interval, tag::pdf >() );
+    print.item( "PDF", g_inputdeck.get< tag::interval, tag::pdf >() );
 
   // Print out statistics estimated
-  m_print.statistics( "Statistical moments and distributions" );
+  print.statistics( "Statistical moments and distributions" );
 
   // Print out info on load distirubtion
-  m_print.section( "Load distribution" );
-  m_print.item( "Virtualization [0.0...1.0]",
-                g_inputdeck.get< tag::cmd, tag::virtualization >() );
-  m_print.item( "Number of work units", nchare );
-  m_print.item( "User load (# of particles)",
-                g_inputdeck.get< tag::discr, tag::npar >() );
-  m_print.item( "Chunksize (load per work unit)", chunksize );
-  m_print.item( "Actual load (# of particles)",
-                std::to_string( nchare * chunksize ) +
-                " (=" +
-                std::to_string( nchare ) + "*" +
-                std::to_string( chunksize ) + ")" );
+  print.section( "Load distribution" );
+  print.item( "Virtualization [0.0...1.0]",
+              g_inputdeck.get< tag::cmd, tag::virtualization >() );
+  print.item( "Number of work units", nchare );
+  print.item( "User load (# of particles)",
+              g_inputdeck.get< tag::discr, tag::npar >() );
+  print.item( "Chunksize (load per work unit)", chunksize );
+  print.item( "Actual load (# of particles)",
+              std::to_string( nchare * chunksize ) +
+              " (=" +
+              std::to_string( nchare ) + "*" +
+              std::to_string( chunksize ) + ")" );
 }
 
 tk::real
@@ -656,13 +658,16 @@ Distributor::finish()
   // Print out reason for stopping
   const auto term = g_inputdeck.get< tag::discr, tag::term >();
   const auto nstep = g_inputdeck.get< tag::discr, tag::nstep >();
-  m_print.endsubsection();
+
+  auto print = printer();
+
+  print.endsubsection();
   if (m_it >= g_inputdeck.get< tag::discr, tag::nstep >())
-     m_print.note( "Normal finish, maximum number of iterations reached: " +
-                   std::to_string( nstep ) );
+     print.note( "Normal finish, maximum number of iterations reached: " +
+                 std::to_string( nstep ) );
    else 
-     m_print.note( "Normal finish, maximum time reached: " +
-                   std::to_string( term ) );
+     print.note( "Normal finish, maximum time reached: " +
+                 std::to_string( term ) );
 
   // Quit
   mainProxy.finalize();
@@ -681,12 +686,13 @@ Distributor::nostat()
 }
 
 void
-Distributor::header() const
+Distributor::header( const WalkerPrint& print ) const
 // *****************************************************************************
 // Print out time integration header
+//! \param[in] print Pretty printer object to use for printing
 // *****************************************************************************
 {
-  m_print.inthead( "Time integration", "Differential equations testbed",
+  print.inthead( "Time integration", "Differential equations testbed",
     "Legend: it - iteration count\n"
     "         t - time\n"
     "        dt - time step size\n"
@@ -711,28 +717,30 @@ Distributor::report()
                     g_inputdeck.get< tag::discr, tag::nstep >(), m_it,
                     ete, eta );
 
+    auto print = printer();
+
     // Output one-liner
-    m_print << std::setfill(' ') << std::setw(8) << m_it << "  "
-            << std::scientific << std::setprecision(6)
-            << std::setw(12) << m_t << "  "
-            << m_dt << "  "
-            << std::setfill('0')
-            << std::setw(3) << ete.hrs.count() << ":"
-            << std::setw(2) << ete.min.count() << ":"
-            << std::setw(2) << ete.sec.count() << "  "
-            << std::setw(3) << eta.hrs.count() << ":"
-            << std::setw(2) << eta.min.count() << ":"
-            << std::setw(2) << eta.sec.count() << "  ";
+    print << std::setfill(' ') << std::setw(8) << m_it << "  "
+          << std::scientific << std::setprecision(6)
+          << std::setw(12) << m_t << "  "
+          << m_dt << "  "
+          << std::setfill('0')
+          << std::setw(3) << ete.hrs.count() << ":"
+          << std::setw(2) << ete.min.count() << ":"
+          << std::setw(2) << ete.sec.count() << "  "
+          << std::setw(3) << eta.hrs.count() << ":"
+          << std::setw(2) << eta.min.count() << ":"
+          << std::setw(2) << eta.sec.count() << "  ";
 
     // Augment one-liner with output indicators
-    if (m_output.get< tag::stat >()) m_print << 'S';
-    if (m_output.get< tag::pdf >()) m_print << 'P';
+    if (m_output.get< tag::stat >()) print << 'S';
+    if (m_output.get< tag::pdf >()) print << 'P';
 
     // Reset output indicators
     m_output.get< tag::stat >() = false;
     m_output.get< tag::pdf >() = false;
 
-    m_print << std::endl;
+    print << std::endl;
   }
 }
 

--- a/src/Walker/Distributor.hpp
+++ b/src/Walker/Distributor.hpp
@@ -68,7 +68,7 @@ class Distributor : public CBase_Distributor {
 
   public:
     //! Constructor
-    explicit Distributor( const ctr::CmdLine& cmdline );
+    explicit Distributor();
 
     //! \brief Reduction target indicating that all Integrator chares have
     //!   registered with the statistics merger (collector)
@@ -100,14 +100,39 @@ class Distributor : public CBase_Distributor {
                                , tag::pdf,  bool
                              > >;
 
+    OutputIndicators m_output;                  //!< Output indicators
+    uint64_t m_it;                              //!< Iteration count
+    tk::real m_npar;                            //!< Total number of particles
+    tk::real m_t;                               //!< Physical time
+    tk::real m_dt;                              //!< Physical time step size
+    CProxy_Integrator m_intproxy;               //!< Integrator array proxy
+    std::vector< tk::Timer > m_timer;           //!< Timers
+    std::vector< std::string > m_nameOrdinary;  //!< Ordinary moment names
+    std::vector< std::string > m_nameCentral;   //!< Central moment names
+    std::vector< tk::real > m_ordinary;         //!< Ordinary moments
+    std::vector< tk::real > m_central;          //!< Central moments
+    std::vector< tk::UniPDF > m_ordupdf;        //!< Ordinary univariate PDFs
+    std::vector< tk::BiPDF > m_ordbpdf;         //!< Ordinary bivariate PDFs
+    std::vector< tk::TriPDF > m_ordtpdf;        //!< Ordinary trivariate PDFs
+    std::vector< tk::UniPDF > m_cenupdf;        //!< Central univariate PDFs
+    std::vector< tk::BiPDF > m_cenbpdf;         //!< Central bivariate PDFs
+    std::vector< tk::TriPDF > m_centpdf;        //!< Central trivariate PDFs
+    //! Names of and tables to sample and output to statistics file
+    std::pair< std::vector< std::string >,
+               std::vector< tk::Table > > m_tables;
+    //! Map used to lookup moments
+    std::map< tk::ctr::Product, tk::real > m_moments;
+
     //! Print information at startup
-    void info( uint64_t chunksize, std::size_t nchare );
+    void info( const WalkerPrint& print,
+               uint64_t chunksize,
+               std::size_t nchare );
 
     //! Compute size of next time step
     tk::real computedt();
 
     //! Print out time integration header
-    void header() const;
+    void header( const WalkerPrint& print ) const;
 
     //! Print out one-liner report on time step
     void report();
@@ -150,31 +175,13 @@ class Distributor : public CBase_Distributor {
     //! Evaluate time step, compute new time step size
     void evaluateTime();
 
-    WalkerPrint m_print;                        //! Pretty printer
-    OutputIndicators m_output;                  //!< Output indicators
-    uint64_t m_it;                              //!< Iteration count
-    tk::real m_npar;                            //!< Total number of particles
-    tk::real m_t;                               //!< Physical time
-    tk::real m_dt;                              //!< Physical time step size
-    CProxy_Integrator m_intproxy;               //!< Integrator array proxy
-    std::vector< tk::Timer > m_timer;           //!< Timers
-    std::vector< std::string > m_nameOrdinary;  //!< Ordinary moment names
-    std::vector< std::string > m_nameCentral;   //!< Central moment names
-    std::vector< tk::real > m_ordinary;         //!< Ordinary moments
-    std::vector< tk::real > m_central;          //!< Central moments
-    std::vector< tk::UniPDF > m_ordupdf;        //!< Ordinary univariate PDFs
-    std::vector< tk::BiPDF > m_ordbpdf;         //!< Ordinary bivariate PDFs
-    std::vector< tk::TriPDF > m_ordtpdf;        //!< Ordinary trivariate PDFs
-    std::vector< tk::UniPDF > m_cenupdf;        //!< Central univariate PDFs
-    std::vector< tk::BiPDF > m_cenbpdf;         //!< Central bivariate PDFs
-    std::vector< tk::TriPDF > m_centpdf;        //!< Central trivariate PDFs
-
-    //! Names of and tables to sample and output to statistics file
-    std::pair< std::vector< std::string >,
-               std::vector< tk::Table > > m_tables;
-
-    //! Map used to lookup moments
-    std::map< tk::ctr::Product, tk::real > m_moments;
+    //! Create pretty printer specialized to Walker
+    //! \return Pretty printer
+    WalkerPrint printer() const { return
+      WalkerPrint( tk::walker_executable() + "_screen.log",
+        g_inputdeck.get< tag::cmd, tag::verbose >() ? std::cout : std::clog,
+        std::ios_base::app );
+    }
 
     //! Normal finish of time stepping
     void finish();

--- a/src/Walker/distributor.ci
+++ b/src/Walker/distributor.ci
@@ -20,7 +20,7 @@ module distributor {
   namespace walker {
 
     chare Distributor {
-      entry Distributor( const ctr::CmdLine& cmdline );
+      entry Distributor();
       entry [reductiontarget] void registered();
       entry [reductiontarget] void nostat();
       entry [reductiontarget] void estimateOrd( tk::real ord[n], int n );

--- a/tests/unit/Base/TestPrint.cpp
+++ b/tests/unit/Base/TestPrint.cpp
@@ -23,7 +23,9 @@ namespace tut {
 
 //! All tests in group inherited from this base
 struct Print_common {
-  Print_common() : verb(), quiet(), prd(), prv( verb ), prq( verb, quiet ) {}
+  Print_common() : verb(), quiet(), prd(),
+                   prv( "", verb ),
+                   prq( "", verb, std::ios_base::out, quiet ) {}
   std::stringstream verb;
   std::stringstream quiet;
   tk::Print prd;                //!< for testing default-constructed object
@@ -102,7 +104,7 @@ void Print_object::test< 5 >() {
   // std::cout and thus we would see no screen output after the reset call
   // below.
   std::stringstream v, q;
-  tk::Print pr( v, q );
+  tk::Print pr( "", v, std::ios_base::out, q );
   // Reset quiet stream in new printer to saved one, has "blah"
   pr.reset< tk::QUIET >( p );
   // Write to new quiet stream, now should have "blah blah"

--- a/tools/docker/Dockerfile.quinoa-build-azure
+++ b/tools/docker/Dockerfile.quinoa-build-azure
@@ -35,6 +35,7 @@ RUN cmake \
     -DCMAKE_CXX_FLAGS="-Werror -ftemplate-depth=1024" \
     -DCMAKE_BUILD_TYPE="${BUILD}" \
     -DCMAKE_CXX_FLAGS_DEBUG=-g0 \
+    -DEXCEPTIONS_WRITE_TO_CERR=false \
     ${SHARED_LIBS:+-DBUILD_SHARED_LIBS=$SHARED_LIBS} \
     -DRUNNER=mpirun \
     -DRUNNER_NCPUS_ARG=-n \


### PR DESCRIPTION
By default, the output file is "screen.log", configurable via the command line argument `-g` or `--screen`. I'm open for suggestions for both the filename and the short and/or long command line arguments. This is now added to all executables and happens by default.

The solution is kind of cool: A new stream buffer, `tk::teebuf`, is created at the lowest level of printing anything out from all executables, handled by `tk::Print`. `tk::teebuf` ties two output streams, e.g., an output-file stream and `std::cout`, together. As a result, anything that goes to the stream configured inside the printer class, `tk::Print`, goes to both, so no changes are needed within `tk::Print` to those functions that implement output, only its configuration via its constructor.

_Caveat:_ Not everything that goes to the screen goes into the log file. E.g., Charm++ output will not show up, but everything else should.

This is progress towards #373, by addressing https://github.com/quinoacomputing/quinoa/issues/373#issuecomment-568504640. (Next is the output of the data held in the command line and input deck objects, filled respectively during command line and input file parsing, for all executables stored as tagged tuples.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/375)
<!-- Reviewable:end -->
