### PR TITLE
Revamp DG::CompFlow BC config

### DIFF
--- a/src/Control/Inciter/Types.hpp
+++ b/src/Control/Inciter/Types.hpp
@@ -182,8 +182,6 @@ using CompFlowPDEParameters = tk::TaggedTuple< brigand::list<
                         std::vector< kw::farfield_density::info::expect::type >
   , tag::farfield_velocity, std::vector< std::vector<
                               kw::farfield_velocity::info::expect::type > >
-  , tag::bcextrapolate, std::vector< std::vector<
-                         kw::sideset::info::expect::type > >
   , tag::bc,            bc
   , tag::ic,            ic
   //! System FCT character

--- a/src/PDE/CMakeLists.txt
+++ b/src/PDE/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(PDE
             ConfigureTransport.cpp
             ConfigureCompFlow.cpp
             ConfigureMultiMat.cpp
+            DGPDE.cpp
             CompFlow/RiemannFactory.cpp
             MultiMat/RiemannFactory.cpp)
 

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -79,8 +79,8 @@ class CompFlow {
       brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
         , Symmetry
-        , tk::StateFn()         // Not implemented!
-        , tk::StateFn()         // Not implemented!
+        , InvalidBC         // Not implemented!
+        , InvalidBC         // Not implemented!
         , Characteristic
         , Extrapolate } ) );
     }
@@ -886,6 +886,20 @@ class CompFlow {
                  tk::real, tk::real, tk::real, tk::real,
                  const std::array< tk::real, 3 >& )
     {
+      return {{ ul, ul }};
+    }
+
+    //! \brief State function for invalid/un-configured boundary conditions
+    //! \param[in] ul Left (domain-internal) state
+    //! \return Left and right states for all scalar components in this PDE
+    //!   system
+    //! \note The function signature must follow tk::StateFn
+    static tk::StateFn::result_type
+    InvalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
+               tk::real, tk::real, tk::real, tk::real,
+               const std::array< tk::real, 3> & )
+    {
+      Throw("Invalid boundary condition set up in input file");
       return {{ ul, ul }};
     }
 };

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -63,32 +63,6 @@ class CompFlow {
     using BCStateFn =
       std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
-
-     //! Extract BC configuration ignoring if BC not specified
-     //! \note A more preferable way of catching errors such as this function
-     //!   hides is during parsing, so that we don't even get here if BCs are
-     //!   not correctly specified. For now we simply ignore if BCs are not
-     //!   specified by allowing empty BC vectors from the user input.
-     struct ConfigBC {
-       std::size_t system;  //! Compflow system id
-       BCStateFn& state;    //!< BC state config: sidesets + statefn
-       const std::vector< tk::StateFn >& fn;    //!< BC state functions
-       std::size_t c;       //!< Counts BC types configured
-       //! Constructor
-       ConfigBC( std::size_t sys,
-                 BCStateFn& s,
-                 const std::vector< tk::StateFn >& f ) :
-         system(sys), state(s), fn(f), c(0) {}
-       //! Function to call for each BC type
-       template< typename U > void operator()( brigand::type_<U> ) {
-         std::vector< bcconf_t > cfg;
-         const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, U >();
-         if (v.size() > system) cfg = v[system];
-         Assert( fn.size() > c, "StateFn missing for BC type" );
-         state.push_back( { cfg, fn[c++] } );
-       }
-     };
-
   public:
     //! Constructor
     //! \param[in] c Equation system index (among multiple systems configured)
@@ -102,7 +76,7 @@ class CompFlow {
         g_inputdeck.get< tag::param, tag::compflow, tag::flux >().at(m_system)))
     {
       // associate boundary condition configurations with state functions
-      brigand::for_each< ctr::bc::Keys >( ConfigBC( m_system, m_bc,
+      brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
         , Symmetry
         , tk::StateFn()         // Not implemented!

--- a/src/PDE/DGPDE.cpp
+++ b/src/PDE/DGPDE.cpp
@@ -12,7 +12,7 @@
 
 #include "DGPDE.hpp"
 
-tk::StateFn::result_type
+[[noreturn]] tk::StateFn::result_type
 inciter::invalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >&,
            tk::real, tk::real, tk::real, tk::real,
            const std::array< tk::real, 3> & )

--- a/src/PDE/DGPDE.cpp
+++ b/src/PDE/DGPDE.cpp
@@ -1,0 +1,26 @@
+// *****************************************************************************
+/*!
+  \file      src/PDE/DGPDE.cpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019-2020 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Functions common to discontinuous Galerkin PDE types
+  \details   Functions common to discontinuous Galerkin PDE types.
+*/
+// *****************************************************************************
+
+#include "DGPDE.hpp"
+
+tk::StateFn::result_type
+inciter::invalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >&,
+           tk::real, tk::real, tk::real, tk::real,
+           const std::array< tk::real, 3> & )
+// *****************************************************************************
+//! State function for invalid/un-configured boundary conditions
+//! \note The function signature must follow tk::StateFn
+// *****************************************************************************
+{
+  Throw( "Invalid boundary condition set up in input file or the PDE does not "
+          "support this BC type" );
+}

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -30,8 +30,41 @@
 #include "Fields.hpp"
 #include "FaceData.hpp"
 #include "UnsMesh.hpp"
+#include "Inciter/InputDeck/InputDeck.hpp"
+#include "FunctionPrototypes.hpp"
 
 namespace inciter {
+
+extern ctr::InputDeck g_inputdeck;
+
+  using bcconf_t = kw::sideset::info::expect::type;
+  using BCStateFn =
+    std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
+
+  //! Extract BC configuration ignoring if BC not specified
+  //! \note A more preferable way of catching errors such as this function
+  //!   hides is during parsing, so that we don't even get here if BCs are
+  //!   not correctly specified. For now we simply ignore if BCs are not
+  //!   specified by allowing empty BC vectors from the user input.
+  template< class Eq > struct ConfigBC {
+    std::size_t system;  //! Compflow system id
+    BCStateFn& state;    //!< BC state config: sidesets + statefn
+    const std::vector< tk::StateFn >& fn;    //!< BC state functions
+    std::size_t c;       //!< Counts BC types configured
+    //! Constructor
+    ConfigBC( std::size_t sys,
+              BCStateFn& s,
+              const std::vector< tk::StateFn >& f ) :
+      system(sys), state(s), fn(f), c(0) {}
+    //! Function to call for each BC type
+    template< typename U > void operator()( brigand::type_<U> ) {
+      std::vector< bcconf_t > cfg;
+      const auto& v = g_inputdeck.get< tag::param, Eq, tag::bc, U >();
+      if (v.size() > system) cfg = v[system];
+      Assert( fn.size() > c, "StateFn missing for BC type" );
+      state.push_back( { cfg, fn[c++] } );
+    }
+  };
 
 //! \brief Partial differential equation base for discontinuous Galerkin PDEs
 //! \details This class uses runtime polymorphism without client-side

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -37,34 +37,41 @@ namespace inciter {
 
 extern ctr::InputDeck g_inputdeck;
 
-  using bcconf_t = kw::sideset::info::expect::type;
-  using BCStateFn =
-    std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
+using ncomp_t = kw::ncomp::info::expect::type;
+using bcconf_t = kw::sideset::info::expect::type;
+using BCStateFn =
+  std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
-  //! Extract BC configuration ignoring if BC not specified
-  //! \note A more preferable way of catching errors such as this function
-  //!   hides is during parsing, so that we don't even get here if BCs are
-  //!   not correctly specified. For now we simply ignore if BCs are not
-  //!   specified by allowing empty BC vectors from the user input.
-  template< class Eq > struct ConfigBC {
-    std::size_t system;  //! Compflow system id
-    BCStateFn& state;    //!< BC state config: sidesets + statefn
-    const std::vector< tk::StateFn >& fn;    //!< BC state functions
-    std::size_t c;       //!< Counts BC types configured
-    //! Constructor
-    ConfigBC( std::size_t sys,
-              BCStateFn& s,
-              const std::vector< tk::StateFn >& f ) :
-      system(sys), state(s), fn(f), c(0) {}
-    //! Function to call for each BC type
-    template< typename U > void operator()( brigand::type_<U> ) {
-      std::vector< bcconf_t > cfg;
-      const auto& v = g_inputdeck.get< tag::param, Eq, tag::bc, U >();
-      if (v.size() > system) cfg = v[system];
-      Assert( fn.size() > c, "StateFn missing for BC type" );
-      state.push_back( { cfg, fn[c++] } );
-    }
-  };
+//! Extract BC configuration ignoring if BC not specified
+//! \note A more preferable way of catching errors such as this function
+//!   hides is during parsing, so that we don't even get here if BCs are
+//!   not correctly specified. For now we simply ignore if BCs are not
+//!   specified by allowing empty BC vectors from the user input.
+template< class Eq > struct ConfigBC {
+  std::size_t system;  //! Compflow system id
+  BCStateFn& state;    //!< BC state config: sidesets + statefn
+  const std::vector< tk::StateFn >& fn;    //!< BC state functions
+  std::size_t c;       //!< Counts BC types configured
+  //! Constructor
+  ConfigBC( std::size_t sys,
+            BCStateFn& s,
+            const std::vector< tk::StateFn >& f ) :
+    system(sys), state(s), fn(f), c(0) {}
+  //! Function to call for each BC type
+  template< typename U > void operator()( brigand::type_<U> ) {
+    std::vector< bcconf_t > cfg;
+    const auto& v = g_inputdeck.get< tag::param, Eq, tag::bc, U >();
+    if (v.size() > system) cfg = v[system];
+    Assert( fn.size() > c, "StateFn missing for BC type" );
+    state.push_back( { cfg, fn[c++] } );
+  }
+};
+
+//! State function for invalid/un-configured boundary conditions
+tk::StateFn::result_type
+invalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >&,
+           tk::real, tk::real, tk::real, tk::real,
+           const std::array< tk::real, 3> & );
 
 //! \brief Partial differential equation base for discontinuous Galerkin PDEs
 //! \details This class uses runtime polymorphism without client-side

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -68,7 +68,7 @@ template< class Eq > struct ConfigBC {
 };
 
 //! State function for invalid/un-configured boundary conditions
-tk::StateFn::result_type
+[[noreturn]] tk::StateFn::result_type
 invalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >&,
            tk::real, tk::real, tk::real, tk::real,
            const std::array< tk::real, 3> & );

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -78,8 +78,8 @@ class MultiMat {
       brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
         , Symmetry
-        , tk::StateFn()         // Not implemented!
-        , tk::StateFn()         // Not implemented!
+        , InvalidBC         // Not implemented!
+        , InvalidBC         // Not implemented!
         , SubsonicOutlet
         , Extrapolate } ) );
     }
@@ -1092,6 +1092,20 @@ class MultiMat {
                  tk::real, tk::real, tk::real, tk::real,
                  const std::array< tk::real, 3 >& )
     {
+      return {{ ul, ul }};
+    }
+
+    //! \brief State function for invalid/un-configured boundary conditions
+    //! \param[in] ul Left (domain-internal) state
+    //! \return Left and right states for all scalar components in this PDE
+    //!   system
+    //! \note The function signature must follow tk::StateFn
+    static tk::StateFn::result_type
+    InvalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
+               tk::real, tk::real, tk::real, tk::real,
+               const std::array< tk::real, 3> & )
+    {
+      Throw("Invalid boundary condition set up in input file");
       return {{ ul, ul }};
     }
 };

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -64,31 +64,6 @@ class MultiMat {
     using BCStateFn =
       std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
-    //! Extract BC configuration ignoring if BC not specified
-    //! \note A more preferable way of catching errors such as this function
-    //!   hides is during parsing, so that we don't even get here if BCs are not
-    //!   correctly specified. For now we simply ignore if BCs are not
-    //!   specified by allowing empty BC vectors from the user input.
-    struct ConfigBC {
-      std::size_t system;  //! Multimat system id
-      BCStateFn& state;    //!< BC state config: sidesets + statefn
-      const std::vector< tk::StateFn >& fn;    //!< BC state functions
-      std::size_t c;       //!< Counts BC types configured
-      //! Constructor
-      ConfigBC( std::size_t sys,
-                BCStateFn& s,
-                const std::vector< tk::StateFn >& f ) :
-        system(sys), state(s), fn(f), c(0) {}
-      //! Function to call for each BC type
-      template< typename U > void operator()( brigand::type_<U> ) {
-        std::vector< bcconf_t > cfg;
-        const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, U >();
-        if (v.size() > system) cfg = v[system];
-        Assert( fn.size() > c, "StateFn missing for BC type" );
-        state.push_back( { cfg, fn[c++] } );
-      }
-    };
-
   public:
     //! Constructor
     //! \param[in] c Equation system index (among multiple systems configured)
@@ -100,7 +75,7 @@ class MultiMat {
         g_inputdeck.get< tag::param, tag::multimat, tag::flux >().at(m_system) ) )
     {
       // associate boundary condition configurations with state functions
-      brigand::for_each< ctr::bc::Keys >( ConfigBC( m_system, m_bc,
+      brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
         , Symmetry
         , tk::StateFn()         // Not implemented!

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -61,23 +61,33 @@ class MultiMat {
     using ncomp_t = kw::ncomp::info::expect::type;
     using bcconf_t = kw::sideset::info::expect::type;
     using eq = tag::multimat;
+    using BCStateFn =
+      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
     //! Extract BC configuration ignoring if BC not specified
-    //! \param[in] c Equation system index (among multiple systems configured)
-    //! \return Vector of BC config of type bcconf_t used to apply BCs for all
-    //!   scalar components this Euler eq system is configured for
     //! \note A more preferable way of catching errors such as this function
     //!   hides is during parsing, so that we don't even get here if BCs are not
     //!   correctly specified. For now we simply ignore if BCs are not
     //!   specified by allowing empty BC vectors from the user input.
-    template< typename bctag >
-    std::vector< bcconf_t >
-    config( ncomp_t c ) {
-      std::vector< bcconf_t > bc;
-      const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, bctag >();
-      if (v.size() > c) bc = v[c];
-      return bc;
-    }
+    struct ConfigBC {
+      std::size_t system;  //! Multimat system id
+      BCStateFn& state;    //!< BC state config: sidesets + statefn
+      const std::vector< tk::StateFn >& fn;    //!< BC state functions
+      std::size_t c;       //!< Counts BC types configured
+      //! Constructor
+      ConfigBC( std::size_t sys,
+                BCStateFn& s,
+                const std::vector< tk::StateFn >& f ) :
+        system(sys), state(s), fn(f), c(0) {}
+      //! Function to call for each BC type
+      template< typename U > void operator()( brigand::type_<U> ) {
+        std::vector< bcconf_t > cfg;
+        const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, U >();
+        if (v.size() > system) cfg = v[system];
+        Assert( fn.size() > c, "StateFn missing for BC type" );
+        state.push_back( { cfg, fn[c++] } );
+      }
+    };
 
   public:
     //! Constructor
@@ -87,12 +97,17 @@ class MultiMat {
       m_ncomp( g_inputdeck.get< tag::component, eq >().at(c) ),
       m_offset( g_inputdeck.get< tag::component >().offset< eq >(c) ),
       m_riemann( tk::cref_find( multimatRiemannSolvers(),
-        g_inputdeck.get< tag::param, tag::multimat, tag::flux >().at(m_system) ) ),
-      m_bcdir( config< tag::bcdir >( c ) ),
-      m_bcsym( config< tag::bcsym >( c ) ),
-      m_bcsubsonicoutlet( config< tag::bcoutlet >( c ) ),
-      m_bcextrapolate( config< tag::bcextrapolate >( c ) )
-    {}
+        g_inputdeck.get< tag::param, tag::multimat, tag::flux >().at(m_system) ) )
+    {
+      // associate boundary condition configurations with state functions
+      brigand::for_each< ctr::bc::Keys >( ConfigBC( m_system, m_bc,
+        { Dirichlet
+        , Symmetry
+        , tk::StateFn()         // Not implemented!
+        , tk::StateFn()         // Not implemented!
+        , SubsonicOutlet
+        , Extrapolate } ) );
+    }
 
     //! Find the number of primitive quantities required for this PDE system
     //! \return The number of primitive quantities required to be stored for
@@ -321,14 +336,6 @@ class MultiMat {
       Assert( fd.Inpofa().size()/3 == fd.Esuf().size()/2,
               "Mismatch in inpofa size" );
 
-      // supported boundary condition types and associated state functions
-      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >
-        bctypes{{
-          { m_bcdir, Dirichlet },
-          { m_bcsym, Symmetry },
-          { m_bcsubsonicoutlet, SubsonicOutlet },
-          { m_bcextrapolate, Extrapolate } }};
-
       // allocate and initialize matrix and vector for reconstruction:
       // lhs_ls is the left-hand side matrix for solving the least-squares
       // system using the normal equation approach, for each mesh element.
@@ -367,7 +374,7 @@ class MultiMat {
       tk::intLeastSq_P0P1( nprim(), m_offset, rdof, fd, geoElem, P, rhsp_ls );
 
       // 2. boundary face contributions
-      for (const auto& b : bctypes)
+      for (const auto& b : m_bc)
       {
         tk::bndLeastSqConservedVar_P0P1( m_system, m_ncomp, m_offset, rdof,
           b.first, fd, geoFace, geoElem, t, b.second, U, rhsu_ls, nprim() );
@@ -484,13 +491,6 @@ class MultiMat {
       auto velfn = [this]( ncomp_t, ncomp_t, tk::real, tk::real, tk::real ){
         return std::vector< std::array< tk::real, 3 > >( m_ncomp ); };
 
-      // supported boundary condition types and associated state functions
-      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > > bctypes{{
-        { m_bcdir, Dirichlet },
-        { m_bcsym, Symmetry },
-        { m_bcsubsonicoutlet, SubsonicOutlet },
-        { m_bcextrapolate, Extrapolate } }};
-
       // compute internal surface flux integrals
       tk::surfInt( m_system, nmat, m_offset, ndof, rdof, inpoel, coord,
                    fd, geoFace, rieflxfn, velfn, U, P, ndofel, R,
@@ -506,7 +506,7 @@ class MultiMat {
                     flux, velfn, U, ndofel, R );
 
       // compute boundary surface flux integrals
-      for (const auto& b : bctypes)
+      for (const auto& b : m_bc)
         tk::bndSurfInt( m_system, nmat, m_offset, ndof, rdof, b.first,
                         fd, geoFace, inpoel, coord, t, rieflxfn, velfn,
                         b.second, U, P, ndofel, R, riemannDeriv );
@@ -848,13 +848,7 @@ class MultiMat {
     //! Riemann solver
     RiemannSolver m_riemann;
     //! Dirichlet BC configuration
-    const std::vector< bcconf_t > m_bcdir;
-    //! Symmetric BC configuration
-    const std::vector< bcconf_t > m_bcsym;
-    //! Subsonic outlet BC configuration
-    const std::vector< bcconf_t > m_bcsubsonicoutlet;
-    //! Extrapolation BC configuration
-    const std::vector< bcconf_t > m_bcextrapolate;
+    BCStateFn m_bc;
 
     //! Evaluate conservative part of physical flux function for this PDE system
     //! \param[in] system Equation system index

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -58,11 +58,7 @@ template< class Physics, class Problem >
 class MultiMat {
 
   private:
-    using ncomp_t = kw::ncomp::info::expect::type;
-    using bcconf_t = kw::sideset::info::expect::type;
     using eq = tag::multimat;
-    using BCStateFn =
-      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
   public:
     //! Constructor
@@ -76,12 +72,12 @@ class MultiMat {
     {
       // associate boundary condition configurations with state functions
       brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
-        { Dirichlet
-        , Symmetry
-        , InvalidBC         // Not implemented!
-        , InvalidBC         // Not implemented!
-        , SubsonicOutlet
-        , Extrapolate } ) );
+        { dirichlet
+        , symmetry
+        , invalidBC         // Inlet BC not implemented
+        , invalidBC         // Outlet BC not implemented
+        , subsonicOutlet
+        , extrapolate } ) );
     }
 
     //! Find the number of primitive quantities required for this PDE system
@@ -822,7 +818,7 @@ class MultiMat {
     const ncomp_t m_offset;
     //! Riemann solver
     RiemannSolver m_riemann;
-    //! Dirichlet BC configuration
+    //! BC configuration
     BCStateFn m_bc;
 
     //! Evaluate conservative part of physical flux function for this PDE system
@@ -913,7 +909,7 @@ class MultiMat {
     //!   left or right state is the vector of conserved quantities, followed by
     //!   the vector of primitive quantities appended to it.
     static tk::StateFn::result_type
-    Dirichlet( ncomp_t system, ncomp_t ncomp, const std::vector< tk::real >& ul,
+    dirichlet( ncomp_t system, ncomp_t ncomp, const std::vector< tk::real >& ul,
                tk::real x, tk::real y, tk::real z, tk::real t,
                const std::array< tk::real, 3 >& )
     {
@@ -966,7 +962,7 @@ class MultiMat {
     //!   left or right state is the vector of conserved quantities, followed by
     //!   the vector of primitive quantities appended to it.
     static tk::StateFn::result_type
-    Symmetry( ncomp_t system, ncomp_t ncomp, const std::vector< tk::real >& ul,
+    symmetry( ncomp_t system, ncomp_t ncomp, const std::vector< tk::real >& ul,
               tk::real, tk::real, tk::real, tk::real,
               const std::array< tk::real, 3 >& fn )
     {
@@ -1033,7 +1029,7 @@ class MultiMat {
     //!   pressure from the outside and other quantities from the internal cell.
     //! \note The function signature must follow tk::StateFn
     static tk::StateFn::result_type
-    SubsonicOutlet( ncomp_t system, ncomp_t ncomp,
+    subsonicOutlet( ncomp_t system, ncomp_t ncomp,
                     const std::vector< tk::real >& ul,
                     tk::real, tk::real, tk::real, tk::real,
                     const std::array< tk::real, 3 >& )
@@ -1088,24 +1084,10 @@ class MultiMat {
     //!   left or right state is the vector of conserved quantities, followed by
     //!   the vector of primitive quantities appended to it.
     static tk::StateFn::result_type
-    Extrapolate( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
+    extrapolate( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
                  tk::real, tk::real, tk::real, tk::real,
                  const std::array< tk::real, 3 >& )
     {
-      return {{ ul, ul }};
-    }
-
-    //! \brief State function for invalid/un-configured boundary conditions
-    //! \param[in] ul Left (domain-internal) state
-    //! \return Left and right states for all scalar components in this PDE
-    //!   system
-    //! \note The function signature must follow tk::StateFn
-    static tk::StateFn::result_type
-    InvalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
-               tk::real, tk::real, tk::real, tk::real,
-               const std::array< tk::real, 3> & )
-    {
-      Throw("Invalid boundary condition set up in input file");
       return {{ ul, ul }};
     }
 };

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -59,31 +59,6 @@ class Transport {
     using BCStateFn =
       std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
-    //! Extract BC configuration ignoring if BC not specified
-    //! \note A more preferable way of catching errors such as this function
-    //!   hides is during parsing, so that we don't even get here if BCs are not
-    //!   correctly specified. For now we simply ignore if BCs are not
-    //!   specified by allowing empty BC vectors from the user input.
-    struct ConfigBC {
-      std::size_t system;  //! Transport system id
-      BCStateFn& state;    //!< BC state config: sidesets + statefn
-      const std::vector< tk::StateFn >& fn;    //!< BC state functions
-      std::size_t c;       //!< Counts BC types configured
-      //! Constructor
-      ConfigBC( std::size_t sys,
-                BCStateFn& s,
-                const std::vector< tk::StateFn >& f ) :
-        system(sys), state(s), fn(f), c(0) {}
-      //! Function to call for each BC type
-      template< typename U > void operator()( brigand::type_<U> ) {
-        std::vector< bcconf_t > cfg;
-        const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, U >();
-        if (v.size() > system) cfg = v[system];
-        Assert( fn.size() > c, "StateFn missing for BC type" );
-        state.push_back( { cfg, fn[c++] } );
-      }
-    };
-
   public:
     //! Constructor
     //! \param[in] c Equation system index (among multiple systems configured)
@@ -97,7 +72,7 @@ class Transport {
         g_inputdeck.get< tag::component >().offset< eq >(c) )
     {
       // associate boundary condition configurations with state functions
-      brigand::for_each< ctr::bc::Keys >( ConfigBC( m_system, m_bc,
+      brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
         , tk::StateFn()  // Not implemented!
         , Inlet

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -56,23 +56,33 @@ class Transport {
     using ncomp_t = kw::ncomp::info::expect::type;
     using bcconf_t = kw::sideset::info::expect::type;
     using eq = tag::transport;
+    using BCStateFn =
+      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >;
 
     //! Extract BC configuration ignoring if BC not specified
-    //! \param[in] c Equation system index (among multiple systems configured)
-    //! \return Vector of BC config of type bcconf_t used to apply BCs for all
-    //!   scalar components this Transport eq system is configured for
     //! \note A more preferable way of catching errors such as this function
     //!   hides is during parsing, so that we don't even get here if BCs are not
     //!   correctly specified. For now we simply ignore if BCs are not
     //!   specified by allowing empty BC vectors from the user input.
-    template< typename bctag >
-    std::vector< bcconf_t >
-    config( ncomp_t c ) {
-      std::vector< bcconf_t > bc;
-      const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, bctag >();
-      if (v.size() > c) bc = v[c];
-      return bc;
-    }
+    struct ConfigBC {
+      std::size_t system;  //! Transport system id
+      BCStateFn& state;    //!< BC state config: sidesets + statefn
+      const std::vector< tk::StateFn >& fn;    //!< BC state functions
+      std::size_t c;       //!< Counts BC types configured
+      //! Constructor
+      ConfigBC( std::size_t sys,
+                BCStateFn& s,
+                const std::vector< tk::StateFn >& f ) :
+        system(sys), state(s), fn(f), c(0) {}
+      //! Function to call for each BC type
+      template< typename U > void operator()( brigand::type_<U> ) {
+        std::vector< bcconf_t > cfg;
+        const auto& v = g_inputdeck.get< tag::param, eq, tag::bc, U >();
+        if (v.size() > system) cfg = v[system];
+        Assert( fn.size() > c, "StateFn missing for BC type" );
+        state.push_back( { cfg, fn[c++] } );
+      }
+    };
 
   public:
     //! Constructor
@@ -84,12 +94,16 @@ class Transport {
       m_ncomp(
         g_inputdeck.get< tag::component >().get< eq >().at(c) ),
       m_offset(
-        g_inputdeck.get< tag::component >().offset< eq >(c) ),
-      m_bcextrapolate( config< tag::bcextrapolate >( c ) ),
-      m_bcinlet( config< tag::bcinlet >( c ) ),
-      m_bcoutlet( config< tag::bcoutlet >( c ) ),
-      m_bcdir( config< tag::bcdir >( c ) )
+        g_inputdeck.get< tag::component >().offset< eq >(c) )
     {
+      // associate boundary condition configurations with state functions
+      brigand::for_each< ctr::bc::Keys >( ConfigBC( m_system, m_bc,
+        { Dirichlet
+        , tk::StateFn()  // Not implemented!
+        , Inlet
+        , Outlet
+        , tk::StateFn()  // Not implemented!
+        , Extrapolate } ) );
       m_problem.errchk( m_system, m_ncomp );
     }
 
@@ -169,14 +183,6 @@ class Transport {
       Assert( fd.Inpofa().size()/3 == fd.Esuf().size()/2,
               "Mismatch in inpofa size" );
 
-      // supported boundary condition types and associated state functions
-      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > >
-        bctypes{{
-          { m_bcextrapolate, Extrapolate },
-          { m_bcinlet, Inlet },
-          { m_bcoutlet, Outlet },
-          { m_bcdir, Dirichlet } }};
-
       // allocate and initialize matrix and vector for reconstruction
       std::vector< std::array< std::array< tk::real, 3 >, 3 > >
         lhs_ls( nelem, {{ {{0.0, 0.0, 0.0}},
@@ -195,7 +201,7 @@ class Transport {
       tk::intLeastSq_P0P1( m_ncomp, m_offset, rdof, fd, geoElem, U, rhs_ls );
 
       // 2. boundary face contributions
-      for (const auto& b : bctypes)
+      for (const auto& b : m_bc)
         tk::bndLeastSqConservedVar_P0P1( m_system, m_ncomp, m_offset, rdof,
           b.first, fd, geoFace, geoElem, t, b.second, U, rhs_ls );
 
@@ -281,13 +287,6 @@ class Transport {
       // system of PDEs.
       std::vector< std::vector < tk::real > > riemannDeriv;
 
-      // supported boundary condition types and associated state functions
-      std::vector< std::pair< std::vector< bcconf_t >, tk::StateFn > > bctypes{{
-        { m_bcextrapolate, Extrapolate },
-        { m_bcinlet, Inlet },
-        { m_bcoutlet, Outlet },
-        { m_bcdir, Dirichlet } }};
-
       // compute internal surface flux integrals
       tk::surfInt( m_system, 1, m_offset, ndof, rdof, inpoel, coord,
                    fd, geoFace, Upwind::flux, Problem::prescribedVelocity, U, P,
@@ -299,7 +298,7 @@ class Transport {
                     flux, Problem::prescribedVelocity, U, ndofel, R );
 
       // compute boundary surface flux integrals
-      for (const auto& b : bctypes)
+      for (const auto& b : m_bc)
         tk::bndSurfInt( m_system, 1, m_offset, ndof, rdof, b.first, fd,
           geoFace, inpoel, coord, t, Upwind::flux, Problem::prescribedVelocity,
           b.second, U, P, ndofel, R, riemannDeriv );
@@ -430,14 +429,8 @@ class Transport {
     const ncomp_t m_system;             //!< Equation system index
     const ncomp_t m_ncomp;              //!< Number of components in this PDE
     const ncomp_t m_offset;             //!< Offset this PDE operates from
-    //! Extrapolation BC configuration
-    const std::vector< bcconf_t > m_bcextrapolate;
-    //! Inlet BC configuration
-    const std::vector< bcconf_t > m_bcinlet;
-    //! Outlet BC configuration
-    const std::vector< bcconf_t > m_bcoutlet;
-    //! Dirichlet BC configuration
-    const std::vector< bcconf_t > m_bcdir;
+    //! BC configuration
+    BCStateFn m_bc;
 
     //! Evaluate physical flux function for this PDE system
     //! \param[in] ncomp Number of scalar components in this PDE system

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -74,10 +74,10 @@ class Transport {
       // associate boundary condition configurations with state functions
       brigand::for_each< ctr::bc::Keys >( ConfigBC< eq >( m_system, m_bc,
         { Dirichlet
-        , tk::StateFn()  // Not implemented!
+        , InvalidBC  // Not implemented!
         , Inlet
         , Outlet
-        , tk::StateFn()  // Not implemented!
+        , InvalidBC  // Not implemented!
         , Extrapolate } ) );
       m_problem.errchk( m_system, m_ncomp );
     }
@@ -494,6 +494,20 @@ class Transport {
                const std::array< tk::real, 3 >& )
     {
       return {{ ul, Problem::solution( system, ncomp, x, y, z, t ) }};
+    }
+
+    //! \brief State function for invalid/un-configured boundary conditions
+    //! \param[in] ul Left (domain-internal) state
+    //! \return Left and right states for all scalar components in this PDE
+    //!   system
+    //! \note The function signature must follow tk::StateFn
+    static tk::StateFn::result_type
+    InvalidBC( ncomp_t, ncomp_t, const std::vector< tk::real >& ul,
+               tk::real, tk::real, tk::real, tk::real,
+               const std::array< tk::real, 3> & )
+    {
+      Throw("Invalid boundary condition set up in input file");
+      return {{ ul, ul }};
     }
 };
 


### PR DESCRIPTION
Replace BC config with a compile-time loop over all BC types supported, thus automatically associating a state function to all BC types in `dg::CompFlow`. Note the stubs as empty `tk::StateFn()`s for inlet and outlet.

The same should be done for `dg::Transport` and `dg::MultiMat` if the BCs in the `ctr::bc` tuple makes sense for all PDE types. Also, should the `farfield_*` BCs be included in the `ctr::bc` tuple? @adityakpandare, can you do this and push it to this branch? Thanks. (We could probably lift `ConfigBC` to `DGPDE.hpp` and reuse it for other PDE types.)

This will resolve #383.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/384)
<!-- Reviewable:end -->
