### PR TITLE
Correct the volume fraction to maintain unit-sum, after trace-material cleanup

### DIFF
--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -240,11 +240,16 @@ class MultiMat {
             auto rhomat = eos_density< tag::multimat >(m_system, pmax, tmax, k);
             auto rhoEmat = eos_totalenergy< tag::multimat >(m_system, rhomat,
               u, v, w, pmax, k);
+            auto almod = al_eps
+              - unk(e, volfracDofIdx(nmat, k, rdof, 0), m_offset);
 
             // clean conserved quantities
             unk(e, volfracDofIdx(nmat, k, rdof, 0), m_offset) = al_eps;
             unk(e, densityDofIdx(nmat, k, rdof, 0), m_offset) = al_eps*rhomat;
             unk(e, energyDofIdx(nmat, k, rdof, 0), m_offset) = al_eps*rhoEmat;
+
+            // correct major material state
+            unk(e, volfracDofIdx(nmat, kmax, rdof, 0), m_offset) -= almod;
 
             // clean primitive quantities
             prim(e, pressureDofIdx(nmat, k, rdof, 0), m_offset) = al_eps*pmax;


### PR DESCRIPTION
This fixes a "bug" that causes inconsistencies in the volume-fraction if the trace-material cleanup is used. If the trace cleanup is used, the volume fraction should be redistributed to maintain unit-sum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/398)
<!-- Reviewable:end -->
