### PR TITLE
Switch the order of filling the node gradients in ALECG

### DIFF
--- a/src/Base/Progress.hpp
+++ b/src/Base/Progress.hpp
@@ -59,11 +59,15 @@ class Progress {
    //!   is usually a list of multiple sub-tasks happening at the same time.
    //!   Appending to msg we also output the legend of subtasks in parentheses.
    void start( const Print& print, const std::string& msg ) {
-     std::string legend( " (" );
-     for (const auto& l : m_legend) legend.append( l + ", " );
-     legend.pop_back();
-     legend.pop_back();
-     legend.append( ") ... " );
+     std::string legend;
+     if (m_feedback) {
+       legend.append( " (" );
+       for (const auto& l : m_legend) legend.append( l + ", " );
+       legend.pop_back();
+       legend.pop_back();
+       legend.append( ")" );
+     }
+     legend.append( " ..." );
      print.diagstart( msg + legend );
      m_progress_size = 0;
    }

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -738,7 +738,7 @@ ALECG::rhs()
   auto prev_rkcoef = m_stage == 0 ? 0.0 : rkcoef[m_stage-1];
   for (const auto& eq : g_cgpde)
     eq.rhs( d->T() + prev_rkcoef * d->Dt(), d->Coord(), d->Inpoel(),
-            m_triinpoel, d->Gid(), d->Bid(), d->Lid(), m_dfn, m_psup, m_bnorm,
+            m_triinpoel, d->Bid(), d->Lid(), m_dfn, m_psup, m_bnorm,
             d->Vol(), m_grad, m_u, m_rhs );
 
   // Query and match user-specified boundary conditions to side sets

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -582,13 +582,13 @@ ALECG::normfinal()
       auto m = ( nit != m_dfnormc.end() ) ? nit->second : n;
       // orient normals
       if (gid[p] > gid[q]) { tk::flip(n); tk::flip(m); }
-      m_dfn[k*6+0] = n[0];
-      m_dfn[k*6+1] = n[1];
-      m_dfn[k*6+2] = n[2];
-      m_dfn[k*6+3] = m[0];
-      m_dfn[k*6+4] = m[1];
-      m_dfn[k*6+5] = m[2];
-      ++k;
+      m_dfn[k+0] = n[0];
+      m_dfn[k+1] = n[1];
+      m_dfn[k+2] = n[2];
+      m_dfn[k+3] = m[0];
+      m_dfn[k+4] = m[1];
+      m_dfn[k+5] = m[2];
+      k += 6;
     }
 
   tk::destroy( m_dfnorm );

--- a/src/Inciter/DiagCG.cpp
+++ b/src/Inciter/DiagCG.cpp
@@ -85,7 +85,7 @@ DiagCG::DiagCG( const CProxy_Discretization& disc,
   if (g_inputdeck.get< tag::discr, tag::operator_reorder >()) {
 
     auto d = Disc();
-    auto& inpoel = d->Inpoel();
+    const auto& inpoel = d->Inpoel();
 
     // Create new local ids based on access pattern of PDE operators
     std::unordered_map< std::size_t, std::size_t > map;

--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -607,7 +607,7 @@ Discretization::grindZero()
     tk::Print print( g_inputdeck.get< tag::cmd >().logname( def, m_nrestart ),
                      verbose ? std::cout : std::clog,
                      std::ios_base::app );
-    print.diag( "Starting time stepping" );
+    print.diag( "Starting time stepping ..." );
   }
 }
 

--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -607,7 +607,7 @@ Discretization::grindZero()
     tk::Print print( g_inputdeck.get< tag::cmd >().logname( def, m_nrestart ),
                      verbose ? std::cout : std::clog,
                      std::ios_base::app );
-    print.diag( "Starting time stepping ..." );
+    print.diag( "Starting time stepping" );
   }
 }
 

--- a/src/PDE/CGPDE.cpp
+++ b/src/PDE/CGPDE.cpp
@@ -79,12 +79,11 @@ nodegrad( ncomp_t ncomp,
           ncomp_t offset,
           const std::array< std::vector< tk::real >, 3 >& coord,
           const std::vector< std::size_t >& inpoel,
-          const std::vector< std::size_t >& gid,
           const std::unordered_map< std::size_t, std::size_t >& lid,
           const std::unordered_map< std::size_t, std::size_t >& bid,
           const std::vector< tk::real >& vol,
-         const std::tuple< std::vector< tk::real >,
-                           std::vector< tk::real > >& stag,
+          const std::tuple< std::vector< tk::real >,
+                            std::vector< tk::real > >& stag,
           const tk::Fields& U,
           const tk::Fields& G,
           tk::ElemGradFn egrad )
@@ -95,7 +94,6 @@ nodegrad( ncomp_t ncomp,
 //! \param[in] offset Offset this PDE system operates from
 //! \param[in] coord Mesh node coordinates
 //! \param[in] inpoel Mesh element connectivity
-//! \param[in] gid Local->global node id map
 //! \param[in] lid Global->local node ids
 //! \param[in] bid Local chare-boundary node ids (value) associated to
 //!    global node ids (key)
@@ -111,25 +109,22 @@ nodegrad( ncomp_t ncomp,
   tk::Fields Grad( U.nunk(), ncomp*3 );
   Grad.fill( 0.0 );
 
-  // copy in nodal gradients of chare-boundary points
-  for (const auto& [g,b] : bid) {
-    auto i = tk::cref_find( lid, g );
-    for (ncomp_t c=0; c<Grad.nprop(); ++c)
-      Grad(i,c,0) = G(b,c,0);
-  }
-
   // compute gradients of primitive variables in internal points
   for (std::size_t e=0; e<inpoel.size()/4; ++e) {
     const auto [N,g,u,J] = egrad( ncomp, offset, e, coord, inpoel, stag, U );
     auto J24 = J/24.0;
-    for (std::size_t a=0; a<4; ++a) {
-      auto i = bid.find( gid[N[a]] );
-      if (i == end(bid))    // only contribute to internal nodes
-        for (std::size_t b=0; b<4; ++b)
-          for (std::size_t j=0; j<3; ++j)
-            for (std::size_t c=0; c<ncomp; ++c)
-              Grad(N[a],c*3+j,0) += J24 * g[b][j] * u[c][b];
-    }
+    for (std::size_t a=0; a<4; ++a)
+      for (std::size_t b=0; b<4; ++b)
+        for (std::size_t j=0; j<3; ++j)
+          for (std::size_t c=0; c<ncomp; ++c)
+            Grad(N[a],c*3+j,0) += J24 * g[b][j] * u[c][b];
+  }
+
+  // put in nodal gradients of chare-boundary points
+  for (const auto& [g,b] : bid) {
+    auto i = tk::cref_find( lid, g );
+    for (ncomp_t c=0; c<Grad.nprop(); ++c)
+      Grad(i,c,0) = G(b,c,0);
   }
 
   // divide weak result in gradients by nodal volume

--- a/src/PDE/CGPDE.cpp
+++ b/src/PDE/CGPDE.cpp
@@ -135,7 +135,7 @@ nodegrad( ncomp_t ncomp,
   // divide weak result in gradients by nodal volume
   for (std::size_t p=0; p<Grad.nunk(); ++p)
     for (std::size_t c=0; c<Grad.nprop(); ++c)
-       Grad(p,c,0) /= vol[p];
+      Grad(p,c,0) /= vol[p];
 
   return Grad;
 }

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -62,12 +62,11 @@ nodegrad( ncomp_t ncomp,
           ncomp_t offset,
           const std::array< std::vector< tk::real >, 3 >& coord,
           const std::vector< std::size_t >& inpoel,
-          const std::vector< std::size_t >& gid,
           const std::unordered_map< std::size_t, std::size_t >& lid,
           const std::unordered_map< std::size_t, std::size_t >& bid,
           const std::vector< tk::real >& vol,
-         const std::tuple< std::vector< tk::real >,
-                           std::vector< tk::real > >& stag,
+          const std::tuple< std::vector< tk::real >,
+                            std::vector< tk::real > >& stag,
           const tk::Fields& U,
           const tk::Fields& G,
           tk::ElemGradFn egrad );
@@ -173,7 +172,6 @@ class CGPDE {
       const std::array< std::vector< tk::real >, 3 >& coord,
       const std::vector< std::size_t >& inpoel,
       const std::vector< std::size_t >& triinpoel,
-      const std::vector< std::size_t >& gid,
       const std::unordered_map< std::size_t, std::size_t >& bid,
       const std::unordered_map< std::size_t, std::size_t >& lid,
       const std::vector< tk::real >& dfn,
@@ -185,7 +183,7 @@ class CGPDE {
       const tk::Fields& G,
       const tk::Fields& U,
       tk::Fields& R ) const
-    { self->rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup,
+    { self->rhs( t, coord, inpoel, triinpoel, bid, lid, dfn, psup,
                  bnorm, vol, G, U, R ); }
 
     //! Public interface for computing the minimum time step size
@@ -298,7 +296,6 @@ class CGPDE {
         const std::array< std::vector< tk::real >, 3 >&,
         const std::vector< std::size_t >&,
         const std::vector< std::size_t >&,
-        const std::vector< std::size_t >&,
         const std::unordered_map< std::size_t, std::size_t >&,
         const std::unordered_map< std::size_t, std::size_t >&,
         const std::vector< tk::real >&,
@@ -381,7 +378,6 @@ class CGPDE {
         const std::array< std::vector< tk::real >, 3 >& coord,
         const std::vector< std::size_t >& inpoel,
         const std::vector< std::size_t >& triinpoel,
-        const std::vector< std::size_t >& gid,
         const std::unordered_map< std::size_t, std::size_t >& bid,
         const std::unordered_map< std::size_t, std::size_t >& lid,
         const std::vector< tk::real >& dfn,
@@ -393,7 +389,7 @@ class CGPDE {
         const tk::Fields& G,
         const tk::Fields& U,
         tk::Fields& R) const override
-      { data.rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup, bnorm,
+      { data.rhs( t, coord, inpoel, triinpoel, bid, lid, dfn, psup, bnorm,
                   vol, G, U, R ); }
       tk::real dt( const std::array< std::vector< tk::real >, 3 >& coord,
                    const std::vector< std::size_t >& inpoel,

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -336,7 +336,6 @@ class CompFlow {
     //! \param[in] coord Mesh node coordinates
     //! \param[in] inpoel Mesh element connectivity
     //! \param[in] triinpoel Boundary triangle face connecitivity
-    //! \param[in] gid Local->global node id map
     //! \param[in] bid Local chare-boundary node ids (value) associated to
     //!    global node ids (key)
     //! \param[in] lid Global->local node ids
@@ -352,7 +351,6 @@ class CompFlow {
       const std::array< std::vector< tk::real >, 3 >& coord,
       const std::vector< std::size_t >& inpoel,
       const std::vector< std::size_t >& triinpoel,
-      const std::vector< std::size_t >& gid,
       const std::unordered_map< std::size_t, std::size_t >& bid,
       const std::unordered_map< std::size_t, std::size_t >& lid,
       const std::vector< tk::real >& dfn,
@@ -384,7 +382,7 @@ class CompFlow {
       for (ncomp_t c=0; c<m_ncomp; ++c) r[c] = R.cptr( c, m_offset );
 
       // compute/assemble gradients in points
-      auto Grad = nodegrad( m_ncomp, m_offset, coord, inpoel, gid, lid, bid,
+      auto Grad = nodegrad( m_ncomp, m_offset, coord, inpoel, lid, bid,
                             vol, m_stag, U, G, egrad );
 
       // domain-edge integral

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -778,7 +778,7 @@ class CompFlow {
     //! \return Tuple of element contribution
     //! \note The function signature must follow tk::ElemGradFn
     static tk::ElemGradFn::result_type
-    egrad( ncomp_t ncomp,
+    egrad( ncomp_t,
            ncomp_t offset,
            std::size_t e,
            const std::array< std::vector< tk::real >, 3 >& coord,
@@ -809,8 +809,8 @@ class CompFlow {
       for (std::size_t i=0; i<3; ++i)
         grad[0][i] = -grad[1][i]-grad[2][i]-grad[3][i];
       // access solution at element nodes
-      std::vector< std::array< tk::real, 4 > > u( ncomp );
-      for (ncomp_t c=0; c<ncomp; ++c) u[c] = U.extract( c, offset, N );
+      std::vector< std::array< tk::real, 4 > > u( m_ncomp );
+      for (ncomp_t c=0; c<m_ncomp; ++c) u[c] = U.extract( c, offset, N );
       // apply stagnation BCs
       for (std::size_t a=0; a<4; ++a)
         if (stagPoint( {x[N[a]],y[N[a]],z[N[a]]}, stag ))

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -186,7 +186,7 @@ class Transport {
       for (std::size_t p=0,k=0; p<U.nunk(); ++p) {  // for each point p
         for (auto q : tk::Around(psup,p)) {
           // access dual-face normals for edge p-q
-          std::array< tk::real, 3 > n{ dfn[k*6+0], dfn[k*6+1], dfn[k*6+2] };
+          std::array< tk::real, 3 > n{ dfn[k+0], dfn[k+1], dfn[k+2] };
           k += 6;
           // compute primitive variables at edge-end points (for Transport,
           // these are the same as the conserved variables)

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -184,10 +184,10 @@ class Transport {
 
       // domain-edge integral
       for (std::size_t p=0,k=0; p<U.nunk(); ++p) {  // for each point p
-        for (auto i=psup.second[p]+1; i<=psup.second[p+1]; ++i,++k) {
-          auto q = psup.first[i];
+        for (auto q : tk::Around(psup,p)) {
           // access dual-face normals for edge p-q
           std::array< tk::real, 3 > n{ dfn[k*6+0], dfn[k*6+1], dfn[k*6+2] };
+          k += 6;
           // compute primitive variables at edge-end points (for Transport,
           // these are the same as the conserved variables)
           std::vector< tk::real > uL( m_ncomp, 0.0 );

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -128,7 +128,6 @@ class Transport {
     //! \param[in] coord Mesh node coordinates
     //! \param[in] inpoel Mesh element connectivity
     //! \param[in] triinpoel Boundary triangle face connecitivity
-    //! \param[in] gid Local->global node id map
     //! \param[in] bid Local chare-boundary node ids (value) associated to
     //!    global node ids (key)
     //! \param[in] lid Global->local node ids
@@ -144,7 +143,6 @@ class Transport {
       const std::array< std::vector< tk::real >, 3 >&  coord,
       const std::vector< std::size_t >& inpoel,
       const std::vector< std::size_t >& triinpoel,
-      const std::vector< std::size_t >& gid,
       const std::unordered_map< std::size_t, std::size_t >& bid,
       const std::unordered_map< std::size_t, std::size_t >& lid,
       const std::vector< tk::real >& dfn,
@@ -176,7 +174,7 @@ class Transport {
       for (ncomp_t c=0; c<m_ncomp; ++c) r[c] = R.cptr( c, m_offset );
 
       // compute/assemble gradients in points
-      auto Grad = nodegrad( m_ncomp, m_offset, coord, inpoel, gid, lid, bid,
+      auto Grad = nodegrad( m_ncomp, m_offset, coord, inpoel, lid, bid,
                             vol, {}, U, G, egrad );
 
       // compute derived data structures


### PR DESCRIPTION
This commit switches the order in which the gradient data structure is populated in `ALECG`. This is in function `nodegrad` in `src/PDE/CGPDE.cpp`.

This allows eliminating a search in the loop over internal points, since the chare-boundary points will simply overwrite those. This results in a small performance increase and a reduction of some code complexity, since the global ids now do not have to be passed down to that function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/406)
<!-- Reviewable:end -->
