### PR TITLE
Extended stencil LS reconstruction using nodal-neighborhood

### DIFF
--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1419,7 +1419,7 @@ DG::reco()
     // if P0P1
     if (rdof == 4 && g_inputdeck.get< tag::discr, tag::ndof >() == 1)
       for (const auto& eq : g_dgpde)
-        eq.reconstruct( d->T(), m_geoFace, m_geoElem, m_fd, d->Inpoel(),
+        eq.reconstruct( d->T(), m_geoFace, m_geoElem, m_fd, m_esup, d->Inpoel(),
                         d->Coord(), m_u, m_p );
   }
 

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -147,6 +147,7 @@ class CompFlow {
                       const tk::Fields& geoFace,
                       const tk::Fields& geoElem,
                       const inciter::FaceData& fd,
+                      const std::map< std::size_t, std::vector< std::size_t > >&,
                       const std::vector< std::size_t >& inpoel,
                       const tk::UnsMesh::Coords& coord,
                       tk::Fields& U,

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -155,12 +155,14 @@ class DGPDE {
                       const tk::Fields& geoFace,
                       const tk::Fields& geoElem,
                       const inciter::FaceData& fd,
+                      const std::map< std::size_t, std::vector< std::size_t > >&
+                        esup,
                       const std::vector< std::size_t >& inpoel,
                       const tk::UnsMesh::Coords& coord,
                       tk::Fields& U,
                       tk::Fields& P ) const
     {
-      self->reconstruct( t, geoFace, geoElem, fd, inpoel, coord, U, P );
+      self->reconstruct( t, geoFace, geoElem, fd, esup, inpoel, coord, U, P );
     }
 
     //! Public interface to limiting the second-order solution
@@ -275,6 +277,8 @@ class DGPDE {
                                 const tk::Fields&,
                                 const tk::Fields&,
                                 const inciter::FaceData&,
+                                const std::map< std::size_t,
+                                  std::vector< std::size_t > >&,
                                 const std::vector< std::size_t >&,
                                 const tk::UnsMesh::Coords&,
                                 tk::Fields&,
@@ -358,12 +362,14 @@ class DGPDE {
                         const tk::Fields& geoFace,
                         const tk::Fields& geoElem,
                         const inciter::FaceData& fd,
+                        const std::map< std::size_t,
+                          std::vector< std::size_t > >& esup,
                         const std::vector< std::size_t >& inpoel,
                         const tk::UnsMesh::Coords& coord,
                         tk::Fields& U,
                         tk::Fields& P ) const override
       {
-        data.reconstruct( t, geoFace, geoElem, fd, inpoel, coord, U, P );
+        data.reconstruct( t, geoFace, geoElem, fd, esup, inpoel, coord, U, P );
       }
       void limit( tk::real t,
                   const tk::Fields& geoFace,

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -342,6 +342,7 @@ class MultiMat {
     //! \param[in] geoFace Face geometry array
     //! \param[in] geoElem Element geometry array
     //! \param[in] fd Face connectivity and boundary conditions object
+//    //! \param[in] esup Elements-surrounding-nodes connectivity
     //! \param[in] inpoel Element-node connectivity
     //! \param[in] coord Array of nodal coordinates
     //! \param[in,out] U Solution vector at recent time step
@@ -350,6 +351,8 @@ class MultiMat {
                       const tk::Fields& geoFace,
                       const tk::Fields& geoElem,
                       const inciter::FaceData& fd,
+                      const std::map< std::size_t, std::vector< std::size_t > >&
+                        /*esup*/,
                       const std::vector< std::size_t >& inpoel,
                       const tk::UnsMesh::Coords& coord,
                       tk::Fields& U,
@@ -412,6 +415,12 @@ class MultiMat {
       // 3. solve 3x3 least-squares system
       tk::solveLeastSq_P0P1( m_ncomp, m_offset, rdof, lhs_ls, rhsu_ls, U );
       tk::solveLeastSq_P0P1( nprim(), m_offset, rdof, lhs_ls, rhsp_ls, P );
+
+      //// 1. Reconstruct second-order dofs in Taylor space using nodal-stencils
+      //tk::recoLeastSqExtStencil( rdof, m_offset, nelem, esup, inpoel, geoElem,
+      //  U );
+      //tk::recoLeastSqExtStencil( rdof, m_offset, nelem, esup, inpoel, geoElem,
+      //  P );
 
       // 4. transform reconstructed derivatives to Dubiner dofs
       tk::transform_P0P1( m_ncomp, m_offset, rdof, nelem, inpoel, coord, U );

--- a/src/PDE/Reconstruction.cpp
+++ b/src/PDE/Reconstruction.cpp
@@ -402,6 +402,19 @@ tk::recoLeastSqExtStencil( std::size_t rdof,
 // *****************************************************************************
 //  \brief Reconstruct the second-order solution using least-squares approach
 //    from an extended stencil involving the node-neighbors
+//! \param[in] rdof Maximum number of reconstructed degrees of freedom
+//! \param[in] offset Offset this PDE system operates from
+//! \param[in] nelem Number of elements
+//! \param[in] esup Elements surrounding points
+//! \param[in] inpoel Element-node connectivity
+//! \param[in] geoElem Element geometry array
+//! \param[in,out] W Solution vector to be reconstructed at recent time step
+//! \details A second-order (piecewise linear) solution polynomial is obtained
+//!   from the first-order (piecewise constant) FV solutions by using a
+//!   least-squares (LS) reconstruction process. This LS reconstruction function
+//!   using the nodal-neighbors of a cell, to get an overdetermined system of
+//!   equations for the derivatives of the solution. This overdetermined system
+//!   is solved in the least-squares sense using the normal equations approach.
 // *****************************************************************************
 {
   const auto ncomp = W.nprop()/rdof;

--- a/src/PDE/Reconstruction.cpp
+++ b/src/PDE/Reconstruction.cpp
@@ -394,7 +394,7 @@ tk::solveLeastSq_P0P1( ncomp_t ncomp,
 void
 tk::recoLeastSqExtStencil( std::size_t rdof,
   std::size_t offset,
-  std::size_t nelem,
+  std::size_t nielem,
   const std::map< std::size_t, std::vector< std::size_t > >& esup,
   const std::vector< std::size_t >& inpoel,
   const Fields& geoElem,
@@ -404,7 +404,7 @@ tk::recoLeastSqExtStencil( std::size_t rdof,
 //    from an extended stencil involving the node-neighbors
 //! \param[in] rdof Maximum number of reconstructed degrees of freedom
 //! \param[in] offset Offset this PDE system operates from
-//! \param[in] nelem Number of elements
+//! \param[in] nielem Number of internal elements in this mesh chunk
 //! \param[in] esup Elements surrounding points
 //! \param[in] inpoel Element-node connectivity
 //! \param[in] geoElem Element geometry array
@@ -419,7 +419,7 @@ tk::recoLeastSqExtStencil( std::size_t rdof,
 {
   const auto ncomp = W.nprop()/rdof;
 
-  for (std::size_t e=0; e<nelem; ++e)
+  for (std::size_t e=0; e<nielem; ++e)
   {
     // lhs matrix
     std::array< std::array< tk::real, 3 >, 3 >
@@ -467,6 +467,9 @@ tk::recoLeastSqExtStencil( std::size_t rdof,
 
       auto ux = tk::cramer( lhs_ls, rhs_ls[c] );
 
+      // Update the P1 dofs with the reconstructioned gradients.
+      // Since this reconstruction does not affect the cell-averaged solution,
+      // W(e,mark+0,offset) is unchanged.
       W(e,mark+1,offset) = ux[0];
       W(e,mark+2,offset) = ux[1];
       W(e,mark+3,offset) = ux[2];

--- a/src/PDE/Reconstruction.hpp
+++ b/src/PDE/Reconstruction.hpp
@@ -91,6 +91,17 @@ solveLeastSq_P0P1(
   const std::vector< std::vector< std::array< real, 3 > > >& rhs,
   Fields& W );
 
+//! \brief Reconstruct the second-order solution using least-squares approach
+//!   from an extended stencil involving the node-neighbors
+void
+recoLeastSqExtStencil( std::size_t rdof,
+  std::size_t offset,
+  std::size_t nelem,
+  const std::map< std::size_t, std::vector< std::size_t > >& esup,
+  const std::vector< std::size_t >& inpoel,
+  const Fields& geoElem,
+  Fields& W );
+
 //! Transform the reconstructed P1-derivatives to the Dubiner dofs
 void
 transform_P0P1( ncomp_t ncomp,

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -142,6 +142,7 @@ class Transport {
                       const tk::Fields& geoFace,
                       const tk::Fields& geoElem,
                       const inciter::FaceData& fd,
+                      const std::map< std::size_t, std::vector< std::size_t > >&,
                       const std::vector< std::size_t >& inpoel,
                       const tk::UnsMesh::Coords& coord,
                       tk::Fields& U,


### PR DESCRIPTION
This branch adds the capability required for an extended stencil least-squares reconstruction. The nodal-neighborhood is used to extend the stencil. Currently unused, but very likely going to be necessary for interface compression and other interface sharpening methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/415)
<!-- Reviewable:end -->
