### PR TITLE
Removed problem-specific field outputs and field names for multimat

### DIFF
--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -40,6 +40,7 @@
 #include "MultiMat/MultiMatIndexing.hpp"
 #include "Reconstruction.hpp"
 #include "Limiter.hpp"
+#include "Problem/FieldOutput.hpp"
 
 namespace inciter {
 
@@ -759,28 +760,35 @@ class MultiMat {
     //! Return field names to be output to file
     //! \return Vector of strings labelling fields output in file
     std::vector< std::string > fieldNames() const
-    { return Problem::fieldNames( m_ncomp ); }
+    {
+      auto nmat =
+        g_inputdeck.get< tag::param, eq, tag::nmat >()[m_system];
+
+      return MultiMatFieldNames(nmat);
+    }
 
     //! Return field output going to file
-    //! \param[in] t Physical time
-    //! \param[in] V Total mesh volume
-    //! \param[in] geoElem Element geometry array
+    //! \param[in] nunk Number of unknowns
     //! \param[in,out] U Solution vector at recent time step
     //! \param[in] P Vector of primitive quantities at recent time step
     //! \return Vector of vectors to be output to file
     std::vector< std::vector< tk::real > >
-    fieldOutput( tk::real t,
-                 tk::real V,
+    fieldOutput( tk::real,
+                 tk::real,
                  std::size_t nunk,
-                 const tk::Fields& geoElem,
+                 const tk::Fields&,
                  tk::Fields& U,
                  const tk::Fields& P ) const
     {
-      std::array< std::vector< tk::real >, 3 > coord{
-        geoElem.extract(1,0), geoElem.extract(2,0), geoElem.extract(3,0) };
+      // number of degrees of freedom
+      const std::size_t rdof =
+        g_inputdeck.get< tag::discr, tag::rdof >();
 
-      return Problem::fieldOutput( m_system, m_ncomp, m_offset, nunk, t,
-                                   V, geoElem.extract(0,0), coord, U, P );
+      // number of materials
+      auto nmat =
+        g_inputdeck.get< tag::param, eq, tag::nmat >()[m_system];
+
+      return MultiMatFieldOutput(m_system, nmat, m_offset, nunk, rdof, U, P);
     }
 
     //! Return surface field output going to file

--- a/src/PDE/MultiMat/Problem/GasImpact.cpp
+++ b/src/PDE/MultiMat/Problem/GasImpact.cpp
@@ -17,7 +17,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "EoS/EoS.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
-#include "FieldOutput.hpp"
 
 namespace inciter {
 
@@ -110,54 +109,6 @@ MultiMatProblemGasImpact::solution( ncomp_t system,
   s[momentumIdx(nmat, 2)] = rb * w;
 
   return s;
-}
-
-std::vector< std::string >
-MultiMatProblemGasImpact::fieldNames( ncomp_t )
-// *****************************************************************************
-// Return field names to be output to file
-//! \return Vector of strings labelling fields output in file
-// *****************************************************************************
-{
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-
-  return MultiMatFieldNames(nmat);
-}
-
-std::vector< std::vector< tk::real > >
-MultiMatProblemGasImpact::fieldOutput(
-  ncomp_t system,
-  ncomp_t,
-  ncomp_t offset,
-  std::size_t nunk,
-  tk::real,
-  tk::real,
-  const std::vector< tk::real >&,
-  const std::array< std::vector< tk::real >, 3 >&,
-  tk::Fields& U,
-  const tk::Fields& P )
-// *****************************************************************************
-//  Return field output going to file
-//! \param[in] system Equation system index, i.e., which compressible
-//!   flow equation system we operate on among the systems of PDEs
-//! \param[in] offset System offset specifying the position of the system of
-//!   PDEs among other systems
-//! \param[in] nunk Number of unknowns to extract
-//! \param[in] U Solution vector at recent time step
-//! \param[in] P Vector of primitive quantities at recent time step
-//! \return Vector of vectors to be output to file
-// *****************************************************************************
-{
-  // number of degrees of freedom
-  const std::size_t rdof =
-    g_inputdeck.get< tag::discr, tag::rdof >();
-
-  // number of materials
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-  return MultiMatFieldOutput( system, nmat, offset, nunk, rdof, U, P );
 }
 
 std::vector< std::string >

--- a/src/PDE/MultiMat/Problem/GasImpact.hpp
+++ b/src/PDE/MultiMat/Problem/GasImpact.hpp
@@ -48,22 +48,6 @@ class MultiMatProblemGasImpact {
       return std::vector< tk::real >( ncomp, 0.0 );
     }
 
-    //! Return field names to be output to file
-    static std::vector< std::string > fieldNames( ncomp_t );
-
-    //! Return field output going to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t ncomp,
-                 ncomp_t offset,
-                 std::size_t nunk,
-                 tk::real,
-                 tk::real /*V*/,
-                 const std::vector< tk::real >& /*vol*/,
-                 const std::array< std::vector< tk::real >, 3 >& /*coord*/,
-                 tk::Fields& U,
-                 const tk::Fields& P );
-
     //! Return names of integral variables to be output to diagnostics file
     static std::vector< std::string > names( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
@@ -16,7 +16,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "EoS/EoS.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
-#include "FieldOutput.hpp"
 
 //namespace inciter {
 //
@@ -105,56 +104,6 @@ MultiMatProblemInterfaceAdvection::solution( ncomp_t system,
   s[momentumIdx(nmat, 2)] = rhob * w;
 
   return s;
-}
-
-std::vector< std::string >
-MultiMatProblemInterfaceAdvection::fieldNames( ncomp_t )
-// *****************************************************************************
-// Return field names to be output to file
-//! \return Vector of strings labelling fields output in file
-// *****************************************************************************
-{
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-
-  return MultiMatFieldNames(nmat);
-}
-
-std::vector< std::vector< tk::real > >
-MultiMatProblemInterfaceAdvection::fieldOutput(
-  ncomp_t system,
-  ncomp_t,
-  ncomp_t offset,
-  std::size_t nunk,
-  tk::real /*t*/,
-  tk::real,
-  const std::vector< tk::real >&,
-  const std::array< std::vector< tk::real >, 3 >& /*coord*/,
-  tk::Fields& U,
-  const tk::Fields& P )
-// *****************************************************************************
-//  Return field output going to file
-//! \param[in] system Equation system index, i.e., which compressible
-//!   flow equation system we operate on among the systems of PDEs
-//! \param[in] offset System offset specifying the position of the system of
-//!   PDEs among other systems
-//! \param[in] nunk Number of unknowns to extract
-//! \param[in] t Physical time
-//! \param[in] coord Mesh node coordinates
-//! \param[in] U Solution vector at recent time step
-//! \param[in] P Vector of primitive quantities at recent time step
-//! \return Vector of vectors to be output to file
-// *****************************************************************************
-{
-  // number of degrees of freedom
-  const std::size_t rdof =
-    g_inputdeck.get< tag::discr, tag::rdof >();
-
-  // number of materials
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-  return MultiMatFieldOutput( system, nmat, offset, nunk, rdof, U, P );
 }
 
 std::vector< std::string >

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.hpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.hpp
@@ -56,22 +56,6 @@ class MultiMatProblemInterfaceAdvection {
       return std::vector< tk::real >( ncomp, 0.0 );
     }
 
-    //! Return field names to be output to file
-    static std::vector< std::string > fieldNames( ncomp_t );
-
-    //! Return field output going to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t /*ncomp*/,
-                 ncomp_t offset,
-                 std::size_t nunk,
-                 tk::real t,
-                 tk::real,
-                 const std::vector< tk::real >&,
-                 const std::array< std::vector< tk::real >, 3 >& coord,
-                 tk::Fields& U,
-                 const tk::Fields& P );
-
     //! Return names of integral variables to be output to diagnostics file
     static std::vector< std::string > names( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/SodShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.cpp
@@ -17,7 +17,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "EoS/EoS.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
-#include "FieldOutput.hpp"
 
 namespace inciter {
 
@@ -109,54 +108,6 @@ MultiMatProblemSodShocktube::src( ncomp_t, ncomp_t ncomp, tk::real,
   std::vector< tk::real > s( ncomp, 0.0 );
 
   return s;
-}
-
-std::vector< std::string >
-MultiMatProblemSodShocktube::fieldNames( ncomp_t )
-// *****************************************************************************
-// Return field names to be output to file
-//! \return Vector of strings labelling fields output in file
-// *****************************************************************************
-{
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-
-  return MultiMatFieldNames(nmat);
-}
-
-std::vector< std::vector< tk::real > >
-MultiMatProblemSodShocktube::fieldOutput(
-  ncomp_t system,
-  ncomp_t,
-  ncomp_t offset,
-  std::size_t nunk,
-  tk::real,
-  tk::real,
-  const std::vector< tk::real >&,
-  const std::array< std::vector< tk::real >, 3 >&,
-  tk::Fields& U,
-  const tk::Fields& P )
-// *****************************************************************************
-//  Return field output going to file
-//! \param[in] system Equation system index, i.e., which compressible
-//!   flow equation system we operate on among the systems of PDEs
-//! \param[in] offset System offset specifying the position of the system of
-//!   PDEs among other systems
-//! \param[in] nunk Number of unknowns to extract
-//! \param[in] U Solution vector at recent time step
-//! \param[in] P Vector of primitive quantities at recent time step
-//! \return Vector of vectors to be output to file
-// *****************************************************************************
-{
-  // number of degrees of freedom
-  const std::size_t rdof =
-    g_inputdeck.get< tag::discr, tag::rdof >();
-
-  // number of materials
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-  return MultiMatFieldOutput( system, nmat, offset, nunk, rdof, U, P );
 }
 
 std::vector< std::string >

--- a/src/PDE/MultiMat/Problem/SodShocktube.hpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.hpp
@@ -44,22 +44,6 @@ class MultiMatProblemSodShocktube {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t ncomp, tk::real, tk::real, tk::real, tk::real );
 
-    //! Return field names to be output to file
-    static std::vector< std::string > fieldNames( ncomp_t );
-
-    //! Return field output going to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t /*ncomp*/,
-                 ncomp_t offset,
-                 std::size_t nunk,
-                 tk::real,
-                 tk::real /*V*/,
-                 const std::vector< tk::real >& /*vol*/,
-                 const std::array< std::vector< tk::real >, 3 >& /*coord*/,
-                 tk::Fields& U,
-                 const tk::Fields& P );
-
     //! Return names of integral variables to be output to diagnostics file
     static std::vector< std::string > names( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/TriplePoint.cpp
+++ b/src/PDE/MultiMat/Problem/TriplePoint.cpp
@@ -17,7 +17,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "EoS/EoS.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
-#include "FieldOutput.hpp"
 
 namespace inciter {
 
@@ -123,53 +122,6 @@ MultiMatProblemTriplePoint::src( ncomp_t, ncomp_t ncomp, tk::real,
   std::vector< tk::real > s( ncomp, 0.0 );
 
   return s;
-}
-
-std::vector< std::string >
-MultiMatProblemTriplePoint::fieldNames( ncomp_t )
-// *****************************************************************************
-// Return field names to be output to file
-//! \return Vector of strings labelling fields output in file
-// *****************************************************************************
-{
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-
-  return MultiMatFieldNames(nmat);
-}
-
-std::vector< std::vector< tk::real > >
-MultiMatProblemTriplePoint::fieldOutput(
-  ncomp_t system,
-  ncomp_t,
-  ncomp_t offset,
-  std::size_t nunk,
-  tk::real,
-  tk::real,
-  const std::vector< tk::real >&,
-  const std::array< std::vector< tk::real >, 3 >&,
-  tk::Fields& U,
-  const tk::Fields& P )
-// *****************************************************************************
-//  Return field output going to file
-//! \param[in] system Equation system index, i.e., which compressible
-//!   flow equation system we operate on among the systems of PDEs
-//! \param[in] offset System offset specifying the position of the system of
-//!   PDEs among other systems
-//! \param[in] U Solution vector at recent time step
-//! \param[in] P Vector of primitive quantities at recent time step
-//! \return Vector of vectors to be output to file
-// *****************************************************************************
-{
-  // number of degrees of freedom
-  const std::size_t rdof =
-    g_inputdeck.get< tag::discr, tag::rdof >();
-
-  // number of materials
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-  return MultiMatFieldOutput(system, nmat, offset, nunk, rdof, U, P);
 }
 
 std::vector< std::string >

--- a/src/PDE/MultiMat/Problem/TriplePoint.hpp
+++ b/src/PDE/MultiMat/Problem/TriplePoint.hpp
@@ -45,22 +45,6 @@ class MultiMatProblemTriplePoint {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! Return field names to be output to file
-    static std::vector< std::string > fieldNames( ncomp_t );
-
-    //! Return field output going to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t ncomp,
-                 ncomp_t offset,
-                 std::size_t nunk,
-                 tk::real,
-                 tk::real /*V*/,
-                 const std::vector< tk::real >& /*vol*/,
-                 const std::array< std::vector< tk::real >, 3 >& /*coord*/,
-                 tk::Fields& U,
-                 const tk::Fields& P );
-
     //! Return names of integral variables to be output to diagnostics file
     static std::vector< std::string > names( ncomp_t );
 

--- a/src/PDE/MultiMat/Problem/UserDefined.hpp
+++ b/src/PDE/MultiMat/Problem/UserDefined.hpp
@@ -22,7 +22,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "FunctionPrototypes.hpp"
 #include "Inciter/Options/Problem.hpp"
-#include "FieldOutput.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
 
 namespace inciter {
@@ -68,45 +67,6 @@ class MultiMatProblemUserDefined {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real )
     { return {{ 0.0, 0.0, 0.0, 0.0, 0.0 }}; }
-
-    //! Return field names to be output to file
-    //! \return Vector of strings labelling fields output in file
-    static std::vector< std::string > fieldNames( ncomp_t ) {
-      auto nmat =
-        g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-      return MultiMatFieldNames(nmat);
-    }
-
-    //! Return field output going to file
-    //! \param[in] system Equation system index, i.e., which compressible
-    //!   flow equation system we operate on among the systems of PDEs
-    //! \param[in] offset System offset specifying the position of the system of
-    //!   PDEs among other systems
-    //! \param[in] U Solution vector at recent time step
-    //! \param[in] P Vector of primitive variables at recent time step
-    //! \return Vector of vectors to be output to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t,
-                 ncomp_t offset,
-                 std::size_t nunk,
-                 tk::real,
-                 tk::real,
-                 const std::vector< tk::real >&,
-                 const std::array< std::vector< tk::real >, 3 >&,
-                 tk::Fields& U,
-                 const tk::Fields& P )
-    {
-      // number of degrees of freedom
-      const std::size_t rdof =
-        g_inputdeck.get< tag::discr, tag::rdof >();
-
-      // number of materials
-      auto nmat =
-        g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-      return MultiMatFieldOutput( system, nmat, offset, nunk, rdof, U, P );
-    }
 
     //! Return names of integral variables to be output to diagnostics file
     //! \return Vector of strings labelling integral variables output

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
@@ -17,7 +17,6 @@
 #include "Inciter/InputDeck/InputDeck.hpp"
 #include "EoS/EoS.hpp"
 #include "MultiMat/MultiMatIndexing.hpp"
-#include "FieldOutput.hpp"
 
 namespace inciter {
 
@@ -112,54 +111,6 @@ MultiMatProblemWaterAirShocktube::src( ncomp_t, ncomp_t ncomp, tk::real,
   std::vector< tk::real > s( ncomp, 0.0 );
 
   return s;
-}
-
-std::vector< std::string >
-MultiMatProblemWaterAirShocktube::fieldNames( ncomp_t )
-// *****************************************************************************
-// Return field names to be output to file
-//! \return Vector of strings labelling fields output in file
-// *****************************************************************************
-{
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[0];
-
-  return MultiMatFieldNames(nmat);
-}
-
-std::vector< std::vector< tk::real > >
-MultiMatProblemWaterAirShocktube::fieldOutput(
-  ncomp_t system,
-  ncomp_t,
-  ncomp_t offset,
-  std::size_t nunk,
-  tk::real,
-  tk::real,
-  const std::vector< tk::real >&,
-  const std::array< std::vector< tk::real >, 3 >&,
-  tk::Fields& U,
-  const tk::Fields& P )
-// *****************************************************************************
-//  Return field output going to file
-//! \param[in] system Equation system index, i.e., which compressible
-//!   flow equation system we operate on among the systems of PDEs
-//! \param[in] offset System offset specifying the position of the system of
-//!   PDEs among other systems
-//! \param[in] nunk Number of unknowns to extract
-//! \param[in] U Solution vector at recent time step
-//! \param[in] P Vector of primitive quantities at recent time step
-//! \return Vector of vectors to be output to file
-// *****************************************************************************
-{
-  // number of degrees of freedom
-  const std::size_t rdof =
-    g_inputdeck.get< tag::discr, tag::rdof >();
-
-  // number of materials
-  auto nmat =
-    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
-
-  return MultiMatFieldOutput( system, nmat, offset, nunk, rdof, U, P );
 }
 
 std::vector< std::string >

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.hpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.hpp
@@ -45,22 +45,6 @@ class MultiMatProblemWaterAirShocktube {
     static tk::SrcFn::result_type
     src( ncomp_t, ncomp_t, tk::real, tk::real, tk::real, tk::real );
 
-    //! Return field names to be output to file
-    static std::vector< std::string > fieldNames( ncomp_t );
-
-    //! Return field output going to file
-    static std::vector< std::vector< tk::real > >
-    fieldOutput( ncomp_t system,
-                 ncomp_t ncomp,
-                 ncomp_t offset,
-                 std::size_t,
-                 tk::real,
-                 tk::real /*V*/,
-                 const std::vector< tk::real >& /*vol*/,
-                 const std::array< std::vector< tk::real >, 3 >& /*coord*/,
-                 tk::Fields& U,
-                 const tk::Fields& P );
-
     //! Return names of integral variables to be output to diagnostics file
     static std::vector< std::string > names( ncomp_t );
 


### PR DESCRIPTION
Removes the Problem::fieldoutput and Problem::fieldnames members, which are not used in a problem-specific way for multimat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/420)
<!-- Reviewable:end -->
