### PR TITLE
Underwater explosion problem setup

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -228,7 +228,8 @@ class InputDeck : public tk::TaggedTuple< InputDeckMembers > {
                                    kw::waterair_shocktube,
                                    kw::triple_point,
                                    kw::gas_impact,
-                                   kw::shock_hebubble >;
+                                   kw::shock_hebubble,
+                                   kw::underwater_ex >;
 
     //! Set of tags to ignore when printing this InputDeck
     using ignore = CmdLine::ignore;

--- a/src/Control/Inciter/Options/Problem.hpp
+++ b/src/Control/Inciter/Options/Problem.hpp
@@ -41,7 +41,8 @@ enum class ProblemType : uint8_t { USER_DEFINED,
                                    WATERAIR_SHOCKTUBE,
                                    TRIPLE_POINT,
                                    GAS_IMPACT,
-                                   SHOCK_HEBUBBLE };
+                                   SHOCK_HEBUBBLE,
+                                   UNDERWATER_EX };
 
 //! Pack/Unpack ProblemType: forward overload to generic enum class packer
 inline void operator|( PUP::er& p, ProblemType& e ) { PUP::pup( p, e ); }
@@ -70,6 +71,7 @@ class Problem : public tk::Toggle< ProblemType > {
                                   , kw::triple_point
                                   , kw::gas_impact
                                   , kw::shock_hebubble
+                                  , kw::underwater_ex
                                   >;
 
     //! \brief Options constructor
@@ -101,7 +103,8 @@ class Problem : public tk::Toggle< ProblemType > {
           { ProblemType::WATERAIR_SHOCKTUBE, kw::waterair_shocktube::name() },
           { ProblemType::TRIPLE_POINT, kw::triple_point::name() },
           { ProblemType::GAS_IMPACT, kw::gas_impact::name() },
-          { ProblemType::SHOCK_HEBUBBLE, kw::shock_hebubble::name() }
+          { ProblemType::SHOCK_HEBUBBLE, kw::shock_hebubble::name() },
+          { ProblemType::UNDERWATER_EX, kw::underwater_ex::name() }
         },
         //! keywords -> Enums
         { { kw::user_defined::string(), ProblemType::USER_DEFINED },
@@ -130,7 +133,9 @@ class Problem : public tk::Toggle< ProblemType > {
           { kw::gas_impact::string(),
             ProblemType::GAS_IMPACT },
           { kw::shock_hebubble::string(),
-            ProblemType::SHOCK_HEBUBBLE }
+            ProblemType::SHOCK_HEBUBBLE },
+          { kw::underwater_ex::string(),
+            ProblemType::UNDERWATER_EX }
         } )
     {
        brigand::for_each< keywords >( assertPolicyCodes() );
@@ -181,6 +186,7 @@ class Problem : public tk::Toggle< ProblemType > {
       , { ProblemType::TRIPLE_POINT, *kw::triple_point::code() }
       , { ProblemType::GAS_IMPACT, *kw::gas_impact::code() }
       , { ProblemType::SHOCK_HEBUBBLE, *kw::shock_hebubble::code() }
+      , { ProblemType::UNDERWATER_EX, *kw::underwater_ex::code() }
     };
 };
 

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -4665,6 +4665,27 @@ struct shock_hebubble_info {
 using shock_hebubble =
   keyword< shock_hebubble_info, TAOCPP_PEGTL_STRING("shock_hebubble") >;
 
+struct underwater_ex_info {
+  using code = Code< T >;
+  static std::string name() { return "Underwater explosion problem"; }
+  static std::string shortDescription() { return
+    "Select the underwater explosion test problem "; }
+  static std::string longDescription() { return
+    R"(This keyword is used to select the underwater explosion test problem. The
+    purpose of this test problem is to test the correctness of the
+    multi-material algorithm and its interface capturing capabilities in the
+    presence of strong shocks and large deformations.
+    Example: "problem underwater_ex". For more details, see
+    Chiapolino, A., Saurel, R., & Nkonga, B. (2017). Sharpening diffuse
+    interfaces with compressible fluids on unstructured meshes. Journal of
+    Computational Physics, 340, 389-417.)"; }
+  struct expect {
+    static std::string description() { return "string"; }
+  };
+};
+using underwater_ex =
+  keyword< underwater_ex_info, TAOCPP_PEGTL_STRING("underwater_ex") >;
+
 struct problem_info {
   using code = Code< t >;
   static std::string name() { return "Test problem"; }

--- a/src/PDE/MultiMat/Problem.hpp
+++ b/src/PDE/MultiMat/Problem.hpp
@@ -54,6 +54,7 @@
 #include "Problem/TriplePoint.hpp"
 #include "Problem/GasImpact.hpp"
 #include "Problem/ShockHeBubble.hpp"
+#include "Problem/UnderwaterEx.hpp"
 
 namespace inciter {
 
@@ -65,7 +66,8 @@ using MultiMatProblems =
                , MultiMatProblemWaterAirShocktube
                , MultiMatProblemTriplePoint
                , MultiMatProblemGasImpact
-               , MultiMatProblemShockHeBubble >;
+               , MultiMatProblemShockHeBubble
+               , MultiMatProblemUnderwaterEx >;
 
 } // inciter::
 

--- a/src/PDE/MultiMat/Problem/CMakeLists.txt
+++ b/src/PDE/MultiMat/Problem/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(MultiMatProblem
             WaterAirShocktube.cpp
             TriplePoint.cpp
             GasImpact.cpp
-            ShockHeBubble.cpp)
+            ShockHeBubble.cpp
+            UnderwaterEx.cpp)
 
 target_include_directories(MultiMatProblem PUBLIC
                            ${QUINOA_SOURCE_DIR}

--- a/src/PDE/MultiMat/Problem/UnderwaterEx.cpp
+++ b/src/PDE/MultiMat/Problem/UnderwaterEx.cpp
@@ -1,0 +1,127 @@
+// *****************************************************************************
+/*!
+  \file      src/PDE/MultiMat/Problem/UnderwaterEx.cpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019-2020 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Problem configuration for the multi-material flow equations
+  \details   This file defines a Problem policy class for the multi-material
+    compressible flow equations, defined in PDE/MultiMat/DGMultiMat.hpp. See
+    PDE/MultiMat/Problem.hpp for general requirements on Problem policy classes
+    for MultiMat.
+*/
+// *****************************************************************************
+
+#include "UnderwaterEx.hpp"
+#include "Inciter/InputDeck/InputDeck.hpp"
+#include "EoS/EoS.hpp"
+#include "MultiMat/MultiMatIndexing.hpp"
+
+namespace inciter {
+
+extern ctr::InputDeck g_inputdeck;
+
+} // ::inciter
+
+using inciter::MultiMatProblemUnderwaterEx;
+
+tk::SolutionFn::result_type
+MultiMatProblemUnderwaterEx::solution( ncomp_t system,
+  ncomp_t ncomp,
+  tk::real x,
+  tk::real y,
+  tk::real z,
+  tk::real,
+  int& )
+// *****************************************************************************
+//! Evaluate analytical solution at (x,y,z,t) for all components
+//! \param[in] system Equation system index, i.e., which multi-material
+//!   flow equation system we operate on among the systems of PDEs
+//! \param[in] ncomp Number of scalar components in this PDE system
+//! \param[in] x X coordinate where to evaluate the solution
+//! \param[in] y Y coordinate where to evaluate the solution
+//! \param[in] z Z coordinate where to evaluate the solution
+//! \return Values of all components evaluated at (x)
+//! \note The function signature must follow tk::SolutionFn
+//! \details This function only initializes the underwater explosion problem,
+//!   but does not actually give the analytical solution at time greater than 0.
+// *****************************************************************************
+{
+  // see also Control/Inciter/InputDeck/Grammar.hpp
+  Assert( ncomp == 12, "Number of scalar components must be 12" );
+
+  auto nmat =
+    g_inputdeck.get< tag::param, eq, tag::nmat >()[system];
+
+  std::vector< tk::real > s(ncomp, 0.0), r(nmat, 0.0);
+  tk::real p, u, v, w, temp;
+  auto alphamin = 1.0e-12;
+
+  // velocity
+  u = 0.0;
+  v = 0.0;
+  w = 0.0;
+
+  // background state (air)
+  // volume-fraction
+  s[volfracIdx(nmat, 0)] = alphamin;
+  s[volfracIdx(nmat, 1)] = alphamin;
+  s[volfracIdx(nmat, 2)] = 1.0-2.0*alphamin;
+  // pressure
+  p = 1.01325e5;
+  // temperature
+  temp = 288.2;
+
+  auto radb = std::sqrt((y-1.0)*(y-1.0) + x*x + z*z);
+
+  // high-pressure gas bubble
+  if (radb <= 0.3) {
+    // volume-fraction
+    s[volfracIdx(nmat, 0)] = alphamin;
+    s[volfracIdx(nmat, 1)] = 1.0-2.0*alphamin;
+    s[volfracIdx(nmat, 2)] = alphamin;
+    // pressure
+    p = 1.0e9;
+    // temperature
+    temp = 2000.0;
+  }
+  // water level
+  else if (y <= 1.5) {
+    // volume-fraction
+    s[volfracIdx(nmat, 0)] = 1.0-2.0*alphamin;
+    s[volfracIdx(nmat, 1)] = alphamin;
+    s[volfracIdx(nmat, 2)] = alphamin;
+    // temperature
+    temp = 185.52;
+  }
+
+  auto rb(0.0);
+  for (std::size_t k=0; k<nmat; ++k)
+  {
+    // densities
+    r[k] = eos_density< eq >( system, p, temp, k );
+    // partial density
+    s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)]*r[k];
+    // total specific energy
+    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]*
+      eos_totalenergy< eq >( system, r[k], u, v, w, p, k );
+    rb += s[densityIdx(nmat, k)];
+  }
+
+  s[momentumIdx(nmat, 0)] = rb * u;
+  s[momentumIdx(nmat, 1)] = rb * v;
+  s[momentumIdx(nmat, 2)] = rb * w;
+
+  return s;
+}
+
+std::vector< std::string >
+MultiMatProblemUnderwaterEx::names( ncomp_t )
+// *****************************************************************************
+//  Return names of integral variables to be output to diagnostics file
+//! \return Vector of strings labelling integral variables output
+// *****************************************************************************
+{
+  return { "r", "ru", "rv", "rw", "re" };
+}

--- a/src/PDE/MultiMat/Problem/UnderwaterEx.hpp
+++ b/src/PDE/MultiMat/Problem/UnderwaterEx.hpp
@@ -1,0 +1,60 @@
+// *****************************************************************************
+/*!
+  \file      src/PDE/MultiMat/Problem/UnderwaterEx.hpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019-2020 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Problem configuration for underwater explosion
+  \details   This file defines a policy class for the multi-material
+    compressible flow equations, defined in PDE/MultiMat/DGMultiMat.hpp.
+    See PDE/MultiMat/Problem.hpp for general requirements on Problem policy
+    classes for MultiMat.
+*/
+// *****************************************************************************
+#ifndef MultiMatProblemUnderwaterEx_h
+#define MultiMatProblemUnderwaterEx_h
+
+#include <string>
+
+#include "Types.hpp"
+#include "Fields.hpp"
+#include "FunctionPrototypes.hpp"
+#include "SystemComponents.hpp"
+#include "Inciter/Options/Problem.hpp"
+
+namespace inciter {
+
+//! MultiMat system of PDEs problem: Underwater explosion problem
+//! \see Chiapolino, A., Saurel, R., & Nkonga, B. (2017). Sharpening diffuse         
+//!   interfaces with compressible fluids on unstructured meshes. Journal of      
+//!   Computational Physics, 340, 389-417.
+class MultiMatProblemUnderwaterEx {
+
+  protected:
+    using ncomp_t = tk::ctr::ncomp_t;
+    using eq = tag::multimat;
+
+  public:
+    //! Evaluate analytical solution at (x,y,0) for all components
+    static tk::SolutionFn::result_type
+    solution( ncomp_t system, ncomp_t ncomp, tk::real x, tk::real y, tk::real,
+              tk::real, int& );
+
+    //! Compute and return source term for this problem
+    static tk::MultiMatSrcFn::result_type
+    src( ncomp_t, tk::real, tk::real, tk::real, tk::real,
+         tk::real& r, tk::real& ru, tk::real& rv, tk::real& rw, tk::real& re )
+    { r = ru = rv = rw = re = 0.0; }
+
+    //! Return names of integral variables to be output to diagnostics file
+    static std::vector< std::string > names( ncomp_t );
+
+    //! Return problem type
+    static ctr::ProblemType type() noexcept
+    { return ctr::ProblemType::UNDERWATER_EX; }
+};
+
+} // inciter::
+
+#endif // MultiMatProblemUnderwaterEx_h

--- a/src/PDE/MultiMat/Problem/UnderwaterEx.hpp
+++ b/src/PDE/MultiMat/Problem/UnderwaterEx.hpp
@@ -26,8 +26,8 @@
 namespace inciter {
 
 //! MultiMat system of PDEs problem: Underwater explosion problem
-//! \see Chiapolino, A., Saurel, R., & Nkonga, B. (2017). Sharpening diffuse         
-//!   interfaces with compressible fluids on unstructured meshes. Journal of      
+//! \see Chiapolino, A., Saurel, R., & Nkonga, B. (2017). Sharpening diffuse
+//!   interfaces with compressible fluids on unstructured meshes. Journal of
 //!   Computational Physics, 340, 389-417.
 class MultiMatProblemUnderwaterEx {
 


### PR DESCRIPTION
setup for the underwater explosion problem which requires a sphere to be set up with high pressure, 0.5 m under water level. Air at NTP is initialized above water level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/427)
<!-- Reviewable:end -->
