### PR TITLE
Skip BC

### DIFF
--- a/src/Control/CommonGrammar.hpp
+++ b/src/Control/CommonGrammar.hpp
@@ -137,6 +137,7 @@ namespace grm {
     SYSFCTVAR,          //!< System-FCT variable index incorrect
     BGICMISSING,        //!< Background IC unspecified
     STAGBCWRONG,        //!< Stagnation BC incorrectly configured
+    SKIPBCWRONG,        //!< Skip BC incorrectly configured
     NONDISJOINTBC,      //!< Different BC types assigned to the same side set
     WRONGSIZE,          //!< Size of parameter vector incorrect
     HYDROTIMESCALES,    //!< Missing required hydrotimescales vector
@@ -357,6 +358,11 @@ namespace grm {
       "The block must list integers between 1 and 5 both inclusive." },
     { MsgKey::STAGBCWRONG, "Stagnation boundary conditions incorrectly "
       "configured. Within a bc_stag ... end block there must be a point ... "
+      "end block and a radius ... end block. Both point and radius blocks must "
+      "contain floating-point numbers, and the number of items in the point "
+      "block must be exactly 3x that of radii." },
+    { MsgKey::SKIPBCWRONG, "Skip boundary conditions incorrectly "
+      "configured. Within a bc_skip ... end block there must be a point ... "
       "end block and a radius ... end block. Both point and radius blocks must "
       "contain floating-point numbers, and the number of items in the point "
       "block must be exactly 3x that of radii." },

--- a/src/Control/Inciter/InputDeck/Grammar.hpp
+++ b/src/Control/Inciter/InputDeck/Grammar.hpp
@@ -292,21 +292,40 @@ namespace grm {
 
       // Error check stagnation BC block
       const auto& bcstag = stack.template get< tag::param, eq, tag::bcstag >();
-      const auto& point = bcstag.template get< tag::point >();
-      const auto& radius = bcstag.template get< tag::radius >();
-      if ( (!point.empty() && !point.back().empty() &&
-            !radius.empty() && !radius.back().empty() &&
-            point.back().size() != 3*radius.back().size()) ||
-           (!radius.empty() && !radius.back().empty() &&
-            !point.empty() && !point.back().empty() &&
-            point.back().size() != 3*radius.back().size()) ||
-           (!point.empty() && !point.back().empty() &&
-            (radius.empty() || (!radius.empty() && radius.back().empty()))) ||
-           (!radius.empty() && !radius.back().empty() &&
-            (point.empty() || (!point.empty() && point.back().empty())))
+      const auto& spoint = bcstag.template get< tag::point >();
+      const auto& sradius = bcstag.template get< tag::radius >();
+      if ( (!spoint.empty() && !spoint.back().empty() &&
+            !sradius.empty() && !sradius.back().empty() &&
+            spoint.back().size() != 3*sradius.back().size()) ||
+           (!sradius.empty() && !sradius.back().empty() &&
+            !spoint.empty() && !spoint.back().empty() &&
+            spoint.back().size() != 3*sradius.back().size()) ||
+           (!spoint.empty() && !spoint.back().empty() &&
+            (sradius.empty() || (!sradius.empty() && sradius.back().empty())))||
+           (!sradius.empty() && !sradius.back().empty() &&
+            (spoint.empty() || (!spoint.empty() && spoint.back().empty())))
          )
       {
         Message< Stack, ERROR, MsgKey::STAGBCWRONG >( stack, in );
+      }
+
+      // Error check skip BC block
+      const auto& bcskip = stack.template get< tag::param, eq, tag::bcskip >();
+      const auto& kpoint = bcskip.template get< tag::point >();
+      const auto& kradius = bcskip.template get< tag::radius >();
+      if ( (!kpoint.empty() && !kpoint.back().empty() &&
+            !kradius.empty() && !kradius.back().empty() &&
+            kpoint.back().size() != 3*kradius.back().size()) ||
+           (!kradius.empty() && !kradius.back().empty() &&
+            !kpoint.empty() && !kpoint.back().empty() &&
+            kpoint.back().size() != 3*kradius.back().size()) ||
+           (!kpoint.empty() && !kpoint.back().empty() &&
+            (kradius.empty() || (!kradius.empty() && kradius.back().empty())))||
+           (!kradius.empty() && !kradius.back().empty() &&
+            (kpoint.empty() || (!kpoint.empty() && kpoint.back().empty())))
+         )
+      {
+        Message< Stack, ERROR, MsgKey::SKIPBCWRONG >( stack, in );
       }
     }
   };
@@ -791,10 +810,10 @@ namespace deck {
                                         eq, tag::bc, param > > > {};
 
   //! Stagnation boundary conditions block
-  template< class eq, class param >
-  struct bc_stag :
+  template< class eq, class bc, class kwbc >
+  struct bc_spec :
          pegtl::if_must<
-           tk::grm::readkw< kw::bc_stag::pegtl_string >,
+           tk::grm::readkw< typename kwbc::pegtl_string >,
            tk::grm::block<
              use< kw::end >,
              tk::grm::parameter_vector< use,
@@ -802,13 +821,13 @@ namespace deck {
                                         tk::grm::Store_back_back,
                                         tk::grm::start_vector,
                                         tk::grm::check_vector,
-                                        eq, tag::bcstag, tag::radius >,
+                                        eq, bc, tag::radius >,
              tk::grm::parameter_vector< use,
                                         use< kw::point >,
                                         tk::grm::Store_back_back,
                                         tk::grm::start_vector,
                                         tk::grm::check_vector,
-                                        eq, tag::bcstag, tag::point > > > {};
+                                        eq, bc, tag::point > > > {};
 
   //! Farfield boundary conditions block
   template< class keyword, class eq, class param >
@@ -1015,7 +1034,8 @@ namespace deck {
                                       tag::kappa >,
                            bc< kw::bc_dirichlet, tag::compflow, tag::bcdir >,
                            bc< kw::bc_sym, tag::compflow, tag::bcsym >,
-                           bc_stag< tag::compflow, tag::bcstag >,
+                           bc_spec< tag::compflow, tag::bcstag, kw::bc_stag >,
+                           bc_spec< tag::compflow, tag::bcskip, kw::bc_skip >,
                            bc< kw::bc_inlet, tag::compflow, tag::bcinlet >,
                            farfield_bc< kw::bc_farfield,
                                         tag::compflow,

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -213,6 +213,7 @@ class InputDeck : public tk::TaggedTuple< InputDeckMembers > {
                                    kw::bc_farfield,
                                    kw::bc_extrapolate,
                                    kw::bc_stag,
+                                   kw::bc_skip,
                                    kw::point,
                                    kw::radius,
                                    kw::gauss_hump,
@@ -327,24 +328,25 @@ class InputDeck : public tk::TaggedTuple< InputDeckMembers > {
       return ids;
     }
 
-    //! Query stagnation point BC configuration
+    //! Query special point BC configuration
     //! \tparam eq PDE type to query
+    //! \tparam bc  Special BC type to query, e.g., stagnation, skip
     //! \param[in] system Equation system id
-    //! \return Vectors configuring the stagnation points and their radii
-    template< class eq >
+    //! \return Vectors configuring the special points and their radii
+    template< class eq, class bc >
     std::tuple< std::vector< tk::real >, std::vector< tk::real > >
-    stagnationBC( std::size_t system ) {
-      const auto& bcstag = get< tag::param, eq, tag::bcstag >();
-      const auto& point = bcstag.template get< tag::point >();
-      const auto& radius = bcstag.template get< tag::radius >();
-      std::vector< tk::real > stag_pnt;
-      std::vector< tk::real > stag_rad;
+    specialBC( std::size_t system ) {
+      const auto& bcspec = get< tag::param, eq, bc >();
+      const auto& point = bcspec.template get< tag::point >();
+      const auto& radius = bcspec.template get< tag::radius >();
+      std::vector< tk::real > pnt;
+      std::vector< tk::real > rad;
       if (point.size() > system && radius.size() > system) {
-        stag_pnt = point[ system ];
-        stag_rad = radius[ system ];
+        pnt = point[ system ];
+        rad = radius[ system ];
       }
-      Assert( stag_pnt.size() == 3*stag_rad.size(), "Size mismatch" );
-      return { std::move(stag_pnt), std::move(stag_rad) };
+      Assert( pnt.size() == 3*rad.size(), "Size mismatch" );
+      return { std::move(pnt), std::move(rad) };
     }
 };
 

--- a/src/Control/Inciter/Types.hpp
+++ b/src/Control/Inciter/Types.hpp
@@ -229,6 +229,14 @@ using StagnationBCParameters = tk::TaggedTuple< brigand::list<
                           std::vector< kw::radius::info::expect::type > >
 > >;
 
+//! Skip boundary conditions parameters storage
+using SkipBCParameters = tk::TaggedTuple< brigand::list<
+    tag::point,         std::vector<
+                          std::vector< kw::point::info::expect::type > >
+  , tag::radius,        std::vector<
+                          std::vector< kw::radius::info::expect::type > >
+> >;
+
 //! Compressible flow equation parameters storage
 using CompFlowPDEParameters = tk::TaggedTuple< brigand::list<
     tag::depvar,        std::vector< char >
@@ -242,6 +250,8 @@ using CompFlowPDEParameters = tk::TaggedTuple< brigand::list<
   , tag::ic,            ic
   //! Stagnation boundary condition configuration storage
   , tag::bcstag,        StagnationBCParameters
+  //! Skip boundary condition configuration storage
+  , tag::bcskip,        SkipBCParameters
   //! System FCT character
   , tag::sysfct,        std::vector< int >
   //! Indices of system-FCT scalar components considered as a system

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -5129,6 +5129,23 @@ struct bc_stag_info {
 };
 using bc_stag = keyword< bc_stag_info, TAOCPP_PEGTL_STRING("bc_stag") >;
 
+struct bc_skip_info {
+  static std::string name() { return "Skip boundary condition"; }
+  static std::string shortDescription() { return
+    "Start configuration block describing skip boundary conditions"; }
+  static std::string longDescription() { return
+    R"(This keyword is used to introduce an bc_skip ... end block, used to
+    specify the configuration for setting 'skip' boundary conditions for a
+    partial differential equation. If a mesh point falls into a skip region,
+    configured by a point and a radius, any application of boundary conditions
+    on those points will be skipped. Keywords allowed in a bc_skip ... end
+    block: )" + std::string("\'")
+    + point::string() + "\', \'"
+    + radius::string() + "\'. ";
+  }
+};
+using bc_skip = keyword< bc_skip_info, TAOCPP_PEGTL_STRING("bc_skip") >;
+
 struct bc_inlet_info {
   static std::string name() { return "Inlet boundary condition"; }
   static std::string shortDescription() { return

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -245,6 +245,7 @@ struct u0 { static std::string name() { return "u0"; } };
 struct bcdir { static std::string name() { return "bcdir"; } };
 struct bcsym { static std::string name() { return "bcsym"; } };
 struct bcstag { static std::string name() { return "bcstag"; } };
+struct bcskip { static std::string name() { return "bcskip"; } };
 struct point { static std::string name() { return "point"; } };
 struct radius { static std::string name() { return "radius"; } };
 struct bcinlet { static std::string name() { return "bcinlet"; } };

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -602,10 +602,10 @@ ALECG::normfinal()
 
   // Apply symmetry BCs on initial conditions
   for (const auto& eq : g_cgpde)
-    eq.symbc( m_u, m_bnorm, m_symbcnodes );
+    eq.symbc( m_u, d->Coord(), m_bnorm, m_symbcnodes );
   // Apply farfield BCs on initial conditions
   for (const auto& eq : g_cgpde)
-    eq.farfieldbc( m_u, m_bnorm, m_farfieldbcnodes );
+    eq.farfieldbc( m_u, d->Coord(), m_bnorm, m_farfieldbcnodes );
 
   // Prepare boundary nodes contiguously accessible from a triangle-face loop
   m_symbctri.resize( m_triinpoel.size()/3, 0 );
@@ -944,10 +944,10 @@ ALECG::solve()
 
   // Apply symmetry BCs on initial conditions
   for (const auto& eq : g_cgpde)
-    eq.symbc( m_u, m_bnorm, m_symbcnodes );
+    eq.symbc( m_u, d->Coord(), m_bnorm, m_symbcnodes );
   // Apply farfield BCs on new solution
   for (const auto& eq : g_cgpde)
-    eq.farfieldbc( m_u, m_bnorm, m_farfieldbcnodes );
+    eq.farfieldbc( m_u, d->Coord(), m_bnorm, m_farfieldbcnodes );
 
   //! [Continue after solve]
   if (m_stage < 2) {

--- a/src/Inciter/DiagCG.cpp
+++ b/src/Inciter/DiagCG.cpp
@@ -292,16 +292,17 @@ DiagCG::setup()
 // *****************************************************************************
 {
   auto d = Disc();
+  const auto& coord = d->Coord();
 
   // Set initial conditions for all PDEs
-  for (auto& eq : g_cgpde) eq.initialize( d->Coord(), m_u, d->T(), m_boxnodes );
+  for (auto& eq : g_cgpde) eq.initialize( coord, m_u, d->T(), m_boxnodes );
 
   // Apply symmetry BCs on initial conditions
   for (const auto& eq : g_cgpde)
-    eq.symbc( m_u, m_bnorm, m_symbcnodes );
+    eq.symbc( m_u, coord, m_bnorm, m_symbcnodes );
   // Apply farfield BCs on initial conditions
   for (const auto& eq : g_cgpde)
-    eq.farfieldbc( m_u, m_bnorm, m_farfieldbcnodes );
+    eq.farfieldbc( m_u, coord, m_bnorm, m_farfieldbcnodes );
 
   // Compute volume of user-defined box IC
   d->boxvol( m_boxnodes );
@@ -624,14 +625,15 @@ DiagCG::solve( tk::Fields& dif )
   m_ul = m_u + dul;
   m_du = m_rhs / m_lhs;
 
+  const auto& coord = d->Coord();
   for (const auto& eq : g_cgpde) {
     // Apply symmetry BCs
-    eq.symbc( dul, m_bnorm, m_symbcnodes );
-    eq.symbc( m_ul, m_bnorm, m_symbcnodes );
-    eq.symbc( m_du, m_bnorm, m_symbcnodes );
+    eq.symbc( dul, coord, m_bnorm, m_symbcnodes );
+    eq.symbc( m_ul, coord, m_bnorm, m_symbcnodes );
+    eq.symbc( m_du, coord, m_bnorm, m_symbcnodes );
     // Apply farfield BCs
-    eq.farfieldbc( m_ul, m_bnorm, m_farfieldbcnodes );
-    eq.farfieldbc( m_du, m_bnorm, m_farfieldbcnodes );
+    eq.farfieldbc( m_ul, coord, m_bnorm, m_farfieldbcnodes );
+    eq.farfieldbc( m_du, coord, m_bnorm, m_farfieldbcnodes );
   }
 
   // Continue with FCT

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -119,10 +119,10 @@ NodeDiagnostics::compute(
     }
     // Apply symmetry BCs on analytic solution (if exist, if not, IC)
     for (const auto& eq : g_cgpde)
-      eq.symbc( an, bnorm, symbcnodes );
+      eq.symbc( an, coord, bnorm, symbcnodes );
     // Apply farfield BCs on analytic solution (if exist, if not, IC)
     for (const auto& eq : g_cgpde)
-      eq.farfieldbc( an, bnorm, farfieldbcnodes );
+      eq.farfieldbc( an, coord, bnorm, farfieldbcnodes );
 
     // Put in norms sweeping our mesh chunk
     for (std::size_t i=0; i<u.nunk(); ++i) {

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -70,6 +70,7 @@ class CGPDE {
 
   private:
     using ncomp_t = kw::ncomp::info::expect::type;
+    using real = tk::real;
 
   public:
     //! Default constructor taking no arguments for Charm++
@@ -106,18 +107,18 @@ class CGPDE {
               std::move( x( std::forward<Args>(args)... ) ) ) ) {}
 
     //! Public interface to setting the initial conditions for the diff eq
-    void initialize( const std::array< std::vector< tk::real >, 3 >& coord,
+    void initialize( const std::array< std::vector< real >, 3 >& coord,
                      tk::Fields& unk,
-                     tk::real t,
+                     real t,
                      std::vector< std::size_t >& inbox )
     { self->initialize( coord, unk, t, inbox ); }
 
     //! Public interface to updating the initial conditions in box ICs
-    void box( tk::real v, const std::vector< std::size_t >& boxnodes,
+    void box( real v, const std::vector< std::size_t >& boxnodes,
               tk::Fields& unk ) const { self->box( v, boxnodes, unk ); }
 
     //! Public interface to computing the nodal gradients for ALECG
-    void grad( const std::array< std::vector< tk::real >, 3 >& coord,
+    void grad( const std::array< std::vector< real >, 3 >& coord,
                const std::vector< std::size_t >& inpoel,
                const std::vector< std::size_t >& bndel,
                const std::vector< std::size_t >& gid,
@@ -127,9 +128,9 @@ class CGPDE {
     { self->grad( coord, inpoel, bndel, gid, bid, U, G ); }
 
     //! Public interface to computing the right-hand side vector for DiagCG
-    void rhs( tk::real t,
-              tk::real deltat,
-              const std::array< std::vector< tk::real >, 3 >& coord,
+    void rhs( real t,
+              real deltat,
+              const std::array< std::vector< real >, 3 >& coord,
               const std::vector< std::size_t >& inpoel,
               const tk::Fields& U,
               tk::Fields& Ue,
@@ -138,70 +139,72 @@ class CGPDE {
 
     //! Public interface to computing the right-hand side vector for ALECG
     void rhs(
-      tk::real t,
-      const std::array< std::vector< tk::real >, 3 >& coord,
+      real t,
+      const std::array< std::vector< real >, 3 >& coord,
       const std::vector< std::size_t >& inpoel,
       const std::vector< std::size_t >& triinpoel,
       const std::vector< std::size_t >& gid,
       const std::unordered_map< std::size_t, std::size_t >& bid,
       const std::unordered_map< std::size_t, std::size_t >& lid,
-      const std::vector< tk::real >& dfn,
+      const std::vector< real >& dfn,
       const std::pair< std::vector< std::size_t >,
                        std::vector< std::size_t > >& psup,
       const std::pair< std::vector< std::size_t >,
                        std::vector< std::size_t > >& esup,
       const std::vector< int >& symbctri,
-      const std::vector< tk::real >& vol,
+      const std::vector< real >& vol,
       const std::vector< std::size_t >& edgenode,
       const std::vector< std::size_t >& edgeid,
       const tk::Fields& G,
       const tk::Fields& U,
-      const std::vector< tk::real >& tp,
+      const std::vector< real >& tp,
       tk::Fields& R ) const
     { self->rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup, esup,
                  symbctri, vol, edgenode, edgeid, G, U, tp, R ); }
 
     //! Public interface for computing the minimum time step size
-    tk::real dt( const std::array< std::vector< tk::real >, 3 >& coord,
-                 const std::vector< std::size_t >& inpoel,
-                 const tk::Fields& U ) const
+    real dt( const std::array< std::vector< real >, 3 >& coord,
+             const std::vector< std::size_t >& inpoel,
+             const tk::Fields& U ) const
     { return self->dt( coord, inpoel, U ); }
 
     //! Public interface for computing a time step size for each mesh node
     void dt( uint64_t it,
-             const std::vector< tk::real >& vol,
+             const std::vector< real >& vol,
              const tk::Fields& U,
-             std::vector< tk::real >& dtp ) const
+             std::vector< real >& dtp ) const
     { self->dt( it, vol, U, dtp ); }
 
     //! \brief Public interface for querying Dirichlet boundary condition values
     //!  set by the user on a given side set for all components in a PDE system
-    std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
-    dirbc( tk::real t,
-           tk::real deltat,
-           const std::vector< tk::real >& tp,
-           const std::vector< tk::real >& dtp,
+    std::map< std::size_t, std::vector< std::pair<bool,real> > >
+    dirbc( real t,
+           real deltat,
+           const std::vector< real >& tp,
+           const std::vector< real >& dtp,
            const std::pair< const int, std::vector< std::size_t > >& sides,
-           const std::array< std::vector< tk::real >, 3 >& coord ) const
+           const std::array< std::vector< real >, 3 >& coord ) const
     { return self->dirbc( t, deltat, tp, dtp, sides, coord ); }
 
     //! Public interface to set symmetry boundary conditions at nodes
     void
     symbc( tk::Fields& U,
+           const std::array< std::vector< real >, 3 >& coord,
            const std::unordered_map< int,
                    std::unordered_map< std::size_t,
-                     std::array< tk::real, 4 > > >& bnorm,
+                     std::array< real, 4 > > >& bnorm,
            const std::unordered_set< std::size_t >& nodes ) const
-    { self->symbc( U, bnorm, nodes ); }
+    { self->symbc( U, coord, bnorm, nodes ); }
 
     //! Public interface to set farfield boundary conditions at nodes
     void
     farfieldbc( tk::Fields& U,
+                const std::array< std::vector< real >, 3 >& coord,
                 const std::unordered_map< int,
                         std::unordered_map< std::size_t,
-                          std::array< tk::real, 4 > > >& bnorm,
+                          std::array< real, 4 > > >& bnorm,
                 const std::unordered_set< std::size_t >& nodes ) const
-    { self->farfieldbc( U, bnorm, nodes ); }
+    { self->farfieldbc( U, coord, bnorm, nodes ); }
 
     //! Public interface to returning field output labels
     std::vector< std::string > fieldNames() const { return self->fieldNames(); }
@@ -216,31 +219,31 @@ class CGPDE {
     std::vector< std::string > names() const { return self->names(); }
 
     //! Public interface to returning field output
-    std::vector< std::vector< tk::real > > fieldOutput(
-      tk::real t,
-      tk::real V,
+    std::vector< std::vector< real > > fieldOutput(
+      real t,
+      real V,
       std::size_t nunk,
-      const std::array< std::vector< tk::real >, 3 >& coord,
-      const std::vector< tk::real >& v,
+      const std::array< std::vector< real >, 3 >& coord,
+      const std::vector< real >& v,
       tk::Fields& U ) const
     { return self->fieldOutput( t, V, nunk, coord, v, U ); }
 
     //! Public interface to returning surface field output
-    std::vector< std::vector< tk::real > >
+    std::vector< std::vector< real > >
     surfOutput( const std::map< int, std::vector< std::size_t > >& bnd,
                 tk::Fields& U ) const
     { return self->surfOutput( bnd, U ); }
 
     //! Public interface to returning time history output
-    std::vector< std::vector< tk::real > >
+    std::vector< std::vector< real > >
     histOutput( const std::vector< HistData >& h,
                 const std::vector< std::size_t >& inpoel,
                 const tk::Fields& U ) const
     { return self->histOutput( h, inpoel, U ); }
 
     //! Public interface to returning analytic solution
-    std::vector< tk::real >
-    analyticSolution( tk::real xi, tk::real yi, tk::real zi, tk::real t ) const
+    std::vector< real >
+    analyticSolution( real xi, real yi, real zi, real t ) const
     { return self->analyticSolution( xi, yi, zi, t ); }
 
     //! Copy assignment
@@ -261,91 +264,95 @@ class CGPDE {
       Concept( const Concept& ) = default;
       virtual ~Concept() = default;
       virtual Concept* copy() const = 0;
-      virtual void initialize( const std::array< std::vector< tk::real >, 3 >&,
+      virtual void initialize( const std::array< std::vector< real >, 3 >&,
                                tk::Fields&,
-                               tk::real,
+                               real,
                                std::vector< std::size_t >& inbox ) = 0;
-      virtual void box( tk::real, const std::vector< std::size_t >&,
+      virtual void box( real, const std::vector< std::size_t >&,
                         tk::Fields& unk ) const = 0;
-      virtual void grad( const std::array< std::vector< tk::real >, 3 >&,
+      virtual void grad( const std::array< std::vector< real >, 3 >&,
                          const std::vector< std::size_t >&,
                          const std::vector< std::size_t >&,
                          const std::vector< std::size_t >&,
                          const std::unordered_map< std::size_t, std::size_t >&,
                          const tk::Fields&,
                          tk::Fields& ) const = 0;
-      virtual void rhs( tk::real,
-                        tk::real,
-                        const std::array< std::vector< tk::real >, 3 >&,
+      virtual void rhs( real,
+                        real,
+                        const std::array< std::vector< real >, 3 >&,
                         const std::vector< std::size_t >&,
                         const tk::Fields&,
                         tk::Fields&,
                         tk::Fields& ) const = 0;
       virtual void rhs(
-        tk::real,
-        const std::array< std::vector< tk::real >, 3 >&,
+        real,
+        const std::array< std::vector< real >, 3 >&,
         const std::vector< std::size_t >&,
         const std::vector< std::size_t >&,
         const std::vector< std::size_t >&,
         const std::unordered_map< std::size_t, std::size_t >&,
         const std::unordered_map< std::size_t, std::size_t >&,
-        const std::vector< tk::real >&,
+        const std::vector< real >&,
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >&,
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >&,
         const std::vector< int >&,
-        const std::vector< tk::real >&,
+        const std::vector< real >&,
         const std::vector< std::size_t >&,
         const std::vector< std::size_t >&,
         const tk::Fields&,
         const tk::Fields&,
-        const std::vector< tk::real >&,
+        const std::vector< real >&,
         tk::Fields& ) const = 0;
-      virtual tk::real dt( const std::array< std::vector< tk::real >, 3 >&,
-                           const std::vector< std::size_t >&,
-                           const tk::Fields& ) const = 0;
+      virtual real dt( const std::array< std::vector< real >, 3 >&,
+                       const std::vector< std::size_t >&,
+                       const tk::Fields& ) const = 0;
       virtual void dt( uint64_t,
-                       const std::vector< tk::real > &,
+                       const std::vector< real > &,
                        const tk::Fields&,
-                       std::vector< tk::real >& ) const = 0;
-      virtual std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
-      dirbc( tk::real,
-             tk::real,
-             const std::vector< tk::real >&,
-             const std::vector< tk::real >&,
+                       std::vector< real >& ) const = 0;
+      virtual std::map< std::size_t, std::vector< std::pair<bool,real> > >
+      dirbc( real,
+             real,
+             const std::vector< real >&,
+             const std::vector< real >&,
              const std::pair< const int, std::vector< std::size_t > >&,
-             const std::array< std::vector< tk::real >, 3 >& ) const = 0;
-      virtual void symbc( tk::Fields& U,
+             const std::array< std::vector< real >, 3 >& ) const = 0;
+      virtual void symbc(
+        tk::Fields& U,
+        const std::array< std::vector< real >, 3 >&,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
-                  std::array< tk::real, 4 > > >&,
+                  std::array< real, 4 > > >&,
         const std::unordered_set< std::size_t >& ) const = 0;
-      virtual void farfieldbc( tk::Fields& U,
+      virtual void farfieldbc(
+        tk::Fields&,
+        const std::array< std::vector< real >, 3 >&,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
-                  std::array< tk::real, 4 > > >&,
+                  std::array< real, 4 > > >&,
         const std::unordered_set< std::size_t >& ) const = 0;
       virtual std::vector< std::string > fieldNames() const = 0;
       virtual std::vector< std::string > surfNames() const = 0;
       virtual std::vector< std::string > histNames() const = 0;
       virtual std::vector< std::string > names() const = 0;
-      virtual std::vector< std::vector< tk::real > > fieldOutput(
-        tk::real,
-        tk::real,
+      virtual std::vector< std::vector< real > > fieldOutput(
+        real,
+        real,
         std::size_t,
-        const std::array< std::vector< tk::real >, 3 >&,
-        const std::vector< tk::real >&,
+        const std::array< std::vector< real >, 3 >&,
+        const std::vector< real >&,
         tk::Fields& ) const = 0;
-      virtual std::vector< std::vector< tk::real > > surfOutput(
+      virtual std::vector< std::vector< real > > surfOutput(
         const std::map< int, std::vector< std::size_t > >&,
         tk::Fields& ) const = 0;
-      virtual std::vector< std::vector< tk::real > > histOutput(
+      virtual std::vector< std::vector< real > > histOutput(
         const std::vector< HistData >&,
         const std::vector< std::size_t >&,
         const tk::Fields& ) const = 0;
-      virtual std::vector< tk::real > analyticSolution(
-        tk::real xi, tk::real yi, tk::real zi, tk::real t ) const = 0;
+      virtual std::vector< real > analyticSolution(
+        real xi, real yi, real zi, real t ) const = 0;
     };
 
     //! \brief Model models the Concept above by deriving from it and overriding
@@ -354,15 +361,15 @@ class CGPDE {
     struct Model : Concept {
       explicit Model( T x ) : data( std::move(x) ) {}
       Concept* copy() const override { return new Model( *this ); }
-      void initialize( const std::array< std::vector< tk::real >, 3 >& coord,
+      void initialize( const std::array< std::vector< real >, 3 >& coord,
                        tk::Fields& unk,
-                       tk::real t,
+                       real t,
                        std::vector< std::size_t >& inbox )
       override { data.initialize( coord, unk, t, inbox ); }
-      void box( tk::real v, const std::vector< std::size_t >& boxnodes,
+      void box( real v, const std::vector< std::size_t >& boxnodes,
                 tk::Fields& unk ) const override
       { data.box( v, boxnodes, unk ); }
-      void grad( const std::array< std::vector< tk::real >, 3 >& coord,
+      void grad( const std::array< std::vector< real >, 3 >& coord,
                  const std::vector< std::size_t >& inpoel,
                  const std::vector< std::size_t >& bndel,
                  const std::vector< std::size_t >& gid,
@@ -370,66 +377,70 @@ class CGPDE {
                  const tk::Fields& U,
                  tk::Fields& G ) const override
       { data.grad( coord, inpoel, bndel, gid, bid, U, G ); }
-      void rhs( tk::real t,
-                tk::real deltat,
-                const std::array< std::vector< tk::real >, 3 >& coord,
+      void rhs( real t,
+                real deltat,
+                const std::array< std::vector< real >, 3 >& coord,
                 const std::vector< std::size_t >& inpoel,
                 const tk::Fields& U,
                 tk::Fields& Ue,
                 tk::Fields& R ) const override
       { data.rhs( t, deltat, coord, inpoel, U, Ue, R ); }
       void rhs(
-        tk::real t,
-        const std::array< std::vector< tk::real >, 3 >& coord,
+        real t,
+        const std::array< std::vector< real >, 3 >& coord,
         const std::vector< std::size_t >& inpoel,
         const std::vector< std::size_t >& triinpoel,
         const std::vector< std::size_t >& gid,
         const std::unordered_map< std::size_t, std::size_t >& bid,
         const std::unordered_map< std::size_t, std::size_t >& lid,
-        const std::vector< tk::real >& dfn,
+        const std::vector< real >& dfn,
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >& psup,
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >& esup,
         const std::vector< int >& symbctri,
-        const std::vector< tk::real >& vol,
+        const std::vector< real >& vol,
         const std::vector< std::size_t >& edgenode,
         const std::vector< std::size_t >& edgeid,
         const tk::Fields& G,
         const tk::Fields& U,
-        const std::vector< tk::real >& tp,
+        const std::vector< real >& tp,
         tk::Fields& R ) const override
       { data.rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup, esup,
                   symbctri, vol, edgenode, edgeid, G, U, tp, R ); }
-      tk::real dt( const std::array< std::vector< tk::real >, 3 >& coord,
+      real dt( const std::array< std::vector< real >, 3 >& coord,
                    const std::vector< std::size_t >& inpoel,
                    const tk::Fields& U ) const override
       { return data.dt( coord, inpoel, U ); }
       void dt( uint64_t it,
-               const std::vector< tk::real > & vol,
+               const std::vector< real > & vol,
                const tk::Fields& U,
-               std::vector< tk::real >& dtp ) const override
+               std::vector< real >& dtp ) const override
       { data.dt( it, vol, U, dtp ); }
-      std::map< std::size_t, std::vector< std::pair<bool,tk::real> > >
-      dirbc( tk::real t,
-             tk::real deltat,
-             const std::vector< tk::real >& tp,
-             const std::vector< tk::real >& dtp,
+      std::map< std::size_t, std::vector< std::pair<bool,real> > >
+      dirbc( real t,
+             real deltat,
+             const std::vector< real >& tp,
+             const std::vector< real >& dtp,
              const std::pair< const int, std::vector< std::size_t > >& sides,
-             const std::array< std::vector< tk::real >, 3 >& coord ) const
+             const std::array< std::vector< real >, 3 >& coord ) const
         override { return data.dirbc( t, deltat, tp, dtp, sides, coord ); }
-      void symbc( tk::Fields& U,
+      void symbc(
+        tk::Fields& U,
+        const std::array< std::vector< real >, 3 >& coord,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
-                  std::array< tk::real, 4 > > >& bnorm,
+                  std::array< real, 4 > > >& bnorm,
         const std::unordered_set< std::size_t >& nodes ) const override
-      { data.symbc( U, bnorm, nodes ); }
-      void farfieldbc( tk::Fields& U,
+      { data.symbc( U, coord, bnorm, nodes ); }
+      void farfieldbc(
+        tk::Fields& U,
+        const std::array< std::vector< real >, 3 >& coord,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
-                  std::array< tk::real, 4 > > >& bnorm,
+                  std::array< real, 4 > > >& bnorm,
         const std::unordered_set< std::size_t >& nodes ) const override
-      { data.farfieldbc( U, bnorm, nodes ); }
+      { data.farfieldbc( U, coord, bnorm, nodes ); }
       std::vector< std::string > fieldNames() const override
       { return data.fieldNames(); }
       std::vector< std::string > surfNames() const override
@@ -438,25 +449,25 @@ class CGPDE {
       { return data.histNames(); }
       std::vector< std::string > names() const override
       { return data.names(); }
-      std::vector< std::vector< tk::real > > fieldOutput(
-        tk::real t,
-        tk::real V,
+      std::vector< std::vector< real > > fieldOutput(
+        real t,
+        real V,
         std::size_t nunk,
-        const std::array< std::vector< tk::real >, 3 >& coord,
-        const std::vector< tk::real >& v,
+        const std::array< std::vector< real >, 3 >& coord,
+        const std::vector< real >& v,
         tk::Fields& U ) const override
       { return data.fieldOutput( t, V, nunk, coord, v, U ); }
-      std::vector< std::vector< tk::real > > surfOutput(
+      std::vector< std::vector< real > > surfOutput(
         const std::map< int, std::vector< std::size_t > >& bnd,
         tk::Fields& U ) const override
       { return data.surfOutput( bnd, U ); }
-      std::vector< std::vector< tk::real > > histOutput(
+      std::vector< std::vector< real > > histOutput(
         const std::vector< HistData >& h,
         const std::vector< std::size_t >& inpoel,
         const tk::Fields& U ) const override
       { return data.histOutput( h, inpoel, U ); }
-      std::vector< tk::real >
-      analyticSolution( tk::real xi, tk::real yi, tk::real zi, tk::real t )
+      std::vector< real >
+      analyticSolution( real xi, real yi, real zi, real t )
        const override { return data.analyticSolution( xi, yi, zi, t ); }
       T data;
     };

--- a/src/PDE/ConfigureCompFlow.cpp
+++ b/src/PDE/ConfigureCompFlow.cpp
@@ -214,12 +214,20 @@ infoCompFlow( std::map< ctr::PDEType, tk::ctr::ncomp_t >& cnt )
   // BCs
 
   const auto& bcstag = g_inputdeck.get< tag::param, eq, tag::bcstag >();
-  const auto& point = bcstag.get< tag::point >();
-  if (point.size() > c)
-    nfo.emplace_back( "Stagnation BC point(s)", parameters( point[c] ) );
-  const auto& radius = bcstag.get< tag::radius >();
-  if (radius.size() > c)
-    nfo.emplace_back( "Stagnation BC radii", parameters( radius[c] ) );
+  const auto& spoint = bcstag.get< tag::point >();
+  if (spoint.size() > c)
+    nfo.emplace_back( "Stagnation BC point(s)", parameters( spoint[c] ) );
+  const auto& sradius = bcstag.get< tag::radius >();
+  if (sradius.size() > c)
+    nfo.emplace_back( "Stagnation BC radii", parameters( sradius[c] ) );
+
+  const auto& bcskip = g_inputdeck.get< tag::param, eq, tag::bcskip >();
+  const auto& kpoint = bcskip.get< tag::point >();
+  if (kpoint.size() > c)
+    nfo.emplace_back( "Skip BC point(s)", parameters( kpoint[c] ) );
+  const auto& kradius = bcskip.get< tag::radius >();
+  if (kradius.size() > c)
+    nfo.emplace_back( "Skip BC radii", parameters( kradius[c] ) );
 
   const auto& fs =
     g_inputdeck.get< tag::param, eq, tag::bc, tag::bcfarfield >();

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -473,6 +473,7 @@ class Transport {
     void
     symbc(
       tk::Fields&,
+      const std::array< std::vector< real >, 3 >&,
       const std::unordered_map< int,
               std::unordered_map< std::size_t,
                 std::array< real, 4 > > >&,
@@ -481,6 +482,7 @@ class Transport {
     //! Set farfield boundary conditions at nodes
     void farfieldbc(
       tk::Fields&,
+      const std::array< std::vector< real >, 3 >&,
       const std::unordered_map< int,
               std::unordered_map< std::size_t,
                 std::array< real, 4 > > >&,


### PR DESCRIPTION
Implement _skip_ boundary conditions.

This adds the possibility to configure a point and a radius within if a mesh point falls, application of boundary conditions will be skipped.

Configuration example:
```
    bc_skip
      point 0 0 0 end
      radius 1.0e-8 end
    end
```
Screen echo feedback of this setting:
```
 * Partial differential equations integrated (1):
 ------------------------------------------------
   < Compressible single-material flow >
     ...
     Skip BC point(s)                         : { 0 0 0 }
     Skip BC radii                            : { 1e-08 }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/430)
<!-- Reviewable:end -->
