### PR TITLE
added explanatory comments for some constants and bcs in alecg

### DIFF
--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -235,6 +235,10 @@ ALECG::edfnorm( const tk::UnsMesh::Edge& edge,
     for (std::size_t i=0; i<3; ++i)
       grad[0][i] = -grad[1][i]-grad[2][i]-grad[3][i];
     // sum normal contributions
+    // The constant 1/48: Eq (12) from Waltz et al. Computers & fluids (92) 2014
+    // The result of the integral of shape function N on a tet is V/4.
+    // This can be written as J/(6*4). Eq (12) has a 1/2 multiplier.
+    // This leads to J/48.
     auto J48 = J/48.0;
     for (const auto& [a,b] : tk::lpoed) {
       auto s = tk::orient( {N[a],N[b]}, edge );
@@ -949,6 +953,12 @@ ALECG::solve()
     m_u = m_un + rkcoef[m_stage] * d->Dt() * m_rhs / m_lhs;
 
   }
+
+  // The following BC enforcement changes the updated solution to ensure strong
+  // imposition of the BCs. This is a matter of choice. Another alternative is
+  // to only apply BCs when computing fluxes at boundary faces, thereby only
+  // weakly enforcing the BCs. The former is conventionally used in finite
+  // element methods, whereas the latter, in finite volume methods.
 
   // Apply symmetry BCs on new solution
   for (const auto& eq : g_cgpde)

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -1118,6 +1118,12 @@ class CompFlow {
         for (auto q : tk::Around(psup,p)) {
           auto s = gid[p] > gid[q] ? -1.0 : 1.0;
           auto e = edgeid[k++];
+          // the 2.0 in the following expression is so that the RHS contribution
+          // conforms with Eq 12 (Waltz et al. Computers & fluids (92) 2014);
+          // The 1/2 in Eq 12 is extracted from the flux function (Rusanov).
+          // However, Rusanov::flux computes the flux with the 1/2. This 2
+          // cancels with the 1/2 in Rusanov::flux, so that the 1/2 can be
+          // extracted out and multiplied as in Eq 12
           for (std::size_t c=0; c<m_ncomp; ++c)
             R.var(r[c],p) -= 2.0*s*dflux[e*m_ncomp+c];
         }

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -158,8 +158,14 @@ class CompFlow {
 
         Assert( boxenc.size() > m_system && !boxenc[m_system].empty(),
           "Box energy content unspecified in input file" );
+        std::vector< tk::real >
+          boxdim{ icbox.get< tag::xmin >(), icbox.get< tag::xmax >(),
+                  icbox.get< tag::ymin >(), icbox.get< tag::ymax >(),
+                  icbox.get< tag::zmin >(), icbox.get< tag::zmax >() };
+        auto V_ex = (boxdim[1]-boxdim[0]) * (boxdim[3]-boxdim[2]) *
+          (boxdim[5]-boxdim[4]);
         rho = boxmas[m_system][0] / V;
-        spi = boxenc[m_system][0] * V / boxmas[m_system][0];
+        spi = boxenc[m_system][0] * V_ex / (V * rho);
         boxmassic = true;
 
       } else {


### PR DESCRIPTION
Some comments for clarity. Also changed the initialization for the Box-IC, so that intended total energy at initialization is maintained, independent of mesh.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/442)
<!-- Reviewable:end -->
