### PR TITLE
Include stdexcept for exceptions

### DIFF
--- a/src/PDE/Integrate/Quadrature.hpp
+++ b/src/PDE/Integrate/Quadrature.hpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <vector>
+#include <stdexcept>
 
 #include "Types.hpp"
 #include "Exception.hpp"


### PR DESCRIPTION
Ran into a compile-time error on Mac OS (OpenMPI-2.1.6 with gcc-10.2.0) which needed this fix. Only a one-line change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/450)
<!-- Reviewable:end -->
