### PR TITLE
Ensure unique Physics and Problem policy codes

### DIFF
--- a/src/Control/Inciter/Options/Physics.hpp
+++ b/src/Control/Inciter/Options/Physics.hpp
@@ -37,12 +37,12 @@ class Physics : public tk::Toggle< PhysicsType > {
 
   public:
     //! Valid expected choices to make them also available at compile-time
-    using keywords = brigand::list< kw::advection
-                                  , kw::advdiff
-                                  , kw::euler
-                                  , kw::navierstokes
-                                  , kw::veleq
-                                  >;
+    using keywords = tk::unique_codes< kw::advection
+                                     , kw::advdiff
+                                     , kw::euler
+                                     , kw::navierstokes
+                                     , kw::veleq
+                                     >::list;
 
     //! \brief Options constructor
     //! \details Simply initialize in-line and pass associations to base, which
@@ -65,7 +65,7 @@ class Physics : public tk::Toggle< PhysicsType > {
           { kw::navierstokes::string(), PhysicsType::NAVIERSTOKES },
           { kw::veleq::string(), PhysicsType::VELEQ } } )
     {
-       brigand::for_each< keywords >( assertPolicyCodes() );
+      brigand::for_each< keywords >( assertPolicyCodes() );
     }
 
     //! \brief Return policy code based on Enum

--- a/src/Control/Inciter/Options/Problem.hpp
+++ b/src/Control/Inciter/Options/Problem.hpp
@@ -54,29 +54,29 @@ class Problem : public tk::Toggle< ProblemType > {
 
   public:
     //! Valid expected choices to make them also available at compile-time
-    using keywords = brigand::list< kw::user_defined
-                                  , kw::shear_diff
-                                  , kw::vortical_flow
-                                  , kw::nl_energy_growth
-                                  , kw::rayleigh_taylor
-                                  , kw::taylor_green
-                                  , kw::slot_cyl
-                                  , kw::gauss_hump
-                                  , kw::cyl_advect
-                                  , kw::cyl_vortex
-                                  , kw::shedding_flow
-                                  , kw::sod_shocktube
-                                  , kw::rotated_sod_shocktube
-                                  , kw::sedov_blastwave
-                                  , kw::interface_advection
-                                  , kw::gauss_hump_compflow
-                                  , kw::waterair_shocktube
-                                  , kw::triple_point
-                                  , kw::gas_impact
-                                  , kw::gas_impact_4mat
-                                  , kw::shock_hebubble
-                                  , kw::underwater_ex
-                                  >;
+    using keywords = tk::unique_codes< kw::user_defined
+                                     , kw::shear_diff
+                                     , kw::vortical_flow
+                                     , kw::nl_energy_growth
+                                     , kw::rayleigh_taylor
+                                     , kw::taylor_green
+                                     , kw::slot_cyl
+                                     , kw::gauss_hump
+                                     , kw::cyl_advect
+                                     , kw::cyl_vortex
+                                     , kw::shedding_flow
+                                     , kw::sod_shocktube
+                                     , kw::rotated_sod_shocktube
+                                     , kw::sedov_blastwave
+                                     , kw::interface_advection
+                                     , kw::gauss_hump_compflow
+                                     , kw::waterair_shocktube
+                                     , kw::triple_point
+                                     , kw::gas_impact
+                                     , kw::gas_impact_4mat
+                                     , kw::shock_hebubble
+                                     , kw::underwater_ex
+                                     >::list;
 
     //! \brief Options constructor
     //! \details Simply initialize in-line and pass associations to base, which
@@ -147,7 +147,7 @@ class Problem : public tk::Toggle< ProblemType > {
             ProblemType::UNDERWATER_EX }
         } )
     {
-       brigand::for_each< keywords >( assertPolicyCodes() );
+      brigand::for_each< keywords >( assertPolicyCodes() );
     }
 
     //! \brief Return policy code based on Enum

--- a/src/Control/Keyword.hpp
+++ b/src/Control/Keyword.hpp
@@ -35,6 +35,18 @@ class cmd_keywords {
     using aliases = brigand::set< alias<T>... >;
 };
 
+//! Helper to ensure uniqueness of policy codes for keywords
+//! \details This ensures that a compile-error is generated if the policy codes
+//!    of the keywords passed in as T... are not unique.
+template< typename... T >
+class unique_codes {
+  public:
+    using list = brigand::list< T... >;
+  private:
+    template< typename K > using code = typename K::info::code::type;
+    using set = brigand::set< code<T>... >;
+};
+
 } // tk::
 
 namespace kw {

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -4584,7 +4584,7 @@ struct cyl_advect_info {
 using cyl_advect = keyword< cyl_advect_info, TAOCPP_PEGTL_STRING("cyl_advect") >;
 
 struct cyl_vortex_info {
-  using code = Code< D >;
+  using code = Code< X >;
   static std::string name() { return "Deformation of cylinder in a vortex"; }
   static std::string shortDescription() { return
     "Select deformation of cylinder in a vortex test problem"; }
@@ -4822,7 +4822,7 @@ using waterair_shocktube =
   keyword< waterair_shocktube_info, TAOCPP_PEGTL_STRING("waterair_shocktube") >;
 
 struct triple_point_info {
-  using code = Code< T >;
+  using code = Code< K >;
   static std::string name() { return "Triple point problem"; }
   static std::string shortDescription() { return
     "Select the triple point test problem "; }
@@ -4842,7 +4842,7 @@ using triple_point =
   keyword< triple_point_info, TAOCPP_PEGTL_STRING("triple_point") >;
 
 struct gas_impact_info {
-  using code = Code< T >;
+  using code = Code< P >;
   static std::string name() { return "Gas impact problem"; }
   static std::string shortDescription() { return
     "Select the gas impact test problem "; }
@@ -4863,7 +4863,7 @@ using gas_impact =
   keyword< gas_impact_info, TAOCPP_PEGTL_STRING("gas_impact") >;
 
 struct gas_impact_4mat_info {
-  using code = Code< T >;
+  using code = Code< L >;
   static std::string name() { return "Gas impacting with two slabs problem"; }
   static std::string shortDescription() { return
     "Select the gas impacting with two slabs test problem "; }
@@ -4882,7 +4882,7 @@ using gas_impact_4mat =
   keyword< gas_impact_4mat_info, TAOCPP_PEGTL_STRING("gas_impact_4mat") >;
 
 struct shock_hebubble_info {
-  using code = Code< T >;
+  using code = Code< E >;
   static std::string name() { return "Shock He-bubble problem"; }
   static std::string shortDescription() { return
     "Select the shock He-bubble test problem "; }
@@ -4901,7 +4901,7 @@ using shock_hebubble =
   keyword< shock_hebubble_info, TAOCPP_PEGTL_STRING("shock_hebubble") >;
 
 struct underwater_ex_info {
-  using code = Code< T >;
+  using code = Code< D >;
   static std::string name() { return "Underwater explosion problem"; }
   static std::string shortDescription() { return
     "Select the underwater explosion test problem "; }


### PR DESCRIPTION
From now on, if Physics or Problem policy codes, configured by their keywords, are not unique, the build fails.

This resolves #438.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/465)
<!-- Reviewable:end -->
