### PR TITLE
Mandatory args and example usage

### DIFF
--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -471,17 +471,18 @@ class Print {
                   const std::string& ver,
                   const std::string& commit,
                   const std::string& copyright ) const
-    {
-      stream<s>() << m_version_fmt % executable % ver % commit % copyright;
-    }
+    { stream<s>() << m_version_fmt % executable % ver % commit % copyright; }
 
     //! Print license information
     template< Style s = VERBOSE >
     void license( const std::string& executable,
                   const std::string& lic ) const
-    {
-      stream<s>() << m_license_fmt % executable % lic;
-    }
+    { stream<s>() << m_license_fmt % executable % lic; }
+
+    //! Print mandatory arguments information
+    template< Style s = VERBOSE >
+    void mandatory( const std::string& args ) const
+    { stream<s>() << m_mandatory_fmt % args; }
 
     //! Print lower and upper bounds for a keyword if defined
     template< Style s = VERBOSE, typename Info >
@@ -811,6 +812,7 @@ class Print {
     mutable format m_version_fmt =
               format("\nQuinoa::%s, version %s (SHA1: %s)\n%s\n\n");
     mutable format m_license_fmt = format("\nQuinoa::%s\n\n%s\n\n");
+    mutable format m_mandatory_fmt = format("\n%s\n\n");
 
     // Stream objects
     std::stringstream m_null;   //!< Default verbose stream

--- a/src/Base/Print.hpp
+++ b/src/Base/Print.hpp
@@ -466,6 +466,10 @@ class Print {
     }
 
     //! Print version information
+    //! \param[in] executable Name of executable to output license for
+    //! \param[in] ver Version to output
+    //! \param[in] commit Commit to output
+    //! \param[in] copyright Copyright info to output
     template< Style s = VERBOSE >
     void version( const std::string& executable,
                   const std::string& ver,
@@ -474,15 +478,28 @@ class Print {
     { stream<s>() << m_version_fmt % executable % ver % commit % copyright; }
 
     //! Print license information
+    //! \param[in] executable Name of executable to output license for
+    //! \param[in] lic License info to output
     template< Style s = VERBOSE >
     void license( const std::string& executable,
                   const std::string& lic ) const
     { stream<s>() << m_license_fmt % executable % lic; }
 
     //! Print mandatory arguments information
+    //! \param[in] args Mandaatory-arguments infor to output
     template< Style s = VERBOSE >
     void mandatory( const std::string& args ) const
     { stream<s>() << m_mandatory_fmt % args; }
+
+    //! Print example usage information
+    //! \param[in] executable Name of executable to output usage info for
+    //! \param[in] example Example command line to output
+    //! \param[in] msg Message to output after example
+    template< Style s = VERBOSE >
+    void usage( const std::string& executable,
+                const std::string& example,
+                const std::string& msg ) const
+    { stream<s>() << m_usage_fmt % executable % example % msg; }
 
     //! Print lower and upper bounds for a keyword if defined
     template< Style s = VERBOSE, typename Info >
@@ -812,7 +829,9 @@ class Print {
     mutable format m_version_fmt =
               format("\nQuinoa::%s, version %s (SHA1: %s)\n%s\n\n");
     mutable format m_license_fmt = format("\nQuinoa::%s\n\n%s\n\n");
-    mutable format m_mandatory_fmt = format("\n%s\n\n");
+    mutable format m_mandatory_fmt = format("\n%s\n");
+    mutable format m_usage_fmt =
+              format("\n%s example usage:\n\n$ %s\n\n%s\n\n");
 
     // Stream objects
     std::stringstream m_null;   //!< Default verbose stream

--- a/src/Control/FileConv/CmdLine/Parser.cpp
+++ b/src/Control/FileConv/CmdLine/Parser.cpp
@@ -76,10 +76,14 @@ CmdLineParser::CmdLineParser( int argc,
   // Print out help on all command-line arguments if the executable was invoked
   // without arguments or the help was requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (argc == 1 || helpcmd)
+  if (argc == 1 || helpcmd) {
     print.help< tk::QUIET >( tk::fileconv_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+    print.mandatory< tk::QUIET >(
+     "The '--" + kw::input().string() + " <filename>' and the "
+     "'--" + kw::output().string() + " <filename>' arguments are mandatory." );
+  }
 
   // Print out verbose help for a single keyword if requested
   const auto helpkw = cmdline.get< tag::helpkw >();

--- a/src/Control/FileConv/CmdLine/Parser.cpp
+++ b/src/Control/FileConv/CmdLine/Parser.cpp
@@ -83,7 +83,13 @@ CmdLineParser::CmdLineParser( int argc,
     print.mandatory< tk::QUIET >(
      "The '--" + kw::input().string() + " <filename>' and the "
      "'--" + kw::output().string() + " <filename>' arguments are mandatory." );
-  }
+    print.usage< tk::QUIET >(
+      tk::fileconv_executable(),
+      tk::fileconv_executable() + " -" + *kw::input().alias() + " in.root -" +
+        *kw::output().alias() + " out.exo",
+      "will read data from 'in.root' (in ROOT format) and output it to "
+      "out.exo' (in ExodusII format)" );
+   }
 
   // Print out verbose help for a single keyword if requested
   const auto helpkw = cmdline.get< tag::helpkw >();

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -90,6 +90,14 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
     print.mandatory< tk::QUIET >(
      "The '--" + kw::input().string() + " <filename>' and the "
      "'--" + kw::control().string() + " <filename>' arguments are mandatory." );
+    print.usage< tk::QUIET >(
+      tk::inciter_executable(),
+      "charmrun +p4 " + tk::inciter_executable() + " -" +
+        *kw::verbose().alias() + " -" + *kw::control().alias() +
+        " vort.q -" + *kw::input().alias() + " unitcube.exo",
+      "will execute the simulation configured in the control file 'vort.q' "
+      "using the mesh in 'unitcube.exo' on 4 CPUs producing verbose screen "
+      "output" );
   }
 
   // Print out help on all control file keywords if they were requested

--- a/src/Control/Inciter/CmdLine/Parser.cpp
+++ b/src/Control/Inciter/CmdLine/Parser.cpp
@@ -83,10 +83,14 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   // Print out help on all command-line arguments if the executable was invoked
   // without arguments or the help was requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (argc == 1 || helpcmd)
+  if (argc == 1 || helpcmd) {
     print.help< tk::QUIET >( tk::inciter_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+    print.mandatory< tk::QUIET >(
+     "The '--" + kw::input().string() + " <filename>' and the "
+     "'--" + kw::control().string() + " <filename>' arguments are mandatory." );
+  }
 
   // Print out help on all control file keywords if they were requested
   const auto helpctr = cmdline.get< tag::helpctr >();

--- a/src/Control/Keywords.hpp
+++ b/src/Control/Keywords.hpp
@@ -4208,9 +4208,9 @@ using particles = keyword< particles_info, TAOCPP_PEGTL_STRING("particles") >;
 
 struct input_info {
   static std::string name() { return "input"; }
-  static std::string shortDescription() { return "Specify the input file(s)"; }
+  static std::string shortDescription() { return "Specify the input file"; }
   static std::string longDescription() { return
-    R"(This option is used to define the name(s) of input file(s).)";
+    R"(This option is used to define the name of input file.)";
   }
   using alias = Alias< i >;
   struct expect {

--- a/src/Control/MeshConv/CmdLine/Parser.cpp
+++ b/src/Control/MeshConv/CmdLine/Parser.cpp
@@ -76,10 +76,14 @@ CmdLineParser::CmdLineParser( int argc,
   // Print out help on all command-line arguments if the executable was invoked
   // without arguments or the help was requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (argc == 1 || helpcmd)
+  if (argc == 1 || helpcmd) {
     print.help< tk::QUIET >( tk::meshconv_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+    print.mandatory< tk::QUIET >(
+     "The '--" + kw::input().string() + " <filename>' and the "
+     "'--" + kw::output().string() + " <filename>' arguments are mandatory." );
+  }
 
   // Print out verbose help for a single keyword if requested
   const auto helpkw = cmdline.get< tag::helpkw >();

--- a/src/Control/MeshConv/CmdLine/Parser.cpp
+++ b/src/Control/MeshConv/CmdLine/Parser.cpp
@@ -83,6 +83,12 @@ CmdLineParser::CmdLineParser( int argc,
     print.mandatory< tk::QUIET >(
      "The '--" + kw::input().string() + " <filename>' and the "
      "'--" + kw::output().string() + " <filename>' arguments are mandatory." );
+    print.usage< tk::QUIET >(
+      tk::meshconv_executable(),
+      tk::meshconv_executable() + " -" + *kw::input().alias() + " in.msh -" +
+        *kw::output().alias() + " out.exo",
+      "will read data from 'in.msh' (in Gmsh format) and output it to "
+      "out.exo' (in ExodusII format)" );
   }
 
   // Print out verbose help for a single keyword if requested

--- a/src/Control/RNGTest/CmdLine/Parser.cpp
+++ b/src/Control/RNGTest/CmdLine/Parser.cpp
@@ -84,10 +84,13 @@ CmdLineParser::CmdLineParser( int argc,
   // Print out help on all command-line arguments if the executable was invoked
   // without arguments or the help was requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (argc == 1 || helpcmd)
+  if (argc == 1 || helpcmd) {
     print.help< tk::QUIET >( tk::rngtest_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+    print.mandatory< tk::QUIET >( "The '--" + kw::control().string() +
+                                  " <filename>' argument is mandatory." );
+  }
 
   // Print out help on all control file keywords if they were requested
   const auto helpctr = cmdline.get< tag::helpctr >();

--- a/src/Control/RNGTest/CmdLine/Parser.cpp
+++ b/src/Control/RNGTest/CmdLine/Parser.cpp
@@ -90,6 +90,12 @@ CmdLineParser::CmdLineParser( int argc,
                              "Command-line Parameters:", "-" );
     print.mandatory< tk::QUIET >( "The '--" + kw::control().string() +
                                   " <filename>' argument is mandatory." );
+    print.usage< tk::QUIET >(
+      tk::rngtest_executable(),
+      "charmrun +p4 " + tk::rngtest_executable() + " -" +
+        *kw::verbose().alias() + " -" + *kw::control().alias() + " allmkl.q",
+      "will execute the statistical tests configured in the control file "
+      "'allmkl.q' on 4 CPUs producing verbose screen output" );
   }
 
   // Print out help on all control file keywords if they were requested

--- a/src/Control/UnitTest/CmdLine/Parser.cpp
+++ b/src/Control/UnitTest/CmdLine/Parser.cpp
@@ -74,10 +74,12 @@ CmdLineParser::CmdLineParser( int argc,
 
   // Print out help on all command-line arguments if requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (helpcmd)
+  if (helpcmd) {
     print.help< tk::QUIET >( tk::unittest_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+   print.mandatory< tk::QUIET >( "None of the arguments are mandatory." );
+  }
 
   // Print out verbose help for a single keyword if requested
   const auto helpkw = cmdline.get< tag::helpkw >();

--- a/src/Control/UnitTest/CmdLine/Parser.cpp
+++ b/src/Control/UnitTest/CmdLine/Parser.cpp
@@ -79,6 +79,11 @@ CmdLineParser::CmdLineParser( int argc,
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
    print.mandatory< tk::QUIET >( "None of the arguments are mandatory." );
+    print.usage< tk::QUIET >(
+      tk::unittest_executable(),
+      "charmrun +p4 " + tk::unittest_executable() + " -" +
+        *kw::verbose().alias(),
+      "will execute all unit tests on 4 CPUs producing verbose screen output" );
   }
 
   // Print out verbose help for a single keyword if requested

--- a/src/Control/Walker/CmdLine/Parser.cpp
+++ b/src/Control/Walker/CmdLine/Parser.cpp
@@ -88,6 +88,12 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
                              "Command-line Parameters:", "-" );
     print.mandatory< tk::QUIET >( "The '--" + kw::control().string() +
                                   " <filename>' argument is mandatory." );
+    print.usage< tk::QUIET >(
+      tk::walker_executable(),
+      "charmrun +p4 " + tk::walker_executable() + " -" +
+        *kw::verbose().alias() + " -" + *kw::control().alias() + " mixdir.q",
+      "will execute the simulation configured in the control file 'mixdir.q' "
+      "on 4 CPUs producing verbose screen output" );
   }
 
   // Print out help on all control file keywords if they were requested

--- a/src/Control/Walker/CmdLine/Parser.cpp
+++ b/src/Control/Walker/CmdLine/Parser.cpp
@@ -82,10 +82,13 @@ CmdLineParser::CmdLineParser( int argc, char** argv,
   // Print out help on all command-line arguments if the executable was invoked
   // without arguments or the help was requested
   const auto helpcmd = cmdline.get< tag::help >();
-  if (argc == 1 || helpcmd)
+  if (argc == 1 || helpcmd) {
     print.help< tk::QUIET >( tk::walker_executable(),
                              cmdline.get< tag::cmdinfo >(),
                              "Command-line Parameters:", "-" );
+    print.mandatory< tk::QUIET >( "The '--" + kw::control().string() +
+                                  " <filename>' argument is mandatory." );
+  }
 
   // Print out help on all control file keywords if they were requested
   const auto helpctr = cmdline.get< tag::helpctr >();


### PR DESCRIPTION
This adds some info to the screen output to all executables when run without any arguments to tell the user what command line arguments are mandatory and gives a simple example command on how to run the executable.

Addresses #80.

Example screen output
```
$ Main/inciter
Charm++> Running on MPI version: 3.1
Charm++> level of thread support used: MPI_THREAD_SINGLE (desired: MPI_THREAD_SINGLE)
Charm++> Running in non-SMP mode: 1 processes (PEs)
Converse/Charm++ Commit ID:
CharmLB> Load balancer assumes all CPUs are same.
Quinoa> Load balancing off
Charm++> Running on 1 hosts (2 sockets x 16 cores x 1 PUs = 32-way SMP)
Charm++> cpu topology info is gathered in 0.000 seconds.

inciter Command-line Parameters:
     -b, --benchmark            Select benchmark mode
       -c, --control     string Specify the control file name [REQUIRED]
   -d, --diagnostics     string Specify the diagnostics file name
      -f, --feedback            Enable on-screen feedback
          -h, --help            Display one-liner help on all command-line arguments
       -C, --helpctr            Display one-liner help on all control file keywords
        -H, --helpkw     string Display verbose help on a single keyword
         -i, --input     string Specify the input file
        -l, --lbfreq        int Set load-balancing frequency during time stepping
       -L, --license            Show license information
   -n, --nonblocking            Select non-blocking migration
        -o, --output     string Specify the output file
    -q, --quiescence            Enable quiescence detection
       -R, --restart     string Specify the directory for restart files
        -r, --rsfreq        int Set checkpoint/restart frequency during time stepping
        -O, --screen     string Specify the screen output file
         -S, --state            Enable verbose chare state screen output
         -t, --trace            Disable call and stack trace
       -v, --verbose            Select verbose screen output
       -V, --version            Show version information
-u, --virtualization       real Set degree of virtualization

The '--input <filename>' and the '--control <filename>' arguments are mandatory.

inciter example usage:

$ charmrun +p4 inciter -v -c vort.q -i unitcube.exo

will execute the simulation configured in the control file 'vort.q' using the mesh in 'unitcube.exo' on 4 CPUs producing verbose screen output

[Partition 0][Node 0] End of program
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/472)
<!-- Reviewable:end -->
