### PR TITLE
AMR refactor

### DIFF
--- a/doc/pages/inciter_amr.dox
+++ b/doc/pages/inciter_amr.dox
@@ -45,8 +45,9 @@ It is not responsible for performing the derefinement, but instead marks what a 
 
 In short, it:
 
-- Iterates over the children of a tet, to find which non-parent-points are safe to remove and are surrounded by edges who are marked for derefinement 
-- It skips tets which are ineligible to derefine, because they themselves have children (TODO: how did we handle grandchildren again?)
+- It only loops through the active mesh, and then queries the parent of the active tet under consideration for derefinement compatibility
+- Iterates over the children of this parent tet (siblings of active tet), to find which non-parent-points are safe to remove and are surrounded by edges who are marked for derefinement 
+- It skips tets which are ineligible to derefine, because they do not have parents, i.e. are a part of the original mesh
 
 It uses the count of these points to implement Algorithm 4 from the paper. The functions for this are implemented in `refinement.hpp`
 

--- a/src/Inciter/AMR/AMR_types.hpp
+++ b/src/Inciter/AMR/AMR_types.hpp
@@ -45,7 +45,7 @@ enum Edge_Lock_Case {unlocked = 0, locked, intermediate, temporary};
 struct Edge_Refinement {
     size_t A;
     size_t B;
-    int needs_refining; // TODO: This could possibly be deduced implicitly
+    int needs_refining; // value of 1= refinement; 2= deref-ref (as in for 8:4)
     bool needs_derefining; // TODO: Marge this with needs_refining
     Edge_Lock_Case lock_case; // TODO: Refactor this to match _ style?
 

--- a/src/Inciter/AMR/Refinement_State.hpp
+++ b/src/Inciter/AMR/Refinement_State.hpp
@@ -34,6 +34,7 @@ namespace AMR {
             size_t child_number;
             size_t parent_id;
             bool normal;
+            bool has_parent;
 
             Refinement_State() {}
 
@@ -47,6 +48,7 @@ namespace AMR {
              * @param refinement_level_in The level of refinement
              * @param child_number_in ??  // TODO: What is this?
              * @param parent_id_in Id of parent element
+             * @param has_parent_in True if element has a parent, default is true
             */
             Refinement_State(
                     size_t active_element_number_in,
@@ -54,7 +56,8 @@ namespace AMR {
                     const child_id_list_t& children_in,
                     size_t refinement_level_in,
                     size_t child_number_in,
-                    size_t parent_id_in
+                    size_t parent_id_in,
+                    bool has_parent_in=true
             ) :
                     active_element_number(active_element_number_in),
                     refinement_case(refinement_case_in),
@@ -62,7 +65,8 @@ namespace AMR {
                     refinement_level(refinement_level_in),
                     child_number(child_number_in),
                     parent_id(parent_id_in),
-                    normal(0)
+                    normal(0),
+                    has_parent(has_parent_in)
             {
                 // Empty
             }
@@ -74,19 +78,22 @@ namespace AMR {
              * @param refinement_case_in The refinement case
              * @param refinement_level_in The level of refinement
              * @param parent_id_in Id of parent element
+             * @param has_parent_in True if element has a parent, default is true
              */
             Refinement_State(
                     size_t active_element_number_in,
                     Refinement_Case refinement_case_in,
                     size_t refinement_level_in,
-                    size_t parent_id_in
+                    size_t parent_id_in,
+                    bool has_parent_in=true
             ) :
                     active_element_number(active_element_number_in),
                     refinement_case(refinement_case_in),
                     refinement_level(refinement_level_in),
                     child_number(DEFUALT_CHILD_NUMBER), // Give it default child id
                     parent_id(parent_id_in),
-                    normal(0)
+                    normal(0),
+                    has_parent(has_parent_in)
             {
                 // Set default size of children to be sensible
                 children.reserve(MAX_CHILDREN);

--- a/src/Inciter/AMR/edge_store.hpp
+++ b/src/Inciter/AMR/edge_store.hpp
@@ -206,6 +206,27 @@ namespace AMR {
             }
 
             /**
+             * @brief function to take a list of edge and mark them all
+             * as needing to be refined as a part of the 8:4 derefinement
+             *
+             * @param ids List of ids to mark for deref-refinement
+             */
+            void mark_edges_for_deref_ref(std::vector<node_pair_t> ids)
+            {
+              for (const auto& id : ids)
+                {
+                  edge_t key = nodes_to_key(id[0], id[1]);
+
+                  // cppcheck-suppress assertWithSideEffect
+                  assert( exists(key) );
+                  // value of 2 for needs_refining indicates part of derefine
+                  get(key).needs_refining = 2;
+
+                  trace_out << get(key).needs_refining << std::endl;
+                }
+            }
+
+            /**
              * @brief Function to unmark and edge as needing refinement
              *
              * @param key The key representing the edge to unmark

--- a/src/Inciter/AMR/master_element_store.hpp
+++ b/src/Inciter/AMR/master_element_store.hpp
@@ -28,6 +28,7 @@ namespace AMR {
              * this element
              * @param refinement_level The level of refinement
              * @param parent_id The id of the parent element
+             * @param has_parent True if element has a parent, default is true
              *
              * @return The id of the added element
             */
@@ -35,42 +36,24 @@ namespace AMR {
             // current none reliance on default input values is nice, as it
             // means that we don't have to do any checks on if a valid value
             // was passed for the base case..
-            size_t add
-            (
+            size_t add(
                  size_t element_number,
                  Refinement_Case refinement_case,
                  size_t refinement_level,
-                 size_t parent_id
+                 size_t parent_id,
+                 bool has_parent=true
             )
             {
                 Refinement_State d = Refinement_State(
                         element_number,
                         refinement_case,
                         refinement_level,
-                        parent_id
+                        parent_id,
+                        has_parent
                 );
 
                 master_elements.insert( std::pair<size_t, Refinement_State>(element_number, d));
 
-                return element_number;
-            }
-
-            /**
-             * @brief Add a master element, with a default parent_id (0) and
-             * default refinement level (0)
-             *
-             * @param element_number The element number to add
-             * @param refinement_case The refinement_case which gave rise to
-             * this element
-             *
-             * @return The id of the added element
-            */
-            size_t add(
-                 size_t element_number,
-                 Refinement_Case refinement_case
-            )
-            {
-                add(element_number, refinement_case, 0, 0);
                 return element_number;
             }
 

--- a/src/Inciter/AMR/mesh_adapter.cpp
+++ b/src/Inciter/AMR/mesh_adapter.cpp
@@ -1229,65 +1229,6 @@ namespace AMR {
 
                 child_id_list_t children = tet_store.data(tet_id).children;
 
-                // the following piece of code is necessary only when this
-                // mark-deref loop is over ALL generations of tets (entire
-                // tet_store). The above if-tests avoid this by only going over
-                // active tets.
-
-                //// Skip tets which have no children or which are grand-parents
-                //bool grandparent = false;
-                //for (const auto& ch : children) {
-                //  if (tet_store.data(ch).children.size()) grandparent = true;
-                //}
-                //if (children.size() <= 0) { continue; }
-                //else if (grandparent) {
-                //  trace_out << "grandparent: " << tet_id
-                //    << " unmarking children from deref" << std::endl;
-                //  // go over grandparent's children and lock its edges, only if
-                //  // that edge does not belong to a grandchild. The following
-                //  // does this in a simple but 'hacky' way
-                //  std::map< edge_t, std::size_t > edge_derefmark;
-
-                //  for (auto child_id : children) {
-                //    auto grandchildren = tet_store.data(child_id).children;
-                //    // get child_id's nodes
-                //    auto child_nodes = tet_store.get(child_id);
-                //    std::unordered_set<size_t> child_node_set{
-                //      std::begin(child_nodes), std::end(child_nodes)};
-                //    trace_out << "looking at child: " << child_id <<
-                //      " which has " << grandchildren.size() << " children" << std::endl;
-                //  // 1. store the grandchildren's edge-markings
-                //    for (auto gchild_id : grandchildren) {
-                //      auto edges = tet_store.generate_edge_keys(gchild_id);
-                //      trace_out << "looking at grandchild: " << gchild_id << std::endl;
-                //      for (const auto& edge_key : edges) {
-                //        // retaining this edge's deref marking only if one of
-                //        // the nodes of this edge does not belong to the parent
-                //        // of gchild_id (which is child_id), i.e. nonparent node.
-                //        // basically, keep deref-decisions only for the edges
-                //        // that have been split
-                //        if (child_node_set.count(edge_key.first())==0 ||
-                //          child_node_set.count(edge_key.second())==0) {
-                //          edge_derefmark[edge_key] =
-                //            tet_store.edge_store.get(edge_key).needs_derefining;
-                //        }
-                //      }
-                //    }
-
-                //  // 2. go thru the children, and unmark their edges for deref
-                //    deactivate_deref_tet_edges(child_id);
-                //  }
-
-                //  // 3. go thru the grandparents again and reinstate their edge
-                //  // derefinement markings
-                //  for (const auto& e_key : edge_derefmark) {
-                //    tet_store.edge_store.get(e_key.first).needs_derefining =
-                //      e_key.second;
-                //  }
-
-                //  continue;
-                //}
-
                 // This is useful for later inspection
                 //edge_list_t edge_list = tet_store.generate_edge_keys(tet_id);
                 std::size_t num_to_derefine = 0; // Nodes

--- a/src/Inciter/AMR/mesh_adapter.cpp
+++ b/src/Inciter/AMR/mesh_adapter.cpp
@@ -425,7 +425,7 @@ namespace AMR {
                             // Count edges which need refining
                             //  We check in here as we won't refine a
                             //  locked edge and will thus ignore it
-                            if (tet_store.edge_store.get(key).needs_refining)
+                            if (tet_store.edge_store.get(key).needs_refining == 1)
                             {
                                 num_to_refine++;
                                 trace_out << "key needs ref " << key << std::endl;
@@ -952,7 +952,7 @@ namespace AMR {
             }
 
             // Count number of marked for refinement
-            if (tet_store.edge_store.get(key).needs_refining)
+            if (tet_store.edge_store.get(key).needs_refining == 1)
             {
                 trace_out << "found refine" << std::endl;
                 num_to_refine++;
@@ -1367,9 +1367,9 @@ namespace AMR {
                     //if (refinement_case == AMR::Refinement_Case::one_to_four)
                     if (children.size() == 4)
                     {
-                        // Accept as 4:2 derefine"
+                        // Accept as 4:1 derefine"
                         trace_out << "Accept as 4:1" << std::endl;
-                        //refiner.derefine_four_to_two(tet_store,  node_connectivity, tet_id);
+                        //refiner.derefine_four_to_one(tet_store,  node_connectivity, tet_id);
                         tet_store.mark_derefinement_decision(tet_id, AMR::Derefinement_Case::four_to_one);
                     }
                     // "Else if icase = 1:8
@@ -1401,7 +1401,7 @@ namespace AMR {
                               ref_edges.push_back(node_connectivity.get(n));
                             }
 
-                            tet_store.edge_store.mark_edges_for_refinement(ref_edges);
+                            tet_store.edge_store.mark_edges_for_deref_ref(ref_edges);
                             //refiner.derefine_eight_to_four(tet_store,  node_connectivity, tet_id);
                             tet_store.mark_derefinement_decision(tet_id, AMR::Derefinement_Case::eight_to_four);
                         }
@@ -1461,7 +1461,7 @@ namespace AMR {
                           ref_edges.push_back(node_connectivity.get(n));
                         }
 
-                        tet_store.edge_store.mark_edges_for_refinement(ref_edges);
+                        tet_store.edge_store.mark_edges_for_deref_ref(ref_edges);
 
                         // Accept as 8:4 derefinement
                         trace_out << "Accept as 8:4" << std::endl;

--- a/src/Inciter/AMR/tet_store.hpp
+++ b/src/Inciter/AMR/tet_store.hpp
@@ -227,10 +227,7 @@ namespace AMR {
 
                 //std::cout << "id " << id << " parent " << parent_id << std::endl;
 
-                add(id, nodes, refinement_case);
-
-                // Set parent id
-                master_elements.get(id).parent_id = parent_id;
+                add_to_master(id, nodes, refinement_case, parent_id, true);
 
                 master_elements.get(id).refinement_level =
                     master_elements.get(parent_id).refinement_level+1;
@@ -250,24 +247,28 @@ namespace AMR {
              * @param refinement_case The refinement case which caused this tet
              * to be generated
             */
-            void add(size_t id, const tet_t& nodes, Refinement_Case refinement_case)
+            void add_to_master(size_t id, const tet_t& nodes,
+              Refinement_Case refinement_case, size_t parent_id=0,
+              bool has_parent=false)
             {
                 store_tet(id, nodes);
 
                 size_t refinement_level = 0;
-                size_t parent_id = 0;
 
                 // Add to master list
-                master_elements.add(id, refinement_case, refinement_level, parent_id);
+                master_elements.add(id, refinement_case, refinement_level, parent_id, has_parent);
 
                 // The new master element should start as active
                 active_elements.add(id);
             }
 
+            /**
+             * @brief Interface to add a tet from the original mesh (no parent)
+            */
             void add(const tet_t& nodes, Refinement_Case refinement_case)
             {
                 size_t id = id_generator.get_next_tet_id();
-                add(id, nodes, refinement_case);
+                add_to_master(id, nodes, refinement_case);
             }
 
             void add(


### PR DESCRIPTION
This set of commits modifies the `mark_derefinement()` algorithm, by considering only the active tets (and their immediate parents) for derefinement. Previously, the entire `tet_store` i.e. all generations of tets were considered for derefinement. This change removes some complicated logic that was required by the previous approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/479)
<!-- Reviewable:end -->
