### PR TITLE
bug fix for dtref

### DIFF
--- a/src/Inciter/AMR/edge.hpp
+++ b/src/Inciter/AMR/edge.hpp
@@ -38,15 +38,39 @@ class edge_t {
             // Piggy back underlying edge_ type where possible
         bool operator==(const edge_t& rhs) const
         {
-            return (this->data==rhs.get_data());
+          // ensure entries of rhs and this are in ascending order
+          auto this_copy = this->data;
+          this_copy[0] = std::min(this->data[0], this->data[1]);
+          this_copy[1] = std::max(this->data[0], this->data[1]);
+          std::array< std::size_t, 2 > rhs_copy;
+          rhs_copy[0] = std::min(rhs.get_data()[0], rhs.get_data()[1]);
+          rhs_copy[1] = std::max(rhs.get_data()[0], rhs.get_data()[1]);
+
+          if (this_copy[0] == rhs_copy[0] && this_copy[1] == rhs_copy[1])
+            return true;
+          else
+            return false;
         }
-        bool operator>(const edge_t& rhs) const
-        {
-          return (data > rhs.get_data());
-        }
+        //bool operator>(const edge_t& rhs) const
+        //{
+        //  return (data > rhs.get_data());
+        //}
         bool operator<(const edge_t& rhs) const
         {
-          return (data < rhs.get_data());
+          // ensure entries of rhs and this are in ascending order
+          auto this_copy = this->data;
+          this_copy[0] = std::min(this->data[0], this->data[1]);
+          this_copy[1] = std::max(this->data[0], this->data[1]);
+          std::array< std::size_t, 2 > rhs_copy;
+          rhs_copy[0] = std::min(rhs.get_data()[0], rhs.get_data()[1]);
+          rhs_copy[1] = std::max(rhs.get_data()[0], rhs.get_data()[1]);
+
+          if (this_copy[0] < rhs_copy[0])
+            return true;
+          else if (this_copy[0] == rhs_copy[0] && this_copy[1] < rhs_copy[1])
+            return true;
+          else
+            return false;
         }
 
         size_t first() const

--- a/src/Inciter/AMR/mesh_adapter.cpp
+++ b/src/Inciter/AMR/mesh_adapter.cpp
@@ -485,8 +485,8 @@ namespace AMR {
 
                     } // if num_to_refine
                     else {
-                            // If we got here, we don't want to refine this guy
-                            //tet_store.marked_refinements.add(tet_id, AMR::Refinement_Case::none);
+                        // If we got here, we don't want to refine this guy
+                        tet_store.marked_refinements.add(tet_id, AMR::Refinement_Case::none);
                     }
                 } // if active
                 else {
@@ -589,6 +589,9 @@ namespace AMR {
                 std::cout << "num children " << element.children.size() << std::endl;
                 assert(0);
             }
+            // remove tets and edges marked for deletion above
+            refiner.delete_intermediates_of_children(tet_store);
+            tet_store.process_delete_list();
 
             refiner.refine_one_to_eight(tet_store,node_connectivity,i);
 

--- a/src/Inciter/Refiner.cpp
+++ b/src/Inciter/Refiner.cpp
@@ -896,8 +896,8 @@ Refiner::perform()
   } else {
 
     // TODO: does not work yet, fix as above
-    m_refiner.perform_derefinement();
     m_refiner.perform_refinement();
+    m_refiner.perform_derefinement();
   }
 
   //auto& tet_store = m_refiner.tet_store;
@@ -1202,8 +1202,8 @@ Refiner::errorRefine()
       tagged_edges.push_back( { edge_t( m_rid[e.first[0]], m_rid[e.first[1]] ),
                                 edge_tag::REFINE } );
     } else if (e.second < tolderef) {
-      //tagged_edges.push_back( { edge_t( m_rid[e.first[0]], m_rid[e.first[1]] ),
-      //                          edge_tag::DEREFINE } );
+      tagged_edges.push_back( { edge_t( m_rid[e.first[0]], m_rid[e.first[1]] ),
+                                edge_tag::DEREFINE } );
     }
   }
 


### PR DESCRIPTION
Bug fix in refinement, where some edges were marked for deletion as a part of a 4:8 in delete_list (implemented as 4:1 derefinement and 1:8 refinement) but the delete_list was not processed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/480)
<!-- Reviewable:end -->
