### PR TITLE
Fix segfault after merging in multi-box ICs, triggered by new shocktube run

### DIFF
--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -458,7 +458,7 @@ ALECG::box( tk::real v )
 
   // Set initial conditions for all PDEs
   for (auto& eq : g_cgpde)
-    eq.initialize( d->Coord(), m_u, d->T(), d->Boxvol(), m_boxnodes );
+    eq.initialize( d->Coord(), m_u, d->T(), v, m_boxnodes );
 
   // Multiply conserved variables with mesh volume
   volumetric( m_u );

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -150,9 +150,7 @@ class CompFlow {
         (bgpreic.size() > m_system && !bgpreic[m_system].empty()) ?
         bgpreic[m_system][0] : 0.0;
 
-      const auto& cvol = g_inputdeck.get< tag::param, eq, tag::cv >();
-      tk::real cv = (cvol.size() > m_system && !cvol[m_system].empty()) ?
-                    cvol[m_system][0] : 0.0;
+      auto cv = g_inputdeck.get< tag::param, eq, tag::cv >()[ m_system ][ 0 ];
 
       // Set initial and boundary conditions using problem policy
       for (ncomp_t i=0; i<x.size(); ++i) {

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -145,9 +145,14 @@ class CompFlow {
 
       const auto eps = 1000.0 * std::numeric_limits< tk::real >::epsilon();
 
-      // if an ic box was not specified, avoid division by zero by setting V
       const auto& bgpreic = ic.get< tag::pressure >();
-      const auto& cv = g_inputdeck.get< tag::param, eq, tag::cv >();
+      tk::real bgpre =
+        (bgpreic.size() > m_system && !bgpreic[m_system].empty()) ?
+        bgpreic[m_system][0] : 0.0;
+
+      const auto& cvol = g_inputdeck.get< tag::param, eq, tag::cv >();
+      tk::real cv = (cvol.size() > m_system && !cvol[m_system].empty()) ?
+                    cvol[m_system][0] : 0.0;
 
       // Set initial and boundary conditions using problem policy
       for (ncomp_t i=0; i<x.size(); ++i) {
@@ -165,8 +170,7 @@ class CompFlow {
                 b.template get< tag::zmin >(), b.template get< tag::zmax >() };
               auto V_ex = (box[1]-box[0]) * (box[3]-box[2]) * (box[5]-box[4]);
               if (V_ex < eps) V = 1.0;
-              initializeBox( m_system, V_ex/V, t, b, bgpreic[m_system][0],
-                             cv[m_system][0], s );
+              initializeBox( m_system, V_ex/V, t, b, bgpre, cv, s );
             }
             ++bcnt;
           }


### PR DESCRIPTION
Fixes indexing out background pressure ICs are unspecified (and unused anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/490)
<!-- Reviewable:end -->
