### PR TITLE
Fix intel/debug bug with tk::conforming()

### DIFF
--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -103,8 +103,16 @@ Discretization::Discretization(
   Assert( !ginpoel.empty(), "No elements assigned to Discretization chare" );
   Assert( tk::positiveJacobians( m_inpoel, m_coord ),
           "Jacobian in input mesh to Discretization non-positive" );
+  #if not defined(__INTEL_COMPILER) || defined(NDEBUG)
+  // The above ifdef skips running the conformity test with the intel compiler
+  // in debug mode only. This is necessary because in tk::conforming(), filling
+  // up the map can fail with some meshes (only in parallel), e.g., tube.exo,
+  // used by some regression tests, due to the intel compiler generating some
+  // garbage incorrect code - only in debug, only in parallel, only with that
+  // mesh.
   Assert( tk::conforming( m_inpoel, m_coord ),
           "Input mesh to Discretization not conforming" );
+  #endif
 
   // Store communication maps
   for (const auto& [ c, maps ] : msum) {

--- a/src/Inciter/Refiner.cpp
+++ b/src/Inciter/Refiner.cpp
@@ -123,8 +123,17 @@ Refiner::Refiner( std::size_t meshid,
             tk::genEsuelTet( m_inpoel, tk::genEsup(m_inpoel,4) ),
             m_inpoel, m_coord ),
           "Input mesh to Refiner leaky" );
+
+  #if not defined(__INTEL_COMPILER) || defined(NDEBUG)
+  // The above ifdef skips running the conformity test with the intel compiler
+  // in debug mode only. This is necessary because in tk::conforming(), filling
+  // up the map can fail with some meshes (only in parallel), e.g., tube.exo,
+  // used by some regression tests, due to the intel compiler generating some
+  // garbage incorrect code - only in debug, only in parallel, only with that
+  // mesh.
   Assert( tk::conforming( m_inpoel, m_coord, true, m_rid ),
           "Input mesh to Refiner not conforming" );
+  #endif
 
   // Generate local -> refiner lib node id map and its inverse
   libmap();

--- a/src/Mesh/DerivedData.cpp
+++ b/src/Mesh/DerivedData.cpp
@@ -1641,9 +1641,7 @@ conforming( const std::vector< std::size_t >& inpoel,
       Coord en{{ (x[n[0]] + x[n[1]]) / 2.0,
                  (y[n[0]] + y[n[1]]) / 2.0,
                  (z[n[0]] + z[n[1]]) / 2.0 }};
-      #if not defined(__INTEL_COMPILER) || defined(NDEBUG)
       edgeNodes[ en ] = std::tuple<std::size_t,Tet,Edge>{ e, {{A,B,C,D}}, n };
-      #endif
     }
   }
 

--- a/src/Mesh/DerivedData.cpp
+++ b/src/Mesh/DerivedData.cpp
@@ -1579,7 +1579,7 @@ conforming( const std::vector< std::size_t >& inpoel,
 //!   tetrahedron mesh within a single refinement step. Thus this algorithm is
 //!   intended for this specific case, i.e., test for conformity after a
 //!   single refinement step and not after multiple ones or for detecting
-//!   hanging nodes in an arbitrary meshes.
+//!   hanging nodes in an arbitrary mesh.
 //*****************************************************************************
 {
   Assert( !inpoel.empty(),

--- a/src/Mesh/DerivedData.cpp
+++ b/src/Mesh/DerivedData.cpp
@@ -1641,7 +1641,9 @@ conforming( const std::vector< std::size_t >& inpoel,
       Coord en{{ (x[n[0]] + x[n[1]]) / 2.0,
                  (y[n[0]] + y[n[1]]) / 2.0,
                  (z[n[0]] + z[n[1]]) / 2.0 }};
+      #if not defined(__INTEL_COMPILER) || defined(NDEBUG)
       edgeNodes[ en ] = std::tuple<std::size_t,Tet,Edge>{ e, {{A,B,C,D}}, n };
+      #endif
     }
   }
 


### PR DESCRIPTION
Totally weird bug, this PR puts in a workaround. See commit messages for details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/502)
<!-- Reviewable:end -->
