### PR TITLE
Remove -Werr arg since charmc linker does not like it inside docker

### DIFF
--- a/tools/docker/Dockerfile.quinoa-build-debian-executable-only
+++ b/tools/docker/Dockerfile.quinoa-build-debian-executable-only
@@ -51,6 +51,6 @@ RUN cd quinoa && git submodule init && git submodule update && cd external && sh
 # Build TPLs
 RUN cd quinoa && mkdir -p external/build && cd external/build && cmake -D${EXECUTABLE^^}_ONLY=true .. && make -sj$(grep -c processor /proc/cpuinfo)
 # Build code
-RUN cd quinoa && mkdir -p build && cd build && cmake -DCMAKE_CXX_FLAGS=-Werror -GNinja -DRUNNER=mpirun -DRUNNER_NCPUS_ARG=-n -DRUNNER_ARGS="--bind-to none -oversubscribe" ../src && ninja ${EXECUTABLE,,}
+RUN cd quinoa && mkdir -p build && cd build && cmake -GNinja -DRUNNER=mpirun -DRUNNER_NCPUS_ARG=-n -DRUNNER_ARGS="--bind-to none -oversubscribe" ../src && ninja ${EXECUTABLE,,}
 # Run tests
 RUN cd quinoa/build && npe=$(expr $(grep -c processor /proc/cpuinfo) / 2) && if [ ${EXECUTABLE} = unittest ]; then mpirun -n $npe Main/unittest -v -q; else ctest -j $npe --output-on-failure -LE extreme -R ${EXECUTABLE,,}; fi


### PR DESCRIPTION
Otherwise errors as:

[34/34] Linking CXX executable Main/fileconv
FAILED: Main/fileconv
: && /home/quinoa/quinoa/external/install/gnu-x86_64/charm/bin/charmc -module CommonLBs   -c++ /usr/bin/c++  -Werror -fdiagnostics-color -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wmissing-field-initializers -Wmissing-format-attribute -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-aliasing=2 -Wunreachable-code -Wunused -Wunused-parameter -Wvariadic-macros -Wwrite-strings -Wno-sign-compare -Wno-unused-function -Wno-stack-protector -Wno-expansion-to-defined -Wno-int-in-bool-context -Wno-cast-function-type -Wno-format-overflow -Wno-pragmas -Wno-unknown-pragmas -O3 -DNDEBUG  -Wno-unused-parameter    -rdynamic Main/CMakeFiles/fileconv.dir/FileConvDriver.cpp.o Main/CMakeFiles/fileconv.dir/FileConv.cpp.o  -o Main/fileconv  -Wl,-rpath,/home/quinoa/quinoa/build/IO:/home/quinoa/quinoa/build/Mesh:/home/quinoa/quinoa/build/Control:/home/quinoa/quinoa/build/Base:/home/quinoa/quinoa/build/Main:/home/quinoa/quinoa/external/install/gnu-x86_64/lib:/usr/lib/x86_64-linux-gnu/netcdf/mpi/lib: IO/libquinoa_rootmeshio.so IO/libquinoa_exodusiimeshio.so Mesh/libquinoa_mesh.so Control/libquinoa_fileconvcontrol.so Base/libquinoa_base.so Main/libquinoa_config.so Main/libquinoa_init.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libexodus.so.12.14.1 /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libRIO.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libCore.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libTree.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libHist.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libThread.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libNet.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libImt.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libMatrix.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libMathCore.so /home/quinoa/quinoa/external/install/gnu-x86_64/lib/libMultiProc.so /usr/lib/x86_64-linux-gnu/netcdf/mpi/lib/libnetcdf.so -ldw && :
c++: error: : No such file or directory
Fatal Error by charmc in directory /home/quinoa/quinoa/build
   Command /usr/bin/c++ -fPIC -DCMK_GFORTRAN -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX -I/home/quinoa/quinoa/external/install/gnu-x86_64/charm/include -D__CHARMC__=1 -DNDEBUG -fdiagnostics-color -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wmissing-field-initializers -Wmissing-format-attribute -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wshadow -Wstack-protector -Wstrict-aliasing=2 -Wunreachable-code -Wunused -Wunused-parameter -Wvariadic-macros -Wwrite-strings -Wno-sign-compare -Wno-unused-function -Wno-stack-protector -Wno-expansion-to-defined -Wno-int-in-bool-context -Wno-cast-function-type -Wno-format-overflow -Wno-pragmas -Wno-unknown-pragmas -O3 -Wno-unused-parameter -rdynamic -Wl,-rpath,/home/quinoa/quinoa/build/IO:/home/quinoa/quinoa/build/Mesh:/home/quinoa/quinoa/build/Control:/home/quinoa/quinoa/build/Base:/home/quinoa/quinoa/build/Main:/home/quinoa/quinoa/external/install/gnu-x86_64/lib:/usr/lib/x86_64-linux-gnu/netcdf/mpi/lib:  -U_FORTIFY_SOURCE -fno-stack-protector -fno-lifetime-dse -c moduleinit6179.C -o moduleinit6179.o returned error code 1
charmc exiting...
ninja: build stopped: subcommand failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/523)
<!-- Reviewable:end -->
