### PR TITLE
make dirichlet bc purely dirichlet

### DIFF
--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -928,7 +928,6 @@ class MultiMat {
     //! \param[in] y Y-coordinate at which to compute the states
     //! \param[in] z Z-coordinate at which to compute the states
     //! \param[in] t Physical time
-    //! \param[in] fn Unit face normal
     //! \return Left and right states for all scalar components in this PDE
     //!   system
     //! \note The function signature must follow tk::StateFn. For multimat, the
@@ -937,7 +936,7 @@ class MultiMat {
     static tk::StateFn::result_type
     dirichlet( ncomp_t system, ncomp_t ncomp, const std::vector< tk::real >& ul,
                tk::real x, tk::real y, tk::real z, tk::real t,
-               const std::array< tk::real, 3 >& fn )
+               const std::array< tk::real, 3 >& )
     {
       const auto nmat =
         g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[system];
@@ -958,51 +957,13 @@ class MultiMat {
       ur[ncomp+velocityIdx(nmat, 1)] = ur[momentumIdx(nmat, 1)] / rho;
       ur[ncomp+velocityIdx(nmat, 2)] = ur[momentumIdx(nmat, 2)] / rho;
 
-      // determine the speed of sound of the majority material
-      auto almax(0.0);
-      std::size_t kmax(0);
+      // material pressures
       for (std::size_t k=0; k<nmat; ++k)
       {
-        if (ul[volfracIdx(nmat, k)] > almax)
-        {
-          almax = ul[volfracIdx(nmat, k)];
-          kmax = k;
-        }
-      }
-
-      auto vn = tk::dot({{ul[ncomp+velocityIdx(nmat, 0)],
-        ul[ncomp+velocityIdx(nmat, 1)], ul[ncomp+velocityIdx(nmat, 2)]}}, fn);
-      auto Ml = vn/eos_soundspeed< tag::multimat >(system,
-        ul[densityIdx(nmat,kmax)], ul[ncomp+pressureIdx(nmat,kmax)],
-        almax, kmax);
-
-      // material pressures
-      if (Ml > 1.0)
-      {
-        for (std::size_t k=0; k<nmat; ++k)
-        {
-          tk::real arhomat = ur[densityIdx(nmat, k)];
-          tk::real arhoemat = ur[energyIdx(nmat, k)];
-          tk::real alphamat = ur[volfracIdx(nmat, k)];
-          ur[ncomp+pressureIdx(nmat, k)] = eos_pressure< tag::multimat >( system,
-            arhomat, ur[ncomp+velocityIdx(nmat, 0)],
-            ur[ncomp+velocityIdx(nmat, 1)], ur[ncomp+velocityIdx(nmat, 2)],
-            arhoemat, alphamat, k );
-        }
-      }
-      else
-      {
-        for (std::size_t k=0; k<nmat; ++k)
-        {
-          ur[ncomp+pressureIdx(nmat, k)] = ul[ncomp+pressureIdx(nmat, k)];
-          ur[energyIdx(nmat, k)] = ur[volfracIdx(nmat, k)] *
-            eos_totalenergy< tag::multimat >(system,
-            ur[densityIdx(nmat, k)]/ur[volfracIdx(nmat, k)],
-            ur[ncomp+velocityIdx(nmat, 0)],
-            ur[ncomp+velocityIdx(nmat, 1)],
-            ur[ncomp+velocityIdx(nmat, 2)],
-            ul[ncomp+pressureIdx(nmat, k)]/ul[volfracIdx(nmat, k)], k);
-        }
+        ur[ncomp+pressureIdx(nmat, k)] = eos_pressure< tag::multimat >( system,
+          ur[densityIdx(nmat, k)], ur[ncomp+velocityIdx(nmat, 0)],
+          ur[ncomp+velocityIdx(nmat, 1)], ur[ncomp+velocityIdx(nmat, 2)],
+          ur[energyIdx(nmat, k)], ur[volfracIdx(nmat, k)], k );
       }
 
       Assert( ur.size() == ncomp+nmat+3, "Incorrect size for appended "


### PR DESCRIPTION
The Dirichlet bc in `dgmultimat` has a mixed nature: it switches to the Neumann condition for pressure when flow becomes locally subsonic near the boundary face. This causes problems when oscillations drive the local state to subsonic, especially since Quinoa does not use bc-information while limiting. This commit changes the `dirichlet()` function so that it enforces purely Dirichlet bcs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/539)
<!-- Reviewable:end -->
