### PR TITLE
limsol_projection for fv

### DIFF
--- a/src/Inciter/FV.cpp
+++ b/src/Inciter/FV.cpp
@@ -628,9 +628,14 @@ FV::lim()
   const auto rdof = g_inputdeck.get< tag::discr, tag::rdof >();
 
   if (rdof > 1)
-    for (const auto& eq : g_fvpde)
+    for (const auto& eq : g_fvpde) {
       eq.limit( myGhosts()->m_geoElem, myGhosts()->m_fd, myGhosts()->m_esup,
         myGhosts()->m_inpoel, myGhosts()->m_coord, m_u, m_p );
+
+      if (g_inputdeck.get< tag::discr, tag::limsol_projection >())
+        eq.Correct_Conserv(m_p, myGhosts()->m_geoElem, m_u,
+          myGhosts()->m_fd.Esuel().size()/4);
+    }
 
   // Send limited solution to neighboring chares
   if (myGhosts()->m_sendGhost.empty())

--- a/src/PDE/FVPDE.hpp
+++ b/src/PDE/FVPDE.hpp
@@ -154,6 +154,15 @@ class FVPDE {
       self->limit( geoElem, fd, esup, inpoel, coord, U, P );
     }
 
+    //! Public interface to update the conservative variable solution
+    void Correct_Conserv( const tk::Fields& prim,
+                          const tk::Fields& geoElem,
+                          tk::Fields& unk,
+                          std::size_t nielem ) const
+    {
+      self->Correct_Conserv( prim, geoElem, unk, nielem );
+    }
+
     //! Public interface to computing the P1 right-hand side vector
     void rhs( tk::real t,
               const tk::Fields& geoFace,
@@ -267,6 +276,10 @@ class FVPDE {
                           const tk::UnsMesh::Coords&,
                           tk::Fields&,
                           tk::Fields& ) const = 0;
+      virtual void Correct_Conserv( const tk::Fields&,
+                                    const tk::Fields&,
+                                    tk::Fields&,
+                                    std::size_t ) const = 0;
       virtual void rhs( tk::real,
                         const tk::Fields&,
                         const tk::Fields&,
@@ -356,6 +369,13 @@ class FVPDE {
                   tk::Fields& P ) const override
       {
         data.limit( geoElem, fd, esup, inpoel, coord, U, P );
+      }
+      void Correct_Conserv( const tk::Fields& prim,
+                          const tk::Fields& geoElem,
+                          tk::Fields& unk,
+                          std::size_t nielem ) const override
+      {
+        data.Correct_Conserv( prim, geoElem, unk, nielem );
       }
       void rhs(
         tk::real t,

--- a/src/PDE/Limiter.cpp
+++ b/src/PDE/Limiter.cpp
@@ -2783,7 +2783,6 @@ correctLimConservMultiMat(
 //!   quantities based on the limited primitive quantities
 // *****************************************************************************
 {
-  const auto ndof = g_inputdeck.get< tag::discr, tag::ndof >();
   const auto rdof = g_inputdeck.get< tag::discr, tag::rdof >();
   std::size_t ncomp = unk.nprop()/rdof;
   std::size_t nprim = prim.nprop()/rdof;
@@ -2818,9 +2817,9 @@ correctLimConservMultiMat(
       auto w = wgp[igp] * geoElem(e, 0, 0);
 
       // Evaluate the solution at quadrature point
-      auto U = tk::eval_state( ncomp, 0, rdof, ndof, e, unk,  B,
+      auto U = tk::eval_state( ncomp, 0, rdof, rdof, e, unk,  B,
                                {0, ncomp-1} );
-      auto P = tk::eval_state( nprim, 0, rdof, ndof, e, prim, B,
+      auto P = tk::eval_state( nprim, 0, rdof, rdof, e, prim, B,
                                {0, nprim-1} );
 
       // Solution vector that stores the material energy and bulk momentum

--- a/src/PDE/Limiter.hpp
+++ b/src/PDE/Limiter.hpp
@@ -298,6 +298,16 @@ timeStepSizeMultiMat(
   const tk::Fields& U,
   const tk::Fields& P );
 
+//! Update the conservative quantities after limiting for multi-material systems
+void
+correctLimConservMultiMat(
+  std::size_t nelem,
+  std::size_t system,
+  std::size_t nmat,
+  const tk::Fields& geoElem,
+  const tk::Fields& prim,
+  tk::Fields& unk );
+
 } // inciter::
 
 #endif // Limiter_h

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -381,6 +381,33 @@ class MultiMat {
       }
     }
 
+    //! Update the conservative variable solution based on limited primitives
+    //! \param[in] prim Array of primitive variables
+    //! \param[in] geoElem Element geometry array
+    //! \param[in,out] unk Array of conservative variables
+    //! \param[in] nielem Number of internal elements
+    //! \details This function computes the updated dofs for conservative
+    //!   quantities based on the limited primitive quantities
+    void Correct_Conserv( const tk::Fields& prim,
+                          const tk::Fields& geoElem,
+                          tk::Fields& unk,
+                          std::size_t nielem ) const
+    {
+      [[maybe_unused]] const auto rdof =
+        g_inputdeck.get< tag::discr, tag::rdof >();
+      const auto nmat =
+        g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[m_system];
+
+      Assert( unk.nunk() == prim.nunk(), "Number of unknowns in solution "
+              "vector and primitive vector at recent time step incorrect" );
+      Assert( unk.nprop() == rdof*m_ncomp, "Number of components in solution "
+              "vector must equal "+ std::to_string(rdof*m_ncomp) );
+      Assert( prim.nprop() == rdof*nprim(), "Number of components in vector of "
+              "primitive quantities must equal "+ std::to_string(rdof*nprim()) );
+
+      correctLimConservMultiMat(nielem, m_offset, nmat, geoElem, prim, unk);
+    }
+
     //! Compute right hand side
     //! \param[in] t Physical time
     //! \param[in] geoFace Face geometry array


### PR DESCRIPTION
Following changes:
1. adding the post-limiting projection to FV;
2. bug fix in this projection: In the previous version, nothing was changing for the p0p1/fv, since ndof was being used. Changed ndof to rdof appropriately in a few places in that function, since for reconstructed methods (like p0p1/fv), rdof needs to be used so that the reconstructed dofs get projected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/552)
<!-- Reviewable:end -->
