### PR TITLE
bugfix: support integration with ExaM2M transfer every iteration

### DIFF
--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -190,7 +190,7 @@ Discretization::Discretization(
     if (thisIndex == 0) {
       exam2m::addMesh( thisProxy, m_nchare,
         CkCallback( CkIndex_Discretization::transferInit(), thisProxy ) );
-      std::cout << "Disc: " << m_meshid << " m2m::addMesh()\n";
+      //      std::cout << "Disc: " << m_meshid << " m2m::addMesh()\n";
     }
     #else
     transferInit();
@@ -300,108 +300,36 @@ Discretization::meshvelConv()
 }
 
 void
-Discretization::transferCallback( std::vector< CkCallback >& cb )
-// *****************************************************************************
-// Receive a list of callbacks from our own child solver
-//! \param[in] cb List of callbacks
-//! \details This is called by our child solver, either when it is coupled to
-//!    another solver or not.
-// *****************************************************************************
-{
-  // Store callback for when there is no transfer we are involved in
-  m_transfer_complete = cb.back();
-  cb.pop_back();
-
-  // Distribute callbacks
-  for (auto& t : m_transfer) {
-    // If we are a source of a transfer, send callback to the destination solver
-    if (m_meshid == t.src) {
-      Assert( !cb.empty(), "Insufficient number of src callbacks, meshid: " +
-                           std::to_string(m_meshid) );
-      m_disc[ t.dst ][ thisIndex ].comcb( m_meshid, cb.back() );
-      cb.pop_back();
-    // If we are a destination of a callback, store it
-    } else if (m_meshid == t.dst) {
-      Assert( !cb.empty(), "Insufficient number of dst callbacks, meshid: " +
-                           std::to_string(m_meshid) );
-      t.cb.push_back( cb.back() );
-      cb.pop_back();
-      //t.cbs.push_back( m_meshid );    // only for debugging
-    }
-  }
-  Assert( cb.empty(), "Not all callbacks have been processed" );
-
-  if (transferCallbacksComplete()) comfinal();
-}
-
-void
-Discretization::comcb( std::size_t srcmeshid, CkCallback c )
-// *****************************************************************************
-// Receive mesh transfer callbacks from source mesh/solver
-//! \param[in] srcmeshid Source mesh (solver) id
-//! \param[in] c Callback received
-// *****************************************************************************
-{
-  // Store received mesh transfer callback from source mesh/solver
-  for (auto& t : m_transfer)
-    if (srcmeshid == t.src && m_meshid == t.dst) {
-      t.cb.push_back( c );
-      //t.cbs.push_back( srcmeshid );   // only for debugging
-    }
-
-  if (transferCallbacksComplete()) comfinal();
-}
-
-bool
-Discretization::transferCallbacksComplete() const
-// *****************************************************************************
-// Determine if communication of mesh transfer callbacks is complete
-//! \return True if communication of mesh transfer callbacks have been
-//!   completed on this solver
-// *****************************************************************************
-{
-  bool c = true;
-
-  // Our callbacks are complete if all transfers we are involved in as a
-  // destination have exactly two callbacks.
-  for (const auto& t : m_transfer)
-    if (m_meshid == t.dst && t.cb.size() != 2)
-      c = false;
-
-  return c;
-}
-
-void
 Discretization::comfinal()
 // *****************************************************************************
 // Finish setting up communication maps and solution transfer callbacks
 // *****************************************************************************
 {
-//  std::cout << "m:" << m_meshid << ": transfer: ";
-//  for (const auto& t : m_transfer) {
-//    std::cout << t.src << "->" << t.dst << ' ';
-//    if (t.cb.size() > 0) {
-//      std::cout << "cb: ";
-//      for (auto m : t.cbs) std::cout << m << ' ';
-//    }
-//  }
-//  std::cout << '\n';
+  //  std::cout << "m:" << m_meshid << ": transfer: ";
+  //  for (const auto& t : m_transfer) {
+  //    std::cout << t.src << "->" << t.dst << ' ';
+  //  if (t.cb.size() > 0) {
+      //      std::cout << "cb: ";
+  //  }
+  // }
+  //  std::cout << '\n';
 
   // Generate own subset of solver/mesh transfer list
   for (const auto& t : m_transfer)
     if (t.src == m_meshid || t.dst == m_meshid)
-      m_mytransfer.push_back( t );
+      {
+	//	std::cout << "--->:" << m_meshid << ": push_back t.src " << t.src <<" t.dst  " <<t.dst << std::endl;
+	m_mytransfer.push_back( t );
+      }
 
-//  std::cout << "m:" << m_meshid << ": mytransfer: ";
-//  for (const auto& t : m_mytransfer) {
-//    std::cout << t.src << "->" << t.dst << ' ';
-//    if (t.cb.size() > 0) {
-//      std::cout << "cb: ";
-//      for (auto m : t.cbs) std::cout << m << ' ';
-//    }
-//  }
-//  std::cout << '\n';
-
+  //  std::cout << "m:" << m_meshid << ": mytransfer: ";
+  //  for (const auto& t : m_mytransfer) {
+  //    std::cout << t.src << "->" << t.dst << ' ';
+  //    if (t.cb.size() > 0) {
+  //      std::cout << "cb: ";
+  //    }
+  //    std::cout << '\n';
+  //}
   // Signal the runtime system that the workers have been created
   std::vector< std::size_t > meshdata{ /* initial */ 1, m_meshid };
   contribute( meshdata, CkReduction::sum_ulong,
@@ -409,31 +337,35 @@ Discretization::comfinal()
 }
 
 void
-Discretization::transfer( [[maybe_unused]] const tk::Fields& u )
+Discretization::transfer( [[maybe_unused]] const tk::Fields& u, CkCallback cb  )
 // *****************************************************************************
 //  Start solution transfer (if coupled)
 //! \param[in] u Solution to transfer from/to
 // *****************************************************************************
 {
   if (m_mytransfer.empty()) {   // skip transfer if not involved in coupling
+    //    std::cout << "empty transfer" <<std::endl;
     m_transfer_complete.send();
   } else {
+    //    std::cout << "Discretization::transfer" <<std::endl;
+    solver_transfer_complete_CB=cb;
     // Pass source and destination meshes to mesh transfer lib (if coupled)
     #ifdef HAS_EXAM2M
     Assert( m_nsrc < m_mytransfer.size(), "Indexing out of mytransfer[src]" );
     if (m_mytransfer[m_nsrc].src == m_meshid) {
       exam2m::setSourceTets( thisProxy, thisIndex, &m_inpoel, &m_coord, u );
+      //      std::cout << m_meshid << " src\n";
       ++m_nsrc;
-      //std::cout << m_meshid << " src\n";
     } else {
       m_nsrc = 0;
     }
     Assert( m_ndst < m_mytransfer.size(), "Indexing out of mytransfer[dst]" );
     if (m_mytransfer[m_ndst].dst == m_meshid) {
+      //      std::cout << "Discretization::transfer dest:" << m_meshid<<std::endl;
       exam2m::setDestPoints( thisProxy, thisIndex, &m_coord, u,
-                             m_mytransfer[m_ndst].cb );
+			     CkCallback(CkIndex_Discretization::transferCompleteCBinDest(), thisProxy ) );
       ++m_ndst;
-      //std::cout << m_meshid << " dst\n";
+      //      std::cout << m_meshid << " dst\n";
     } else {
       m_ndst = 0;
     }
@@ -441,7 +373,44 @@ Discretization::transfer( [[maybe_unused]] const tk::Fields& u )
     m_transfer_complete.send();
     #endif
   }
+  m_nsrc = 0;
+  m_ndst = 0;
 }
+
+void Discretization::transferCompleteCBinDest()
+// *****************************************************************************
+//! Solution transfer completed CB
+//! Called by destination when transfer completes
+//! triggers callback passed in by solver
+//! triggers call to discretization source
+// *****************************************************************************
+{
+  //! lookup the source disc and notify it of completion
+  for (auto& t : m_transfer) {
+    // If we are a source of a transfer, ignore that transfer
+    if (m_meshid == t.src)
+      {
+      }
+    // If we are the destination, notify the source of completion
+    else if (m_meshid == t.dst)
+      {
+	m_disc[ t.src ][ thisIndex ].transferCompleteNotifyFromDest();
+      }
+  }
+  //! callback to the solver that initiated the transfer
+  solver_transfer_complete_CB.send();
+}
+
+void Discretization::transferCompleteNotifyFromDest()
+// *****************************************************************************
+//! Solution transfer completed
+//! Called into source by destination when transfer completes
+//! triggers callback passed in by solver in the source mesh
+// *****************************************************************************
+{
+  solver_transfer_complete_CB.send();
+}
+
 
 std::vector< std::size_t >
 Discretization::bndel() const

--- a/src/Inciter/Transporter.cpp
+++ b/src/Inciter/Transporter.cpp
@@ -1054,7 +1054,7 @@ Transporter::disccreated( std::size_t summeshid, std::size_t npoin )
 // *****************************************************************************
 {
   auto meshid = tk::cref_find( m_meshid, summeshid );
-
+  std::cout << "Trans: " << meshid << " Transporter::disccreated()\n";
   // Update number of mesh points for mesh, since it may have been refined
   if (g_inputdeck.get< tag::amr, tag::t0ref >()) m_npoin[meshid] = npoin;
 

--- a/src/Inciter/discretization.ci
+++ b/src/Inciter/discretization.ci
@@ -47,7 +47,9 @@ module discretization {
                          const std::vector< tk::real >& nodevol );
       entry void stat( tk::real mesh_volume );
       entry void transferInit();
-      entry void comcb( std::size_t srcmeshid, CkCallback c );
+      entry void transferCompleteCBinDest ();
+
+      entry void transferCompleteNotifyFromDest ();
 
       // SDAG code follows. See http://charm.cs.illinois.edu/manuals/html/
       // charm++/manual.html, Sec. "Structured Control Flow: Structured Dagger".


### PR DESCRIPTION
This revised the callback scheme to be compatible with recent changes to ExaM2M.  ExaM2M will trigger a single callback to the destination mesh when the solution transfer is complete. Discretization will set that callback to be transferCompleteCBinDest. That will call the callback passed in by the destination mesh solver in the transfer call, and call transferCompleteNotifyFromDest in the Discretization source mesh, which will call the callback passed in by the source mesh solver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/564)
<!-- Reviewable:end -->
