### PR TITLE
bugfix: support integration with ExaM2M transfer every iteration

### DIFF
--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -144,21 +144,8 @@ ALECG::ALECG( const CProxy_Discretization& disc,
   thisProxy[ thisIndex ].wait4meshblk();
 
   // Generate callbacks for solution transfers we are involved in
+  d->comfinal();
 
-  // Always add a callback to be used when we are not involved in any transfers
-  std::vector< CkCallback > cb;
-  auto c = CkCallback(CkIndex_ALECG::transfer_complete(), thisProxy[thisIndex]);
-  cb.push_back( c );
-
-  // Generate a callback for each transfer we are involved in (either as a
-  // source or a destination)
-  auto meshid = d->MeshId();
-  for (const auto& t : d->Transfers())
-    if (meshid == t.src || meshid == t.dst)
-      cb.push_back( c );
-
-  // Send callbacks to base
-  d->transferCallback( cb );
 }
 //! [Constructor]
 
@@ -639,7 +626,7 @@ ALECG::box( tk::real v, const std::vector< tk::real >& blkvols )
   volumetric( m_u, Disc()->Vol() );
 
   // Initiate IC transfer (if coupled)
-  Disc()->transfer( m_u );
+  Disc()->transfer(m_u, CkCallback(CkIndex_ALECG::transfer_complete(), thisProxy[thisIndex]));
 
   // Initialize nodal mesh volumes at previous time step stage
   d->Voln() = d->Vol();
@@ -1389,9 +1376,12 @@ ALECG::transfer()
 // *****************************************************************************
 {
   // Initiate solution transfer (if coupled)
-  //Disc()->transfer( m_u,
-  //  CkCallback(CkIndex_ALECG::stage(), thisProxy[thisIndex]) );
+
+#ifdef HAS_EXAM2M
+  Disc()->transfer(m_u, CkCallback(CkIndex_ALECG::stage(), thisProxy[thisIndex]));
+#else
   thisProxy[thisIndex].stage();
+#endif
 }
 
 //! [stage]

--- a/src/Inciter/Transporter.cpp
+++ b/src/Inciter/Transporter.cpp
@@ -1054,6 +1054,7 @@ Transporter::disccreated( std::size_t summeshid, std::size_t npoin )
 // *****************************************************************************
 {
   auto meshid = tk::cref_find( m_meshid, summeshid );
+  //std::cout << "Trans: " << meshid << " Transporter::disccreated()\n";
 
   // Update number of mesh points for mesh, since it may have been refined
   if (g_inputdeck.get< tag::amr, tag::t0ref >()) m_npoin[meshid] = npoin;

--- a/src/Inciter/discretization.ci
+++ b/src/Inciter/discretization.ci
@@ -47,7 +47,8 @@ module discretization {
                          const std::vector< tk::real >& nodevol );
       entry void stat( tk::real mesh_volume );
       entry void transferInit();
-      entry void comcb( std::size_t srcmeshid, CkCallback c );
+      entry void transferCompleteCBinDest ();
+      entry void transferCompleteNotifyFromDest ();
 
       // SDAG code follows. See http://charm.cs.illinois.edu/manuals/html/
       // charm++/manual.html, Sec. "Structured Control Flow: Structured Dagger".


### PR DESCRIPTION
This pull request mirrors https://github.com/quinoacomputing/quinoa/pull/564, creating the commits in [this repo](https://github.com/quinoacomputing/quinoa/) instead of the [fork](https://github.com/ericjbohm/quinoa/tree/exam2m-callback-in-transfer).

Changes by @ericjbohm:
This revised the callback scheme to be compatible with recent changes to ExaM2M.  ExaM2M will trigger a single callback to the destination mesh when the solution transfer is complete. Discretization will set that callback to be transferCompleteCBinDest. That will call the callback passed in by the destination mesh solver in the transfer call, and call transferCompleteNotifyFromDest in the Discretization source mesh, which will call the callback passed in by the source mesh solver.