### PR TITLE
Multi-Material problems combining solids and fluids

### DIFF
--- a/src/PDE/Integrate/Boundary.cpp
+++ b/src/PDE/Integrate/Boundary.cpp
@@ -234,6 +234,8 @@ update_rhs_bc ( ncomp_t ncomp,
   // following line commented until rdofel is made available.
   //Assert( B_l.size() == ndof_l, "Size mismatch" );
 
+  using inciter::newSolidsAccFn;
+
     const auto& solidx = inciter::g_inputdeck.get< tag::param, tag::multimat,
     tag::matidxmap >().template get< tag::solidx >();
 
@@ -282,8 +284,8 @@ update_rhs_bc ( ncomp_t ncomp,
           for (std::size_t j=0; j<3; ++j)
             for (std::size_t l=0; l<3; ++l)
               for (std::size_t idir=0; idir<3; ++idir)
-                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
-                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+                riemannDeriv[3*nmat+ndof+3*newSolidsAccFn(k,i,j,l)+idir][el] +=
+                  wt * fl[ncomp+nmat+1+newSolidsAccFn(k,i,j,l)] * fn[idir];
       }
   }
 }

--- a/src/PDE/Integrate/Boundary.cpp
+++ b/src/PDE/Integrate/Boundary.cpp
@@ -192,6 +192,13 @@ bndSurfInt( ncomp_t system,
           auto fl = flux( mat_blk, fn, var, vel( system, ncomp, gp[0], gp[1],
                           gp[2], t ) );
 
+          // Code below commented until details about the form of these terms in
+          // the \alpha_k g_k equations are sorted out.
+          // // Add RHS inverse deformation terms if necessary
+          // if (haveSolid)
+          //   solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
+          //                      coordel_l, coordel_r, igp, coordgp, dt, fl );
+
           // Add the surface integration term to the rhs
           update_rhs_bc( ncomp, nmat, ndof, ndofel[el], wt, fn, el, fl,
                          B_l, R, riemannDeriv );

--- a/src/PDE/Integrate/Boundary.cpp
+++ b/src/PDE/Integrate/Boundary.cpp
@@ -274,15 +274,16 @@ update_rhs_bc ( ncomp_t ncomp,
     for(std::size_t idof = 0; idof < ndof; idof++)
       riemannDeriv[3*nmat+idof][el] += wt * fl[ncomp+nmat] * B_l[idof];
 
-        // Gradient of u*g
+    // Gradient of u*g``
     for (std::size_t k=0; k<nmat; ++k)
       if (solidx[k] > 0)
       {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-            for (std::size_t idir=0; idir<3; ++idir)
-              riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][el] +=
-                wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+idir] * fn[idir];
+	    for (std::size_t l=0; l<3; ++l)
+	      for (std::size_t idir=0; idir<3; ++idir)
+		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
+		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
       }
   }
 }

--- a/src/PDE/Integrate/Boundary.cpp
+++ b/src/PDE/Integrate/Boundary.cpp
@@ -280,10 +280,10 @@ update_rhs_bc ( ncomp_t ncomp,
       {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-	    for (std::size_t l=0; l<3; ++l)
-	      for (std::size_t idir=0; idir<3; ++idir)
-		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
-		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+            for (std::size_t l=0; l<3; ++l)
+              for (std::size_t idir=0; idir<3; ++idir)
+                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
+                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
       }
   }
 }
@@ -408,7 +408,7 @@ bndSurfIntFV( ncomp_t system,
         {
           R(el, c) -= geoFace(f,0) * fl[c];
         }
-      
+
         // Prep for non-conservative terms in multimat
         if (fl.size() > ncomp)
         {
@@ -419,7 +419,7 @@ bndSurfIntFV( ncomp_t system,
               riemannDeriv[3*k+idir][el] += geoFace(f,0) * fl[ncomp+k]
               * fn[idir];
           }
-      
+
           // Divergence of velocity
           riemannDeriv[3*nmat][el] += geoFace(f,0) * fl[ncomp+nmat];
         }

--- a/src/PDE/Integrate/MultiMatTerms.cpp
+++ b/src/PDE/Integrate/MultiMatTerms.cpp
@@ -237,7 +237,7 @@ nonConservativeInt( [[maybe_unused]] ncomp_t system,
                 {
                   ncf[deformIdx(nmat,solidx[k],i,j)][idof] +=
                   state[volfracIdx(nmat, k)]*
-                    riemannDeriv[3*2*nmat+ndof+3*9*k+3*(3*i+j)+idir][e];
+                    riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][e];
                 }
               }
         }

--- a/src/PDE/Integrate/MultiMatTerms.cpp
+++ b/src/PDE/Integrate/MultiMatTerms.cpp
@@ -313,11 +313,12 @@ updateRhsNonCons(
           wt * ncf[volfracIdx(nmat,k)][idof];
         R(e, energyDofIdx(nmat,k,ndof,idof)) +=
           wt * ncf[energyIdx(nmat,k)][idof] * B[idof];
-	if (solidx[k] > 0)
-	  for(std::size_t i=0; i<3; ++i)
-	    for(std::size_t j=0; j<3; ++j)
-	      R(e, deformDofIdx(nmat,solidx[k],i,j,ndof,idof)) +=
-		wt * ncf[deformIdx(nmat,solidx[k],i,j)][idof] * B[idof];
+        if (solidx[k] > 0) {
+          for(std::size_t i=0; i<3; ++i)
+            for(std::size_t j=0; j<3; ++j)
+              R(e, deformDofIdx(nmat,solidx[k],i,j,ndof,idof)) +=
+              wt * ncf[deformIdx(nmat,solidx[k],i,j)][idof] * B[idof];
+        }
       }
     }
   }

--- a/src/PDE/Integrate/MultiMatTerms.cpp
+++ b/src/PDE/Integrate/MultiMatTerms.cpp
@@ -233,13 +233,13 @@ nonConservativeInt( [[maybe_unused]] ncomp_t system,
               for(std::size_t idof=0; idof<ndof; ++idof)
               {
                 ncf[deformIdx(nmat,solidx[k],i,j)][idof] = 0.0;
-		for (std::size_t l=0; l<3; ++l)
-		{
-		  ncf[deformIdx(nmat,solidx[k],i,j)][idof] +=
-		    state[volfracIdx(nmat, k)]*(
-		    riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+l][e]
-		   -riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+l)+3*l+j][e]);
-		  }
+                for (std::size_t l=0; l<3; ++l)
+                {
+                  ncf[deformIdx(nmat,solidx[k],i,j)][idof] +=
+                    state[volfracIdx(nmat, k)]*(
+                    riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+l][e]
+                   -riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+l)+3*l+j][e]);
+                  }
               }
         }
       }

--- a/src/PDE/Integrate/MultiMatTerms.cpp
+++ b/src/PDE/Integrate/MultiMatTerms.cpp
@@ -233,12 +233,13 @@ nonConservativeInt( [[maybe_unused]] ncomp_t system,
               for(std::size_t idof=0; idof<ndof; ++idof)
               {
                 ncf[deformIdx(nmat,solidx[k],i,j)][idof] = 0.0;
-                for (std::size_t idir=0; idir<3; ++idir)
-                {
-                  ncf[deformIdx(nmat,solidx[k],i,j)][idof] +=
-                  state[volfracIdx(nmat, k)]*
-                    riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][e];
-                }
+		for (std::size_t l=0; l<3; ++l)
+		{
+		  ncf[deformIdx(nmat,solidx[k],i,j)][idof] +=
+		    state[volfracIdx(nmat, k)]*(
+		    riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+l][e]
+		   -riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+l)+3*l+j][e]);
+		  }
               }
         }
       }

--- a/src/PDE/Integrate/MultiMatTerms.hpp
+++ b/src/PDE/Integrate/MultiMatTerms.hpp
@@ -21,6 +21,7 @@
 #include "Fields.hpp"
 #include "UnsMesh.hpp"
 #include "EoS/EOS.hpp"
+#include "MultiMat/MiscMultiMatFns.hpp"
 
 namespace tk {
 
@@ -142,6 +143,7 @@ std::vector< std::array< tk::real, 3 > >
 fluxTerms(
   std::size_t ncomp,
   std::size_t nmat,
+  const std::vector< inciter::EOS >& mat_blk,
   const std::vector< tk::real >& ugp );
 } // tk::
 

--- a/src/PDE/Integrate/SolidTerms.cpp
+++ b/src/PDE/Integrate/SolidTerms.cpp
@@ -176,7 +176,7 @@ solidTermsVolInt( ncomp_t system,
               for (std::size_t idof=0; idof<ndof; ++idof)
               {
                 for (std::size_t l=0; l<deriv.size(); ++l)
-		  deriv[l] = 0.0;
+                  deriv[l] = 0.0;
                 for (std::size_t jdof=0; jdof<rdof; ++jdof)
                 {
                   // Find indeces for all unknowns used
@@ -199,7 +199,7 @@ solidTermsVolInt( ncomp_t system,
                                   -v[(j+2)%3]*(deriv[2]-deriv[3]))
                   + D*((alpha*dBdx[(j+1)%3][idof]+B[idof]*deriv[4])
                        *(deriv[0]-deriv[1])
-		      -(alpha*dBdx[(j+2)%3][idof]+B[idof]*deriv[5])
+                      -(alpha*dBdx[(j+2)%3][idof]+B[idof]*deriv[5])
                        *(deriv[2]-deriv[3]));
               }
 

--- a/src/PDE/Integrate/SolidTerms.cpp
+++ b/src/PDE/Integrate/SolidTerms.cpp
@@ -165,7 +165,7 @@ solidTermsVolInt( ncomp_t system,
           tk::real rho0;
           if (k==0) rho0 = 8900.0;
           else rho0 = 2700.0;
-          tk::real rfact = 0.0; //eta*(rho/(rho0*tk::determinant(g))-1.0);
+          tk::real rfact = eta*(rho/(rho0*tk::determinant(g))-1.0);
 
           // Compute the source terms
           std::vector< real > s(9*ndof, 0.0);

--- a/src/PDE/Integrate/SolidTerms.cpp
+++ b/src/PDE/Integrate/SolidTerms.cpp
@@ -175,7 +175,8 @@ solidTermsVolInt( ncomp_t system,
             for (std::size_t j=0; j<3; ++j)
               for (std::size_t idof=0; idof<ndof; ++idof)
               {
-                for (std::size_t l=0; l<deriv.size(); ++l) deriv[l] = 0.0;
+                for (std::size_t l=0; l<deriv.size(); ++l)
+		  deriv[l] = 0.0;
                 for (std::size_t jdof=0; jdof<rdof; ++jdof)
                 {
                   // Find indeces for all unknowns used
@@ -211,9 +212,9 @@ solidTermsVolInt( ncomp_t system,
                   + D*((alpha*dBdx[(j+1)%3][idof]+B[idof]*deriv[4])
                        *(deriv[0]-deriv[1])
 		      -(alpha*dBdx[(j+2)%3][idof]+B[idof]*deriv[5])
-                       *(deriv[2]-deriv[3]))
-                  - alpha*(v[0]*deriv[6]+v[1]*deriv[7]+v[2]*deriv[8]
-                        +g[i][0]*deriv[9]+g[i][1]*deriv[10]+g[i][2]*deriv[11]);
+                       *(deriv[2]-deriv[3]));
+                  //- alpha*(v[0]*deriv[6]+v[1]*deriv[7]+v[2]*deriv[8]
+                  //      +g[i][0]*deriv[9]+g[i][1]*deriv[10]+g[i][2]*deriv[11]);
               }
 
         auto wt = wgp[igp] * geoElem(e, 0);

--- a/src/PDE/Integrate/SolidTerms.cpp
+++ b/src/PDE/Integrate/SolidTerms.cpp
@@ -169,8 +169,8 @@ solidTermsVolInt( ncomp_t system,
 
           // Compute the source terms
           std::vector< real > s(9*ndof, 0.0);
-          std::vector< real > deriv(12, 0.0);
-          std::vector< std::size_t > defIdx(12, 0);
+          std::vector< real > deriv(6, 0.0);
+          std::vector< std::size_t > defIdx(6, 0);
           for (std::size_t i=0; i<3; ++i)
             for (std::size_t j=0; j<3; ++j)
               for (std::size_t idof=0; idof<ndof; ++idof)
@@ -186,12 +186,6 @@ solidTermsVolInt( ncomp_t system,
                   defIdx[3]  = deformDofIdx(nmat,solidx[k],i,(j+2)%3,rdof,jdof);
                   defIdx[4]  = volfracDofIdx(nmat,k,rdof,jdof);
                   defIdx[5]  = volfracDofIdx(nmat,k,rdof,jdof);
-                  defIdx[6]  = deformDofIdx(nmat,solidx[k],i,0,rdof,jdof);
-                  defIdx[7]  = deformDofIdx(nmat,solidx[k],i,1,rdof,jdof);
-                  defIdx[8]  = deformDofIdx(nmat,solidx[k],i,2,rdof,jdof);
-                  defIdx[9]  = velocityDofIdx(nmat,0,rdof,jdof);
-                  defIdx[10] = velocityDofIdx(nmat,1,rdof,jdof);
-                  defIdx[11] = velocityDofIdx(nmat,2,rdof,jdof);
                   // Compute derivatives
                   deriv[0]  += U(e,defIdx[0]) *dBdx[      j][jdof];
                   deriv[1]  += U(e,defIdx[1]) *dBdx[(j+1)%3][jdof];
@@ -199,12 +193,6 @@ solidTermsVolInt( ncomp_t system,
                   deriv[3]  += U(e,defIdx[3]) *dBdx[      j][jdof];
                   deriv[4]  += U(e,defIdx[4]) *dBdx[(j+1)%3][jdof];
                   deriv[5]  += U(e,defIdx[5]) *dBdx[(j+2)%3][jdof];
-                  deriv[6]  += U(e,defIdx[6]) *dBdx[      j][jdof];
-                  deriv[7]  += U(e,defIdx[7]) *dBdx[      j][jdof];
-                  deriv[8]  += U(e,defIdx[8]) *dBdx[      j][jdof];
-                  deriv[9]  += U(e,defIdx[9]) *dBdx[      j][jdof];
-                  deriv[10] += U(e,defIdx[10])*dBdx[      j][jdof];
-                  deriv[11] += U(e,defIdx[11])*dBdx[      j][jdof];
                 }
                 s[(i*3+j)*ndof+idof] = B[idof]*rfact*alpha*g[i][j]
                   + alpha*B[idof]*(v[(j+1)%3]*(deriv[0]-deriv[1])
@@ -213,8 +201,6 @@ solidTermsVolInt( ncomp_t system,
                        *(deriv[0]-deriv[1])
 		      -(alpha*dBdx[(j+2)%3][idof]+B[idof]*deriv[5])
                        *(deriv[2]-deriv[3]));
-                  //- alpha*(v[0]*deriv[6]+v[1]*deriv[7]+v[2]*deriv[8]
-                  //      +g[i][0]*deriv[9]+g[i][1]*deriv[10]+g[i][2]*deriv[11]);
               }
 
         auto wt = wgp[igp] * geoElem(e, 0);

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -274,6 +274,9 @@ update_rhs_fa( ncomp_t ncomp,
   //Assert( B_l.size() == ndof_l, "Size mismatch" );
   //Assert( B_r.size() == ndof_r, "Size mismatch" );
 
+  const auto& solidx = inciter::g_inputdeck.get< tag::param, tag::multimat,
+    tag::matidxmap >().template get< tag::solidx >();
+
   for (ncomp_t c=0; c<ncomp; ++c)
   {
     auto mark = c*ndof;
@@ -333,6 +336,21 @@ update_rhs_fa( ncomp_t ncomp,
       riemannDeriv[3*nmat+idof][el] += wt * fl[ncomp+nmat] * B_l[idof];
       riemannDeriv[3*nmat+idof][er] -= wt * fl[ncomp+nmat] * B_r[idof];
     }
+
+    // Gradient of u*g
+    for (std::size_t k=0; k<nmat; ++k)
+      if (solidx[k] > 0)
+      {
+        for (std::size_t i=0; i<3; ++i)
+          for (std::size_t j=0; j<3; ++j)
+            for (std::size_t idir=0; idir<3; ++idir)
+            {
+              riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][el] +=
+                    wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+idir] * fn[idir];
+              riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][er] -=
+                    wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+idir] * fn[idir];
+            }
+      }
   }
 }
 

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -222,10 +222,10 @@ surfInt( ncomp_t system,
       // compute flux
       auto fl = flux( mat_blk, fn, state, v );
 
-      // Add RHS inverse deformation terms if necessary
-      if (haveSolid)
-        solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
-                           coordel_l, coordel_r, igp, coordgp, dt, fl );
+      // // Add RHS inverse deformation terms if necessary
+      // if (haveSolid)
+      //   solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
+      //                      coordel_l, coordel_r, igp, coordgp, dt, fl );
 
       // Add the surface integration term to the rhs
       update_rhs_fa( ncomp, nmat, ndof, ndofel[el], ndofel[er], wt, fn,
@@ -273,6 +273,8 @@ update_rhs_fa( ncomp_t ncomp,
   // following lines commented until rdofel is made available.
   //Assert( B_l.size() == ndof_l, "Size mismatch" );
   //Assert( B_r.size() == ndof_r, "Size mismatch" );
+
+  using inciter::newSolidsAccFn;
 
   const auto& solidx = inciter::g_inputdeck.get< tag::param, tag::multimat,
     tag::matidxmap >().template get< tag::solidx >();
@@ -346,10 +348,10 @@ update_rhs_fa( ncomp_t ncomp,
             for (std::size_t l=0; l<3; ++l)
               for (std::size_t idir=0; idir<3; ++idir)
               {
-                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
-                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
-                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][er] -=
-                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+                riemannDeriv[3*nmat+ndof+3*newSolidsAccFn(k,i,j,l)+idir][el] +=
+                  wt * fl[ncomp+nmat+1+newSolidsAccFn(k,i,j,l)] * fn[idir];
+                riemannDeriv[3*nmat+ndof+3*newSolidsAccFn(k,i,j,l)+idir][er] -=
+                  wt * fl[ncomp+nmat+1+newSolidsAccFn(k,i,j,l)] * fn[idir];
             }
       }
   }

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -222,10 +222,10 @@ surfInt( ncomp_t system,
       // compute flux
       auto fl = flux( mat_blk, fn, state, v );
 
-      // // Add RHS inverse deformation terms if necessary
-      // if (haveSolid)
-      //   solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
-      //                      coordel_l, coordel_r, igp, coordgp, dt, fl );
+      // Add RHS inverse deformation terms if necessary
+      if (haveSolid)
+        solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
+                           coordel_l, coordel_r, igp, coordgp, dt, fl );
 
       // Add the surface integration term to the rhs
       update_rhs_fa( ncomp, nmat, ndof, ndofel[el], ndofel[er], wt, fn,

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -343,12 +343,13 @@ update_rhs_fa( ncomp_t ncomp,
       {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-            for (std::size_t idir=0; idir<3; ++idir)
-            {
-              riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][el] +=
-                    wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+idir] * fn[idir];
-              riemannDeriv[3*nmat+ndof+3*9*k+3*(3*i+j)+idir][er] -=
-                    wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+idir] * fn[idir];
+	    for (std::size_t l=0; l<3; ++l)
+	      for (std::size_t idir=0; idir<3; ++idir)
+	      {
+		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
+		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][er] -=
+		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
             }
       }
   }

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -47,7 +47,7 @@ surfInt( ncomp_t system,
          const Fields& U,
          const Fields& P,
          const std::vector< std::size_t >& ndofel,
-         const tk::real dt,
+         const tk::real /*dt*/,
          Fields& R,
          std::vector< std::vector< tk::real > >&,
          std::vector< std::vector< tk::real > >&,
@@ -72,7 +72,7 @@ surfInt( ncomp_t system,
 //! \param[in] U Solution vector at recent time step
 //! \param[in] P Vector of primitives at recent time step
 //! \param[in] ndofel Vector of local number of degrees of freedom
-//! \param[in] dt Delta time
+// //! \param[in] dt Delta time
 //! \param[in,out] R Right-hand side vector computed
 //! \param[in,out] vriem Vector of the riemann velocity
 //! \param[in,out] riemannLoc Vector of coordinates where Riemann velocity data
@@ -95,8 +95,8 @@ surfInt( ncomp_t system,
   auto ncomp = U.nprop()/rdof;
   auto nprim = P.nprop()/rdof;
 
-  // Determine if we have solids in our problem
-  bool haveSolid = inciter::haveSolid(nmat, solidx);
+  //// Determine if we have solids in our problem
+  //bool haveSolid = inciter::haveSolid(nmat, solidx);
 
   //Assert( (nmat==1 ? riemannDeriv.empty() : true), "Non-empty Riemann "
   //        "derivative vector for single material compflow" );

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -222,6 +222,8 @@ surfInt( ncomp_t system,
       // compute flux
       auto fl = flux( mat_blk, fn, state, v );
 
+      // Code below commented until details about the form of these terms in the
+      // \alpha_k g_k equations are sorted out.
       // // Add RHS inverse deformation terms if necessary
       // if (haveSolid)
       //   solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -222,10 +222,10 @@ surfInt( ncomp_t system,
       // compute flux
       auto fl = flux( mat_blk, fn, state, v );
 
-      // Add RHS inverse deformation terms if necessary
-      if (haveSolid)
-        solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
-                           coordel_l, coordel_r, igp, coordgp, dt, fl );
+      // // Add RHS inverse deformation terms if necessary
+      // if (haveSolid)
+      //   solidTermsSurfInt( nmat, ndof, rdof, fn, el, er, solidx, geoElem, U,
+      //                      coordel_l, coordel_r, igp, coordgp, dt, fl );
 
       // Add the surface integration term to the rhs
       update_rhs_fa( ncomp, nmat, ndof, ndofel[el], ndofel[er], wt, fn,

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -343,13 +343,13 @@ update_rhs_fa( ncomp_t ncomp,
       {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-	    for (std::size_t l=0; l<3; ++l)
-	      for (std::size_t idir=0; idir<3; ++idir)
-	      {
-		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
-		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
-		riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][er] -=
-		  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+            for (std::size_t l=0; l<3; ++l)
+              for (std::size_t idir=0; idir<3; ++idir)
+              {
+                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][el] +=
+                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
+                riemannDeriv[3*nmat+ndof+3*3*9*k+3*3*(3*i+j)+3*l+idir][er] -=
+                  wt * fl[ncomp+nmat+1+9*3*k+3*(3*i+j)+l] * fn[idir];
             }
       }
   }

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -37,7 +37,7 @@ surfInt( ncomp_t system,
          const std::size_t ndof,
          const std::size_t rdof,
          const std::vector< std::size_t >& inpoel,
-         const std::vector< std::size_t >& solidx,
+         const std::vector< std::size_t >& /*solidx*/,
          const UnsMesh::Coords& coord,
          const inciter::FaceData& fd,
          const Fields& geoFace,
@@ -62,7 +62,7 @@ surfInt( ncomp_t system,
 //! \param[in] ndof Maximum number of degrees of freedom
 //! \param[in] rdof Maximum number of reconstructed degrees of freedom
 //! \param[in] inpoel Element-node connectivity
-//! \param[in] solidx Material index indicator
+// //! \param[in] solidx Material index indicator
 //! \param[in] coord Array of nodal coordinates
 //! \param[in] fd Face connectivity and boundary conditions object
 //! \param[in] geoFace Face geometry array

--- a/src/PDE/Limiter.cpp
+++ b/src/PDE/Limiter.cpp
@@ -1567,7 +1567,7 @@ void consistentMultiMatLimiting_P1(
             auto gij = U(e,deformDofIdx(nmat,solidx[k],i,j,rdof,0)) / alk;
             for (std::size_t idof=1; idof<rdof; ++idof)
               U(e,deformDofIdx(nmat,solidx[k],i,j,rdof,idof)) = gij *
-		U(e,volfracDofIdx(nmat,k,rdof,idof));
+                U(e,volfracDofIdx(nmat,k,rdof,idof));
           }
     }
 
@@ -2320,14 +2320,16 @@ void MarkShockCells ( const std::size_t nelem,
 
       // Force deformation unknown to first order
       for (std::size_t k=0; k<nmat; ++k)
-	if (solidx[k] > 0)
-	  for (std::size_t i=0; i<3; ++i)
-	    for (std::size_t j=0; j<3; ++j)
-	    {
-	      state[0][deformIdx(nmat, solidx[k], i, j)] = U(el,deformDofIdx(nmat, solidx[k], i, j, rdof, 0));
-	      state[1][deformIdx(nmat, solidx[k], i, j)] = U(er,deformDofIdx(nmat, solidx[k], i, j, rdof, 0));
+        if (solidx[k] > 0)
+          for (std::size_t i=0; i<3; ++i)
+            for (std::size_t j=0; j<3; ++j)
+            {
+              state[0][deformIdx(nmat, solidx[k], i, j)] = U(el,deformDofIdx(
+                nmat, solidx[k], i, j, rdof, 0));
+              state[1][deformIdx(nmat, solidx[k], i, j)] = U(er,deformDofIdx(
+                nmat, solidx[k], i, j, rdof, 0));
             }
-      
+
       // Evaluate the flux
       auto fl = flux( system, ncomp, mat_blk, state[0], {} );
       auto fr = flux( system, ncomp, mat_blk, state[1], {} );

--- a/src/PDE/Limiter.cpp
+++ b/src/PDE/Limiter.cpp
@@ -2437,6 +2437,20 @@ correctLimConservMultiMat(
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
             gmat[i][j] /= alphamat;
+	// printf("alpha  = %e \n", alphamat);
+	// printf("g11 = %e \n", gmat[0][0]);
+	// printf("g12 = %e \n", gmat[0][1]);
+	// printf("g13 = %e \n", gmat[0][2]);
+	// printf("g21 = %e \n", gmat[1][0]);
+	// printf("g22 = %e \n", gmat[1][1]);
+	// printf("g23 = %e \n", gmat[1][2]);
+	// printf("g31 = %e \n", gmat[2][0]);
+	// printf("g32 = %e \n", gmat[2][1]);
+	// printf("g33 = %e \n", gmat[2][2]);
+	// printf("u = %e \n", vel[0]);
+	// printf("v = %e \n", vel[1]);
+	// printf("w = %e \n", vel[2]);
+	// printf("rho %e \n", rhomat);
         s[imat] = alphamat * mat_blk[imat].compute< EOS::totalenergy >( rhomat,
           vel[0], vel[1], vel[2], premat, gmat );
       }

--- a/src/PDE/Limiter.cpp
+++ b/src/PDE/Limiter.cpp
@@ -2437,20 +2437,6 @@ correctLimConservMultiMat(
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
             gmat[i][j] /= alphamat;
-	// printf("alpha  = %e \n", alphamat);
-	// printf("g11 = %e \n", gmat[0][0]);
-	// printf("g12 = %e \n", gmat[0][1]);
-	// printf("g13 = %e \n", gmat[0][2]);
-	// printf("g21 = %e \n", gmat[1][0]);
-	// printf("g22 = %e \n", gmat[1][1]);
-	// printf("g23 = %e \n", gmat[1][2]);
-	// printf("g31 = %e \n", gmat[2][0]);
-	// printf("g32 = %e \n", gmat[2][1]);
-	// printf("g33 = %e \n", gmat[2][2]);
-	// printf("u = %e \n", vel[0]);
-	// printf("v = %e \n", vel[1]);
-	// printf("w = %e \n", vel[2]);
-	// printf("rho %e \n", rhomat);
         s[imat] = alphamat * mat_blk[imat].compute< EOS::totalenergy >( rhomat,
           vel[0], vel[1], vel[2], premat, gmat );
       }

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -222,9 +222,6 @@ class MultiMat {
                 for (std::size_t c=0; c<m_ncomp; ++c) {
                   auto mark = c*rdof;
                   unk(e,mark) = s[c];
-		  // set high-order DOFs to zero
-		  for (std::size_t i=1; i<rdof; ++i)
-		    unk(e,mark+i) = 0.0;
                 }
               }
             }
@@ -280,12 +277,13 @@ class MultiMat {
                 unk(e, densityDofIdx(nmat,k,rdof,i)) = 0.0;
                 unk(e, energyDofIdx(nmat,k,rdof,i)) = 0.0;
               }
-	      if (solidx[k] > 0)
-		for (std::size_t i=0; i<3; ++i)
-		  for (std::size_t j=0; j<3; ++j)
-		    for (std::size_t idof=1; idof<rdof; ++idof){
-		      unk(e, deformDofIdx(nmat,k,i,j,rdof,idof)) = 0.0;
-		}
+              if (solidx[k] > 0) {
+                for (std::size_t i=0; i<3; ++i)
+                  for (std::size_t j=0; j<3; ++j)
+                    for (std::size_t idof=1; idof<rdof; ++idof) {
+                      unk(e, deformDofIdx(nmat,k,i,j,rdof,idof)) = 0.0;
+		                }
+              }
             }
           }
           for (std::size_t idir=0; idir<3; ++idir) {
@@ -771,6 +769,8 @@ class MultiMat {
                               inpoel, coord, geoElem, U, P, riemannDeriv,
                               ndofel, R, intsharp );
 
+      // Code below commented until details about the form of these terms in the
+      // \alpha_k g_k equations are sorted out.
       // // Compute integrals for inverse deformation in solid materials
       // if (inciter::haveSolid(nmat, solidx))
       //   tk::solidTermsVolInt( m_system, nmat, m_mat_blk, ndof, rdof, nelem,

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -709,7 +709,7 @@ class MultiMat {
       // to derivatives of Riemann velocity times basis function in the volume
       // fraction equation.
       std::vector< std::vector< tk::real > >
-        riemannDeriv( (3+3*9)*nmat+ndof, std::vector<tk::real>(U.nunk(),0.0) );
+        riemannDeriv((3+3*3*9)*nmat+ndof, std::vector<tk::real>(U.nunk(),0.0));
 
       // vectors to store the data of riemann velocity used for reconstruction
       // in volume fraction equation
@@ -743,7 +743,7 @@ class MultiMat {
                         m_riemann, velfn, b.second, U, P, ndofel, R, vriem,
                         riemannLoc, riemannDeriv, intsharp );
 
-      Assert( riemannDeriv.size() == (3+3*9)*nmat+ndof, "Size of Riemann "
+      Assert( riemannDeriv.size() == (3+3*3*9)*nmat+ndof, "Size of Riemann "
               "derivative vector incorrect" );
 
       // get derivatives from riemannDeriv

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -760,10 +760,10 @@ class MultiMat {
                               inpoel, coord, geoElem, U, P, riemannDeriv,
                               ndofel, R, intsharp );
 
-      // // Compute integrals for inverse deformation in solid materials
-      // if (inciter::haveSolid(nmat, solidx))
-      //   tk::solidTermsVolInt( m_system, nmat, m_mat_blk, ndof, rdof, nelem,
-      //                         inpoel, coord, geoElem, U, P, ndofel, dt, R);
+      // Compute integrals for inverse deformation in solid materials
+      if (inciter::haveSolid(nmat, solidx))
+        tk::solidTermsVolInt( m_system, nmat, m_mat_blk, ndof, rdof, nelem,
+                              inpoel, coord, geoElem, U, P, ndofel, dt, R);
 
       // compute finite pressure relaxation terms
       if (g_inputdeck.get< tag::param, tag::multimat, tag::prelax >()[m_system])

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -282,7 +282,7 @@ class MultiMat {
                   for (std::size_t j=0; j<3; ++j)
                     for (std::size_t idof=1; idof<rdof; ++idof) {
                       unk(e, deformDofIdx(nmat,k,i,j,rdof,idof)) = 0.0;
-		                }
+                    }
               }
             }
           }

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -760,10 +760,10 @@ class MultiMat {
                               inpoel, coord, geoElem, U, P, riemannDeriv,
                               ndofel, R, intsharp );
 
-      // Compute integrals for inverse deformation in solid materials
-      if (inciter::haveSolid(nmat, solidx))
-        tk::solidTermsVolInt( m_system, nmat, m_mat_blk, ndof, rdof, nelem,
-                              inpoel, coord, geoElem, U, P, ndofel, dt, R);
+      // // Compute integrals for inverse deformation in solid materials
+      // if (inciter::haveSolid(nmat, solidx))
+      //   tk::solidTermsVolInt( m_system, nmat, m_mat_blk, ndof, rdof, nelem,
+      //                         inpoel, coord, geoElem, U, P, ndofel, dt, R);
 
       // compute finite pressure relaxation terms
       if (g_inputdeck.get< tag::param, tag::multimat, tag::prelax >()[m_system])

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -709,7 +709,7 @@ class MultiMat {
       // to derivatives of Riemann velocity times basis function in the volume
       // fraction equation.
       std::vector< std::vector< tk::real > >
-        riemannDeriv( 3*nmat+ndof, std::vector<tk::real>(U.nunk(),0.0) );
+        riemannDeriv( (3+3*9)*nmat+ndof, std::vector<tk::real>(U.nunk(),0.0) );
 
       // vectors to store the data of riemann velocity used for reconstruction
       // in volume fraction equation
@@ -743,8 +743,8 @@ class MultiMat {
                         m_riemann, velfn, b.second, U, P, ndofel, R, vriem,
                         riemannLoc, riemannDeriv, intsharp );
 
-      Assert( riemannDeriv.size() == 3*nmat+ndof, "Size of Riemann derivative "
-              "vector incorrect" );
+      Assert( riemannDeriv.size() == (3+3*9)*nmat+ndof, "Size of Riemann "
+              "derivative vector incorrect" );
 
       // get derivatives from riemannDeriv
       for (std::size_t k=0; k<riemannDeriv.size(); ++k)
@@ -1053,14 +1053,14 @@ class MultiMat {
     static tk::FluxFn::result_type
     flux( ncomp_t system,
           [[maybe_unused]] ncomp_t ncomp,
-          const std::vector< EOS >&,
+          const std::vector< EOS >& mat_blk,
           const std::vector< tk::real >& ugp,
           const std::vector< std::array< tk::real, 3 > >& )
     {
       const auto nmat =
         g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[system];
 
-      return tk::fluxTerms(ncomp, nmat, ugp);
+      return tk::fluxTerms(ncomp, nmat, mat_blk, ugp);
     }
 
     //! \brief Boundary state function providing the left and right state of a

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -796,14 +796,14 @@ class MultiMat {
     static tk::FluxFn::result_type
     flux( ncomp_t system,
           [[maybe_unused]] ncomp_t ncomp,
-          const std::vector< EOS >&,
+          const std::vector< EOS >& mat_blk,
           const std::vector< tk::real >& ugp,
           const std::vector< std::array< tk::real, 3 > >& )
     {
       const auto nmat =
         g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[system];
 
-      return tk::fluxTerms(ncomp, nmat, ugp);
+      return tk::fluxTerms(ncomp, nmat, mat_blk, ugp);
     }
 
     //! \brief Boundary state function providing the left and right state of a

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -407,10 +407,10 @@ timeStepSizeMultiMat(
     {
       if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
         auto gk = getDeformGrad(nmat, k, ugp);
-        gk = tk::rotateTensor(gk, fn);
         auto sk = mat_blk[k].computeTensor< EOS::CauchyStress >(
           ugp[densityIdx(nmat, k)], u, v, w, ugp[energyIdx(nmat, k)],
           ugp[volfracIdx(nmat, k)], k, gk );
+        gk = tk::rotateTensor(gk, fn);
         tk::real snn = tk::dot(tk::matvec(sk, fn), fn);
         a = std::max( a, mat_blk[k].compute< EOS::soundspeed >(
           ugp[densityIdx(nmat, k)],

--- a/src/PDE/MultiMat/MultiMatIndexing.hpp
+++ b/src/PDE/MultiMat/MultiMatIndexing.hpp
@@ -178,6 +178,21 @@ inline std::size_t pressureDofIdx( std::size_t nmat, std::size_t kmat,
 inline bool matExists( tk::real volfrac )
 { return (volfrac > 1e-10) ? true : false; }
 
+//! \brief Get the index of the quantity vel[l]*g[i][j] computed inside the
+//!   Riemann flux solver.
+//! \param[in] nmat Number of materials
+//! \param[in] kmat Index of required material
+//! \param[in] i Row of inverse deformation tensor
+//! \param[in] j Column of inverse deformation tensor
+//! \param[in] l Velocity component
+//! \return Index of the quantity vel[l]*g[i][j] computed inside the
+//!   Riemann flux solver.
+//! \details This function is used to get the index of the quantity
+//!   vel[l]*g[i][j] computed inside the Riemann flux solver.
+inline std::size_t newSolidsAccFn( std::size_t kmat,
+  std::size_t i, std::size_t j, std::size_t l)
+{ return 3*9*kmat+3*(3*i+j)+l; }
+
 //@}
 
 } //inciter::

--- a/src/PDE/MultiMat/MultiMatIndexing.hpp
+++ b/src/PDE/MultiMat/MultiMatIndexing.hpp
@@ -180,7 +180,6 @@ inline bool matExists( tk::real volfrac )
 
 //! \brief Get the index of the quantity vel[l]*g[i][j] computed inside the
 //!   Riemann flux solver.
-//! \param[in] nmat Number of materials
 //! \param[in] kmat Index of required material
 //! \param[in] i Row of inverse deformation tensor
 //! \param[in] j Column of inverse deformation tensor

--- a/src/PDE/MultiMat/Problem/BoxInitialization.hpp
+++ b/src/PDE/MultiMat/Problem/BoxInitialization.hpp
@@ -186,7 +186,7 @@ void initializeBox( std::size_t system,
         }
       }
       else {
-	gk = {{}};
+        gk = {{}};
       }
       s[energyIdx(nmat,k)] = s[volfracIdx(nmat,k)] *
         mat_blk[k].compute< EOS::totalenergy >( rhok[k], u, v, w, pr, gk );

--- a/src/PDE/MultiMat/Problem/BoxInitialization.hpp
+++ b/src/PDE/MultiMat/Problem/BoxInitialization.hpp
@@ -58,6 +58,9 @@ void initializeBox( std::size_t system,
   auto nmat =
     g_inputdeck.get< tag::param, tag::multimat, tag::nmat >()[system];
 
+  const auto& solidx = g_inputdeck.get< tag::param, tag::multimat,
+    tag::matidxmap >().template get< tag::solidx >();
+  
   const auto& initiate = b.template get< tag::initiate >();
   auto inittype = initiate.template get< tag::init >();
 
@@ -171,10 +174,20 @@ void initializeBox( std::size_t system,
       s[energyIdx(nmat,k)] = s[volfracIdx(nmat,k)] * rhok[k] * spi;
     }
     else {
-      // although the following function returns alpha_k * g_k, since box-init
-      // only works with pure material region initialization (alpha_k=1), the
-      // result is equivalent to g_k
-      auto gk = getDeformGrad(nmat, k, s);
+      // TEMP: Eventually we would need to initialize gk from control file
+      std::array< std::array< tk::real, 3 >, 3 > gk;
+      if (solidx[k] > 0) {
+        for (std::size_t i=0; i<3; ++i) {
+          for (std::size_t j=0; j<3; ++j) {
+            if (i==j) gk[i][j] = 1.0;
+            else gk[i][j] = 0.0;
+            s[deformIdx(nmat,solidx[k],i,j)] = s[volfracIdx(nmat,k)]*gk[i][j];
+          }
+        }
+      }
+      else {
+	gk = {{}};
+      }
       s[energyIdx(nmat,k)] = s[volfracIdx(nmat,k)] *
         mat_blk[k].compute< EOS::totalenergy >( rhok[k], u, v, w, pr, gk );
     }

--- a/src/PDE/MultiMat/Problem/BoxInitialization.hpp
+++ b/src/PDE/MultiMat/Problem/BoxInitialization.hpp
@@ -60,7 +60,7 @@ void initializeBox( std::size_t system,
 
   const auto& solidx = g_inputdeck.get< tag::param, tag::multimat,
     tag::matidxmap >().template get< tag::solidx >();
-  
+
   const auto& initiate = b.template get< tag::initiate >();
   auto inittype = initiate.template get< tag::init >();
 

--- a/src/PDE/Reconstruction.cpp
+++ b/src/PDE/Reconstruction.cpp
@@ -495,16 +495,20 @@ THINCReco( std::size_t system,
   using inciter::energyDofIdx;
   using inciter::pressureDofIdx;
   using inciter::velocityDofIdx;
+  using inciter::deformDofIdx;
   using inciter::volfracIdx;
   using inciter::densityIdx;
   using inciter::momentumIdx;
   using inciter::energyIdx;
   using inciter::pressureIdx;
   using inciter::velocityIdx;
+  using inciter::deformIdx;
 
   auto bparam = inciter::g_inputdeck.get< tag::param, tag::multimat,
     tag::intsharp_param >()[system];
   const auto ncomp = U.nprop()/rdof;
+  const auto& solidx = inciter::g_inputdeck.get< tag::param, tag::multimat,
+    tag::matidxmap >().template get< tag::solidx >();
 
   // interface detection
   std::vector< std::size_t > matInt(nmat, 0);
@@ -566,6 +570,11 @@ THINCReco( std::size_t system,
           * U(e, energyDofIdx(nmat,k,rdof,0))/alCC;
         state[ncomp+pressureIdx(nmat,k)] = alReco[k]
           * P(e, pressureDofIdx(nmat,k,rdof,0))/alCC;
+        if (solidx[k] > 0)
+          for (std::size_t i=0; i<3; ++i)
+            for (std::size_t j=0; j<3; ++j)
+              state[deformIdx(nmat,solidx[k],i,j)] = alReco[k]
+                * U(e, deformDofIdx(nmat,solidx[k],i,j,rdof,0))/alCC;
       }
 
       rhobCC += U(e, densityDofIdx(nmat,k,rdof,0));

--- a/src/PDE/Riemann/LaxFriedrichsSolids.hpp
+++ b/src/PDE/Riemann/LaxFriedrichsSolids.hpp
@@ -167,7 +167,7 @@ struct LaxFriedrichsSolids {
       if (solidx[k] > 0) {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-            fluxr[deformIdx(nmat,solidx[k],i,j)] = ag_l[k][i][j]*vnl;
+            fluxr[deformIdx(nmat,solidx[k],i,j)] = ag_r[k][i][j]*vnr;
       }
     }
 
@@ -199,7 +199,7 @@ struct LaxFriedrichsSolids {
     l_plus = l_plus/( std::fabs(vriem) + 1.0e-12 );
     l_minus = l_minus/( std::fabs(vriem) + 1.0e-12 );
 
-    // Store Riemann u*g (3*9=18)
+    // Store Riemann u*g (3*9=27)
     if (std::fabs(l_plus) > 1.0e-10)
     {
       for (std::size_t k=0; k<nmat; ++k)

--- a/src/PDE/Riemann/LaxFriedrichsSolids.hpp
+++ b/src/PDE/Riemann/LaxFriedrichsSolids.hpp
@@ -151,8 +151,7 @@ struct LaxFriedrichsSolids {
       if (solidx[k] > 0) {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-            fluxl[deformIdx(nmat,solidx[k],i,j)] =
-              (ul*ag_l[k][i][0] + vl*ag_l[k][i][1] + wl*ag_l[k][i][2]) * fn[j];
+            fluxl[deformIdx(nmat,solidx[k],i,j)] = ag_l[k][i][j]*vnl;
       }
 
       // Right fluxes
@@ -168,8 +167,7 @@ struct LaxFriedrichsSolids {
       if (solidx[k] > 0) {
         for (std::size_t i=0; i<3; ++i)
           for (std::size_t j=0; j<3; ++j)
-            fluxr[deformIdx(nmat,solidx[k],i,j)] =
-              (ur*ag_r[k][i][0] + vr*ag_r[k][i][1] + wr*ag_r[k][i][2]) * fn[j];
+            fluxr[deformIdx(nmat,solidx[k],i,j)] = ag_l[k][i][j]*vnl;
       }
     }
 
@@ -187,13 +185,60 @@ struct LaxFriedrichsSolids {
 
     // Store Riemann-advected partial pressures
     for (std::size_t k=0; k<nmat; ++k)
-      flx.push_back( 0.5*(pml[k] + pmr[k]) );
+      flx.push_back( 0.5*(pml[k]+pmr[k])
+                   + 0.5*(tk::dot(asign_l[k],fn)
+                         +tk::dot(asign_r[k],fn)));
 
     // Store Riemann velocity
     flx.push_back( vriem );
 
-    Assert( flx.size() == (ncomp+nmat+1), "Size of multi-material flux "
-            "vector incorrect" );
+        // Flux vector splitting
+    auto l_plus = 0.5 * (vriem + std::fabs(vriem));
+    auto l_minus = 0.5 * (vriem - std::fabs(vriem));
+
+    l_plus = l_plus/( std::fabs(vriem) + 1.0e-12 );
+    l_minus = l_minus/( std::fabs(vriem) + 1.0e-12 );
+
+    // Store Riemann u*g (3*9=18)
+    if (std::fabs(l_plus) > 1.0e-10)
+    {
+      for (std::size_t k=0; k<nmat; ++k)
+        for (std::size_t i=0; i<3; ++i)
+          for (std::size_t j=0; j<3; ++j)
+          {
+            flx.push_back( ul*ag_l[k][i][j]/al_l[k] );
+            flx.push_back( vl*ag_l[k][i][j]/al_l[k] );
+            flx.push_back( wl*ag_l[k][i][j]/al_l[k] );
+          }
+    }
+    else if (std::fabs(l_minus) > 1.0e-10)
+    {
+      for (std::size_t k=0; k<nmat; ++k)
+        for (std::size_t i=0; i<3; ++i)
+          for (std::size_t j=0; j<3; ++j)
+          {
+            flx.push_back( ur*ag_r[k][i][j]/al_r[k] );
+            flx.push_back( vr*ag_r[k][i][j]/al_r[k] );
+            flx.push_back( wr*ag_r[k][i][j]/al_r[k] );
+          }
+    }
+    else
+    {
+      for (std::size_t k=0; k<nmat; ++k)
+        for (std::size_t i=0; i<3; ++i)
+          for (std::size_t j=0; j<3; ++j)
+          {
+            flx.push_back( 0.5 * (ul*ag_l[k][i][j]/al_l[k]
+                                 +ur*ag_r[k][i][j]/al_r[k]) );
+            flx.push_back( 0.5 * (vl*ag_l[k][i][j]/al_l[k]
+                                 +vr*ag_r[k][i][j]/al_r[k]) );
+            flx.push_back( 0.5 * (wl*ag_l[k][i][j]/al_l[k]
+                                 +wr*ag_r[k][i][j]/al_r[k]) );
+          }
+    }
+
+    Assert( flx.size() == (ncomp+nmat+1+3*9*nmat), "Size of multi-material "
+            "flux vector incorrect" );
 
     return flx;
   }

--- a/src/PDE/Riemann/LaxFriedrichsSolids.hpp
+++ b/src/PDE/Riemann/LaxFriedrichsSolids.hpp
@@ -185,9 +185,8 @@ struct LaxFriedrichsSolids {
 
     // Store Riemann-advected partial pressures
     for (std::size_t k=0; k<nmat; ++k)
-      flx.push_back( 0.5*(pml[k]+pmr[k])
-                   + 0.5*(tk::dot(asign_l[k],fn)
-                         +tk::dot(asign_r[k],fn)));
+      flx.push_back( -0.5*(tk::dot(asign_l[k],fn)
+                          +tk::dot(asign_r[k],fn)));
 
     // Store Riemann velocity
     flx.push_back( vriem );


### PR DESCRIPTION
First iteration of fully multi-material implementation to run cases with solids and fluids. So far P0 runs of advection cases run well. Tested with case 5.1 of [1].

[1] Favrie, Nicolas, Sergey L. Gavrilyuk, and Richard Saurel. "Solid–fluid diffuse interface model in cases of extreme deformations." Journal of computational physics 228.16 (2009): 6037-6077.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/585)
<!-- Reviewable:end -->
