### PR TITLE
added volfrac to multimat history output

### DIFF
--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -639,7 +639,8 @@ class MultiMat {
     //! \param[in] U Array of unknowns
     //! \param[in] P Array of primitive quantities
     //! \return Vector of time history output of bulk flow quantities (density,
-    //!   velocity, total energy, and pressure) evaluated at time history points
+    //!   velocity, total energy, pressure, and volume fraction) evaluated at 
+    //!   time history points
     std::vector< std::vector< tk::real > >
     histOutput( const std::vector< HistData >& h,
                 const std::vector< std::size_t >& inpoel,
@@ -678,11 +679,12 @@ class MultiMat {
         auto php = eval_state(nprim(), rdof, rdof, e, P, B);
 
         // store solution in history output vector
-        Up[j].resize(6, 0.0);
+        Up[j].resize(6+nmat, 0.0);
         for (std::size_t k=0; k<nmat; ++k) {
           Up[j][0] += uhp[densityIdx(nmat,k)];
           Up[j][4] += uhp[energyIdx(nmat,k)];
           Up[j][5] += php[pressureIdx(nmat,k)];
+          Up[j][6+k] = uhp[volfracIdx(nmat,k)];
         }
         Up[j][1] = php[velocityIdx(nmat,0)];
         Up[j][2] = php[velocityIdx(nmat,1)];

--- a/src/PDE/MultiMat/Problem/FieldOutput.cpp
+++ b/src/PDE/MultiMat/Problem/FieldOutput.cpp
@@ -269,6 +269,7 @@ std::vector< std::string > MultiMatHistNames()
 // *****************************************************************************
 {
   std::vector< std::string > n;
+  auto nmat = g_inputdeck.get< tag::param, tag::multimat, tag::nmat >();
 
   n.push_back( "density" );
   n.push_back( "x-velocity" );
@@ -276,6 +277,8 @@ std::vector< std::string > MultiMatHistNames()
   n.push_back( "z-velocity" );
   n.push_back( "energy" );
   n.push_back( "pressure" );
+  for (std::size_t k=0; k<nmat; ++k)
+    n.push_back( "volfrac"+std::to_string(k+1) );
 
   return n;
 }


### PR DESCRIPTION
Volume fractions of all materials are outputted in hist files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/604)
<!-- Reviewable:end -->
