### PR TITLE
Control file options for stress-tensor and deform-tensor

### DIFF
--- a/src/Control/Inciter/OutVar.hpp
+++ b/src/Control/Inciter/OutVar.hpp
@@ -68,7 +68,8 @@ struct OutVar {
     bool is_prim(false);
 
     if (varFnIdx.find("pressure") != std::string::npos ||
-        varFnIdx.find("velocity") != std::string::npos )
+        varFnIdx.find("velocity") != std::string::npos ||
+        varFnIdx.find("stress") != std::string::npos )
     { is_prim = true; }
     else if ( name.length() == 2 &&
       (name.find('u') != std::string::npos ||

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1691,17 +1691,6 @@ DG::writeFields(
     shockmarker[child] = static_cast< tk::real >(m_shockmarker[parent]);
   elemfields.push_back( shockmarker );
 
-  // Add inverse deformation gradient tensor to element-centered field output
-  auto defgrad = g_dgpde[d->MeshId()].cellAvgDeformGrad(m_u,
-    myGhosts()->m_fd.Esuel().size()/4);
-  if (!defgrad[0].empty()) {
-    for (const auto& [child,parent] : addedTets)
-      for (auto& gij : defgrad)
-        gij[child] = static_cast< tk::real >(gij[parent]);
-    for (const auto& gij : defgrad)
-      elemfields.push_back(gij);
-  }
-
   // Query fields names requested by user
   auto elemfieldnames = numericFieldNames( tk::Centering::ELEM );
   auto nodefieldnames = numericFieldNames( tk::Centering::NODE );
@@ -1714,12 +1703,6 @@ DG::writeFields(
     elemfieldnames.push_back( "NDOF" );
 
   elemfieldnames.push_back( "shock_marker" );
-
-  if (!defgrad[0].empty()) {
-    for (std::size_t i=1; i<=3; ++i)
-      for (std::size_t j=1; j<=3; ++j)
-        elemfieldnames.push_back("g"+std::to_string(i)+std::to_string(j));
-  }
 
   Assert( elemfieldnames.size() == elemfields.size(), "Size mismatch" );
   Assert( nodefieldnames.size() == nodefields.size(), "Size mismatch" );

--- a/src/PDE/MultiMat/Problem/FieldOutput.cpp
+++ b/src/PDE/MultiMat/Problem/FieldOutput.cpp
@@ -37,6 +37,26 @@ std::map< std::string, tk::GetVarFn > MultiMatOutVarFn()
   OutFnMap["y-velocity"] = multimat::velocityOutVar<1>;
   OutFnMap["z-velocity"] = multimat::velocityOutVar<2>;
   OutFnMap["material_indicator"] = multimat::matIndicatorOutVar;
+  // Cauchy stress tensor
+  OutFnMap["stress11"] = multimat::stressOutVar<0,0>;
+  OutFnMap["stress12"] = multimat::stressOutVar<0,1>;
+  OutFnMap["stress13"] = multimat::stressOutVar<0,2>;
+  OutFnMap["stress21"] = multimat::stressOutVar<1,0>;
+  OutFnMap["stress22"] = multimat::stressOutVar<1,1>;
+  OutFnMap["stress23"] = multimat::stressOutVar<1,2>;
+  OutFnMap["stress31"] = multimat::stressOutVar<2,0>;
+  OutFnMap["stress32"] = multimat::stressOutVar<2,1>;
+  OutFnMap["stress33"] = multimat::stressOutVar<2,2>;
+  // Inverse deformation gradient tensor
+  OutFnMap["g11"] = multimat::defGradOutVar<0,0>;
+  OutFnMap["g12"] = multimat::defGradOutVar<0,1>;
+  OutFnMap["g13"] = multimat::defGradOutVar<0,2>;
+  OutFnMap["g21"] = multimat::defGradOutVar<1,0>;
+  OutFnMap["g22"] = multimat::defGradOutVar<1,1>;
+  OutFnMap["g23"] = multimat::defGradOutVar<1,2>;
+  OutFnMap["g31"] = multimat::defGradOutVar<2,0>;
+  OutFnMap["g32"] = multimat::defGradOutVar<2,1>;
+  OutFnMap["g33"] = multimat::defGradOutVar<2,2>;
 
   return OutFnMap;
 }

--- a/tests/regression/inciter/multimat/SolidFluidAdv/solidfluid_adv_p0p1.lua
+++ b/tests/regression/inciter/multimat/SolidFluidAdv/solidfluid_adv_p0p1.lua
@@ -81,7 +81,8 @@ inciter = {
       "specific_total_energy",
       "x-velocity",
       "y-velocity",
-      "z-velocity"
+      "z-velocity",
+      "g_tensor"
     },
     elemalias = {
       "volfrac1",
@@ -90,7 +91,8 @@ inciter = {
       "total_energy_density",
       "x-velocity",
       "y-velocity",
-      "z-velocity"
+      "z-velocity",
+      ""
     }
   }
 

--- a/tests/regression/inciter/multimat/SolidShocktube/solid_shocktube_p0p1.lua
+++ b/tests/regression/inciter/multimat/SolidShocktube/solid_shocktube_p0p1.lua
@@ -76,7 +76,8 @@ inciter = {
       "specific_total_energy",
       "x-velocity",
       "y-velocity",
-      "z-velocity"
+      "z-velocity",
+      "g_tensor"
     }
   }
 


### PR DESCRIPTION
Adding options for stress-tensor and deform-tensor in control file. These can be requested by specifying `"stress_tensor"` and `"g_tensor"` in the `field_output` block. Other tensor outputs can be easily added using the machinery for `_tensor`. The stress tensor is symmetric, but we output all 9 components so that we use the same tensor-output machinery for symmetric and non-symmetric tensors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/607)
<!-- Reviewable:end -->
