### PR TITLE
Option for mass average speed of sound

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -791,10 +791,10 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
 
       keywords.insert({"dt_sos_massavg",
         "Toggle method for calculating speed of sound used for time step in a cell",
-        R"(This keyword is used to specify the method to calculate the speed of 
-        sound in a cell used for the time step. If set to 1, the speed of sound 
+        R"(This keyword is used to specify the method to calculate the speed of
+        sound in a cell used for the time step. If set to 1, the speed of sound
         will be calculated using the mass average, rather than the maximum value
-        across materials. It is used for multimat, and has no effect for the 
+        across materials. It is used for multimat, and has no effect for the
         other PDE types.)", "uint 0/1" });
 
       // Dependent variable name

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -791,7 +791,7 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
 
       keywords.insert({"sos_mass_avg",
         "Toggle method for calculating speed of sound in a cell",
-        R"(This keyword is used to specify if the speed of sound should be 
+        R"(This keyword is used to specify if the speed of sound should be
         calculated using a mass average of materials in the cell, rather than
         the maximum speed of sound across materials. It is used for multimat,
         and has no effect for the other PDE types.)", "uint 0/1" });

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -88,6 +88,7 @@ using multimatList = tk::TaggedTuple< brigand::list<
   tag::prelax_timescale, tk::real,
   tag::intsharp,         int,
   tag::intsharp_param,   tk::real,
+  tag::sos_mass_avg,     int,
   tag::problem,          ProblemType
 > >;
 
@@ -787,6 +788,13 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         sharpening. This parameter affects how many cells the material interfaces
         span, after the use of sharpening. It is used for multimat and transport,
         and has no effect for the other PDE types.)", "real" });
+
+      keywords.insert({"sos_mass_avg",
+        "Toggle method for calculating speed of sound in a cell",
+        R"(This keyword is used to specify if the speed of sound should be 
+        calculated using a mass average of materials in the cell, rather than
+        the maximum speed of sound across materials. It is used for multimat,
+        and has no effect for the other PDE types.)", "uint 0/1" });
 
       // Dependent variable name
       keywords.insert({"depvar",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -88,7 +88,7 @@ using multimatList = tk::TaggedTuple< brigand::list<
   tag::prelax_timescale, tk::real,
   tag::intsharp,         int,
   tag::intsharp_param,   tk::real,
-  tag::sos_mass_avg,     int,
+  tag::dt_sos_massavg,   int,
   tag::problem,          ProblemType
 > >;
 
@@ -789,12 +789,13 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         span, after the use of sharpening. It is used for multimat and transport,
         and has no effect for the other PDE types.)", "real" });
 
-      keywords.insert({"sos_mass_avg",
-        "Toggle method for calculating speed of sound in a cell",
-        R"(This keyword is used to specify if the speed of sound should be
-        calculated using a mass average of materials in the cell, rather than
-        the maximum speed of sound across materials. It is used for multimat,
-        and has no effect for the other PDE types.)", "uint 0/1" });
+      keywords.insert({"dt_sos_massavg",
+        "Toggle method for calculating speed of sound used for time step in a cell",
+        R"(This keyword is used to specify the method to calculate the speed of 
+        sound in a cell used for the time step. If set to 1, the speed of sound 
+        will be calculated using the mass average, rather than the maximum value
+        across materials. It is used for multimat, and has no effect for the 
+        other PDE types.)", "uint 0/1" });
 
       // Dependent variable name
       keywords.insert({"depvar",

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -304,13 +304,16 @@ LuaParser::storeInputDeck(
       gideck.get< tag::multimat, tag::prelax >(), 1);
     storeIfSpecd< tk::real >(
       lua_ideck["multimat"], "prelax_timescale",
-      gideck.get< tag::multimat, tag::prelax_timescale >(), 0.25);
+      gideck.get< tag::multimat, tag::prelax_timescale >(), 0.25); 
     storeIfSpecd< int >(
       lua_ideck["multimat"], "intsharp",
       gideck.get< tag::multimat, tag::intsharp >(), 0);
     storeIfSpecd< tk::real >(
       lua_ideck["multimat"], "intsharp_param",
       gideck.get< tag::multimat, tag::intsharp_param >(), 1.8);
+    storeIfSpecd< int >(
+      lua_ideck["multimat"], "sos_mass_avg",
+      gideck.get< tag::multimat, tag::sos_mass_avg >(), 0);
     storeOptIfSpecd< inciter::ctr::ProblemType, inciter::ctr::Problem >(
       lua_ideck["multimat"], "problem",
       gideck.get< tag::multimat, tag::problem >(),

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -304,7 +304,7 @@ LuaParser::storeInputDeck(
       gideck.get< tag::multimat, tag::prelax >(), 1);
     storeIfSpecd< tk::real >(
       lua_ideck["multimat"], "prelax_timescale",
-      gideck.get< tag::multimat, tag::prelax_timescale >(), 0.25); 
+      gideck.get< tag::multimat, tag::prelax_timescale >(), 0.25);
     storeIfSpecd< int >(
       lua_ideck["multimat"], "intsharp",
       gideck.get< tag::multimat, tag::intsharp >(), 0);

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -312,8 +312,8 @@ LuaParser::storeInputDeck(
       lua_ideck["multimat"], "intsharp_param",
       gideck.get< tag::multimat, tag::intsharp_param >(), 1.8);
     storeIfSpecd< int >(
-      lua_ideck["multimat"], "sos_mass_avg",
-      gideck.get< tag::multimat, tag::sos_mass_avg >(), 0);
+      lua_ideck["multimat"], "dt_sos_massavg",
+      gideck.get< tag::multimat, tag::dt_sos_massavg >(), 0);
     storeOptIfSpecd< inciter::ctr::ProblemType, inciter::ctr::Problem >(
       lua_ideck["multimat"], "problem",
       gideck.get< tag::multimat, tag::problem >(),

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -180,7 +180,7 @@ DEFTAG(prelax);
 DEFTAG(prelax_timescale);
 DEFTAG(intsharp);
 DEFTAG(intsharp_param);
-DEFTAG(sos_mass_avg);
+DEFTAG(dt_sos_massavg);
 DEFTAG(depvar);
 DEFTAG(sys);
 DEFTAG(physics);

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -180,6 +180,7 @@ DEFTAG(prelax);
 DEFTAG(prelax_timescale);
 DEFTAG(intsharp);
 DEFTAG(intsharp_param);
+DEFTAG(sos_mass_avg);
 DEFTAG(depvar);
 DEFTAG(sys);
 DEFTAG(physics);

--- a/src/PDE/ConfigureMultiMat.cpp
+++ b/src/PDE/ConfigureMultiMat.cpp
@@ -97,6 +97,10 @@ infoMultiMat( std::map< ctr::PDEType, tk::ncomp_t >& cnt )
   auto intsharp = g_inputdeck.get< eq, tag::intsharp >();
   nfo.emplace_back( "interface sharpening", std::to_string( intsharp ) );
 
+  auto sos_mass_avg = g_inputdeck.get< eq, tag::sos_mass_avg >();
+  nfo.emplace_back( "mass average speed of sound",
+                    std::to_string( sos_mass_avg ) );
+
   auto ncomp = g_inputdeck.get< tag::ncomp >();
   nfo.emplace_back( "number of components", std::to_string( ncomp ) );
 

--- a/src/PDE/ConfigureMultiMat.cpp
+++ b/src/PDE/ConfigureMultiMat.cpp
@@ -97,10 +97,6 @@ infoMultiMat( std::map< ctr::PDEType, tk::ncomp_t >& cnt )
   auto intsharp = g_inputdeck.get< eq, tag::intsharp >();
   nfo.emplace_back( "interface sharpening", std::to_string( intsharp ) );
 
-  auto sos_mass_avg = g_inputdeck.get< eq, tag::sos_mass_avg >();
-  nfo.emplace_back( "mass average speed of sound",
-                    std::to_string( sos_mass_avg ) );
-
   auto ncomp = g_inputdeck.get< tag::ncomp >();
   nfo.emplace_back( "number of components", std::to_string( ncomp ) );
 

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -757,6 +757,8 @@ class MultiMat {
 
       const auto ndof = g_inputdeck.get< tag::ndof >();
       const auto rdof = g_inputdeck.get< tag::rdof >();
+      const auto use_mass_avg =
+        g_inputdeck.get< tag::multimat, tag::dt_sos_massavg >();
       auto nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
       std::size_t ncomp = U.nprop()/rdof;
       std::size_t nprim = P.nprop()/rdof;
@@ -775,22 +777,18 @@ class MultiMat {
 
         // acoustic speed (this should be consistent with time-step calculation)
         ss[e] = 0.0;
-        const auto use_mass_avg =
-          g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
         tk::real mixtureDensity = 0.0;
         for (std::size_t k=0; k<nmat; ++k)
         {
           if (use_mass_avg > 0)
           {
             // mass averaging SoS
-            auto densXVolFrac =
-              ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
-
-            ss[e] += densXVolFrac*m_mat_blk[k].compute< EOS::soundspeed >(
+            ss[e] += ugp[densityIdx(nmat,k)]*
+              m_mat_blk[k].compute< EOS::soundspeed >(
               ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
               ugp[volfracIdx(nmat, k)], k );
 
-            mixtureDensity += densXVolFrac;
+            mixtureDensity += ugp[densityIdx(nmat,k)];
           }
           else
           {

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -775,28 +775,27 @@ class MultiMat {
 
         // acoustic speed (this should be consistent with time-step calculation)
         ss[e] = 0.0;
-        const auto use_mass_avg = 
+        const auto use_mass_avg =
           g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
         tk::real mixtureDensity = 0.0;
         for (std::size_t k=0; k<nmat; ++k)
         {
-        if (use_mass_avg > 0)
+          if (use_mass_avg > 0)
           {
-            if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
-              // mass averaging SoS
-              auto densXVolFrac =
-                ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
+            // mass averaging SoS
+            auto densXVolFrac =
+              ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
 
-              ss[e] += densXVolFrac*m_mat_blk[k].compute< EOS::soundspeed >(
-                ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
-                ugp[volfracIdx(nmat, k)], k );
+            ss[e] += densXVolFrac*m_mat_blk[k].compute< EOS::soundspeed >(
+              ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
+              ugp[volfracIdx(nmat, k)], k );
 
-              mixtureDensity += densXVolFrac;
-            }
+            mixtureDensity += densXVolFrac;
           }
           else
           {
-            if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
+            if (ugp[volfracIdx(nmat, k)] > 1.0e-04)
+            {
               ss[e] = std::max( ss[e], m_mat_blk[k].compute< EOS::soundspeed >(
                 ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
                 ugp[volfracIdx(nmat, k)], k ) );

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -775,14 +775,35 @@ class MultiMat {
 
         // acoustic speed (this should be consistent with time-step calculation)
         ss[e] = 0.0;
+        const auto use_mass_avg = 
+          g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
+        tk::real mixtureDensity = 0.0;
         for (std::size_t k=0; k<nmat; ++k)
         {
-          if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
-            ss[e] = std::max( ss[e], m_mat_blk[k].compute< EOS::soundspeed >(
-              ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
-              ugp[volfracIdx(nmat, k)], k ) );
+        if (use_mass_avg > 0)
+          {
+            if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
+              // mass averaging SoS
+              auto densXVolFrac =
+                ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
+
+              ss[e] += densXVolFrac*m_mat_blk[k].compute< EOS::soundspeed >(
+                ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
+                ugp[volfracIdx(nmat, k)], k );
+
+              mixtureDensity += densXVolFrac;
+            }
+          }
+          else
+          {
+            if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
+              ss[e] = std::max( ss[e], m_mat_blk[k].compute< EOS::soundspeed >(
+                ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
+                ugp[volfracIdx(nmat, k)], k ) );
+            }
           }
         }
+        if (use_mass_avg > 0) ss[e] /= mixtureDensity;
       }
     }
 

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -493,6 +493,8 @@ timeStepSizeMultiMatFV(
 {
   const auto ndof = g_inputdeck.get< tag::ndof >();
   const auto rdof = g_inputdeck.get< tag::rdof >();
+  const auto use_mass_avg =
+    g_inputdeck.get< tag::multimat, tag::dt_sos_massavg >();
   std::size_t ncomp = U.nprop()/rdof;
   std::size_t nprim = P.nprop()/rdof;
 
@@ -519,22 +521,17 @@ timeStepSizeMultiMatFV(
 
     // acoustic speed
     tk::real a = 0.0;
-    const auto use_mass_avg =
-      g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
     tk::real mixtureDensity = 0.0;
     for (std::size_t k=0; k<nmat; ++k)
     {
       if (use_mass_avg > 0)
       {
         // mass averaging SoS
-        auto densXVolFrac =
-          ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
-
-        a += densXVolFrac*mat_blk[k].compute< EOS::soundspeed >(
+        a += ugp[densityIdx(nmat,k)]*mat_blk[k].compute< EOS::soundspeed >(
           ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
           ugp[volfracIdx(nmat, k)], k );
 
-        mixtureDensity += densXVolFrac;
+        mixtureDensity += ugp[densityIdx(nmat,k)];
       }
       else
       {

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -519,14 +519,31 @@ timeStepSizeMultiMatFV(
 
     // acoustic speed
     tk::real a = 0.0;
+    const auto use_mass_avg = 
+      g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
+    tk::real mixtureDensity = 0.0;
     for (std::size_t k=0; k<nmat; ++k)
     {
-      if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
-        a = std::max( a, mat_blk[k].compute< EOS::soundspeed >(
+      if (use_mass_avg > 0)
+      {
+        auto densXVolFrac = ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
+
+        a += densXVolFrac*mat_blk[k].compute< EOS::soundspeed >(
           ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
-          ugp[volfracIdx(nmat, k)], k ) );
+          ugp[volfracIdx(nmat, k)], k );
+
+        mixtureDensity += densXVolFrac;
+      }
+      else
+      {
+        if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
+          a = std::max( a, mat_blk[k].compute< EOS::soundspeed >(
+            ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
+            ugp[volfracIdx(nmat, k)], k ) );
+        }
       }
     }
+    if (use_mass_avg > 0) a /= mixtureDensity;
 
     // characteristic wave speed
     auto v_char = vmag + a;

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -519,14 +519,16 @@ timeStepSizeMultiMatFV(
 
     // acoustic speed
     tk::real a = 0.0;
-    const auto use_mass_avg = 
+    const auto use_mass_avg =
       g_inputdeck.get< tag::multimat, tag::sos_mass_avg >();
     tk::real mixtureDensity = 0.0;
     for (std::size_t k=0; k<nmat; ++k)
     {
       if (use_mass_avg > 0)
       {
-        auto densXVolFrac = ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
+        // mass averaging SoS
+        auto densXVolFrac =
+          ugp[volfracIdx(nmat,k)]*ugp[densityIdx(nmat,k)];
 
         a += densXVolFrac*mat_blk[k].compute< EOS::soundspeed >(
           ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
@@ -536,7 +538,8 @@ timeStepSizeMultiMatFV(
       }
       else
       {
-        if (ugp[volfracIdx(nmat, k)] > 1.0e-04) {
+        if (ugp[volfracIdx(nmat, k)] > 1.0e-04)
+        {
           a = std::max( a, mat_blk[k].compute< EOS::soundspeed >(
             ugp[densityIdx(nmat, k)], pgp[pressureIdx(nmat, k)],
             ugp[volfracIdx(nmat, k)], k ) );


### PR DESCRIPTION
Added an option for FV Multimat simulations to use the mass average to calculate the speed of sound instead of maximum across all materials in a cell.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/610)
<!-- Reviewable:end -->
