### PR TITLE
Remove the "p" pressure-coupling correction from AUSM+up

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -268,6 +268,7 @@ using ConfigMembers = brigand::list<
   tag::ndof,   std::size_t,
   tag::rdof,   std::size_t,
   tag::flux,   FluxType,
+  tag::lowspeed_kp, tk::real,
 
   // limiter options
   tag::limiter,              LimiterType,
@@ -711,6 +712,14 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         function used for discontinuous Galerkin (DG) spatial discretization
         used in inciter. It is only set up for for multi-material hydro, and
         not selectable for anything else.)"});
+
+      keywords.insert({"lowspeed_kp",
+        "Select the low-speed coefficient K_p in the AUSM+up flux function",
+        R"(This keyword is used to select the low-speed coefficient K_p in the
+        AUSM+up flux function used for the DG or FV spatial discretization for
+        multi-material hydro, and not used for anything else. The default
+        value is 0, and recommended value for low speed flows (Mach < 0.1) is
+        1.)"});
 
       keywords.insert({"hll",
         "Select the Harten-Lax-vanLeer (HLL) flux function",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -264,10 +264,10 @@ using ConfigMembers = brigand::list<
   tag::operator_reorder, bool,
 
   // discretization scheme choices
-  tag::scheme, SchemeType,
-  tag::ndof,   std::size_t,
-  tag::rdof,   std::size_t,
-  tag::flux,   FluxType,
+  tag::scheme,      SchemeType,
+  tag::ndof,        std::size_t,
+  tag::rdof,        std::size_t,
+  tag::flux,        FluxType,
   tag::lowspeed_kp, tk::real,
 
   // limiter options

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -174,6 +174,8 @@ LuaParser::storeInputDeck(
   storeIfSpecd< bool >(
     lua_ideck, "limsol_projection", gideck.get< tag::limsol_projection >(),
     true);
+  storeIfSpecd< tk::real >(
+    lua_ideck, "lowspeed_kp", gideck.get< tag::lowspeed_kp >(), 0.0);
 
   // configure solutions DOFs
   auto scheme = gideck.get< tag::scheme >();

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -151,6 +151,7 @@ DEFTAG(scheme);
 DEFTAG(ndof);
 DEFTAG(rdof);
 DEFTAG(flux);
+DEFTAG(lowspeed_kp);
 DEFTAG(limiter);
 DEFTAG(cweight);
 DEFTAG(shock_detector_coeff);

--- a/src/PDE/Riemann/AUSM.hpp
+++ b/src/PDE/Riemann/AUSM.hpp
@@ -41,6 +41,7 @@ struct AUSM {
         const std::vector< std::array< tk::real, 3 > >& = {} )
   {
     auto nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
+    auto k_p = g_inputdeck.get< tag::lowspeed_kp >();
 
     auto ncomp = u[0].size()-(3+nmat);
     std::vector< tk::real > flx( ncomp, 0 );
@@ -115,7 +116,7 @@ struct AUSM {
     // 137-170" for more mathematical explanation. k_u is the velocity diffusion
     // term and k_p is the pressure diffusion term. These two terms reduce
     // pressure-velocity decoupling (chequerboarding/odd-even oscillations).
-    tk::real k_u(1.0), k_p(1.0), f_a(1.0);
+    tk::real k_u(1.0), f_a(1.0);
 
     // Split Mach polynomials
     auto msl = splitmach_ausm( f_a, ml );

--- a/tests/regression/inciter/multimat/EnergyPill/energy_pill_fv.lua
+++ b/tests/regression/inciter/multimat/EnergyPill/energy_pill_fv.lua
@@ -7,6 +7,7 @@ inciter = {
   cfl = 0.9,
 
   scheme = "fv",
+  lowspeed_kp = 1.0,
   limiter = "vertexbasedp1",
 
   partitioning = "mj",

--- a/tests/regression/inciter/multimat/InterfaceAdvection/interface_advection_dg.lua
+++ b/tests/regression/inciter/multimat/InterfaceAdvection/interface_advection_dg.lua
@@ -7,6 +7,7 @@ inciter = {
   ttyi = 1,    -- TTY output interval
   scheme = "dg",
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   multimat = {
     physics = "euler",

--- a/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dg.lua
+++ b/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dg.lua
@@ -7,6 +7,7 @@ inciter = {
   ttyi = 10,    -- TTY output interval
   scheme = "dg",
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   multimat = {
     physics = "euler",

--- a/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dgp1.lua
+++ b/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dgp1.lua
@@ -9,6 +9,7 @@ inciter = {
   limiter = "vertexbasedp1",
   shock_detector_coeff = 1.0,
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   partitioning = "mj",
 

--- a/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dgp1_lsp.lua
+++ b/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_dgp1_lsp.lua
@@ -9,6 +9,7 @@ inciter = {
   limiter = "vertexbasedp1",
   limsol_projection = true,
   shock_detector_coeff = 0.0,
+  lowspeed_kp = 1.0,
 
   partitioning = "mj",
 

--- a/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_p0p1.lua
+++ b/tests/regression/inciter/multimat/SodShocktube/sod_shocktube_p0p1.lua
@@ -9,6 +9,7 @@ inciter = {
   limiter = "vertexbasedp1",
   shock_detector_coeff = 0.0,
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   partitioning = "mj",
 

--- a/tests/regression/inciter/multimat/WaterAirShocktube/waterair_shocktube_dgp1_thinc.lua
+++ b/tests/regression/inciter/multimat/WaterAirShocktube/waterair_shocktube_dgp1_thinc.lua
@@ -9,6 +9,7 @@ inciter = {
   limiter = "vertexbasedp1",
   shock_detector_coeff = 1.0,
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   partitioning = "mj",
 

--- a/tests/regression/inciter/multimat/WaterAirShocktube/waterair_shocktube_p0p1.lua
+++ b/tests/regression/inciter/multimat/WaterAirShocktube/waterair_shocktube_p0p1.lua
@@ -9,6 +9,7 @@ inciter = {
   limiter = "vertexbasedp1",
   shock_detector_coeff = 0.0,
   limsol_projection = false,
+  lowspeed_kp = 1.0,
 
   partitioning = "mj",
 


### PR DESCRIPTION
The "p" pressure-coupling correction from AUSM+up was found to cause the carbuncle shock-instability to reappear. Therefore, as a default do not use the "p" correction. However, it is retained as a user-specified option in control files under "lowspeed_kp", in case low-speed cases need to be run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/611)
<!-- Reviewable:end -->
