### PR TITLE
Implemented new explicit Runge Kutta scheme and added keyword for IMEX

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -90,7 +90,7 @@ using multimatList = tk::TaggedTuple< brigand::list<
   tag::intsharp_param,   tk::real,
   tag::dt_sos_massavg,   int,
   tag::problem,          ProblemType,
-  tag::plasticity,       int,
+  tag::plasticity,       int
 > >;
 
 // Material/EOS object

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -89,8 +89,7 @@ using multimatList = tk::TaggedTuple< brigand::list<
   tag::intsharp,         int,
   tag::intsharp_param,   tk::real,
   tag::dt_sos_massavg,   int,
-  tag::problem,          ProblemType,
-  tag::plasticity,       int
+  tag::problem,          ProblemType
 > >;
 
 // Material/EOS object
@@ -254,6 +253,7 @@ using ConfigMembers = brigand::list<
   tag::dt,    tk::real,
   tag::cfl,   tk::real,
   tag::ttyi,  uint32_t,
+  tag::imex_runge_kutta, uint32_t,
 
   // steady-state solver options
   tag::steady_state, bool,
@@ -453,6 +453,13 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
       keywords.insert({"ttyi", "Set screen output interval",
         R"(This keyword is used to specify the interval in time steps for screen
         output during a simulation.)", "uint"});
+
+      keywords.insert({"imex_runge_kutta",
+        "Toggle use of IMplicit-EXplicit Runge-Kutta scheme",
+        R"(This keywords is used to turn IMEX integrator on/off for solid materials
+        in a multimat run. Plastic terms are integrated implicitly in time. This
+        flag will activate an Implicit-Explicit Runge-Kutta scheme to replace the
+        explicit one that is usually used.)", "uint 0/1"});
 
       // -----------------------------------------------------------------------
       // steady-state solver options
@@ -806,13 +813,6 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         will be calculated using the mass average, rather than the maximum value
         across materials. It is used for multimat, and has no effect for the
         other PDE types.)", "uint 0/1" });
-
-      keywords.insert({"plasticity",
-        "Toggle plasticity for solid materials. Triggers use of IMEX Runge-Kutta",
-        R"(This keywords is used to turn plasticity on/off for solid materials
-        in a multimat run. Plastic terms are integrated implicitly in time. This
-        flag will activate an Implicit-Explicit Runge-Kutta scheme to replace the
-        explicit one that is usually used.)", "uint 0/1"});
 
       // Dependent variable name
       keywords.insert({"depvar",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -89,7 +89,8 @@ using multimatList = tk::TaggedTuple< brigand::list<
   tag::intsharp,         int,
   tag::intsharp_param,   tk::real,
   tag::dt_sos_massavg,   int,
-  tag::problem,          ProblemType
+  tag::problem,          ProblemType,
+  tag::plasticity,       int,
 > >;
 
 // Material/EOS object
@@ -805,6 +806,13 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         will be calculated using the mass average, rather than the maximum value
         across materials. It is used for multimat, and has no effect for the
         other PDE types.)", "uint 0/1" });
+
+      keywords.insert({"plasticity",
+        "Toggle plasticity for solid materials. Triggers use of IMEX Runge-Kutta",
+        R"(This keywords is used to turn plasticity on/off for solid materials
+        in a multimat run. Plastic terms are integrated implicitly in time. This
+        flag will activate an Implicit-Explicit Runge-Kutta scheme to replace the
+        explicit one that is usually used.)", "uint 0/1"});
 
       // Dependent variable name
       keywords.insert({"depvar",

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -328,6 +328,9 @@ LuaParser::storeInputDeck(
     storeOptIfSpecd< inciter::ctr::FluxType, inciter::ctr::Flux >(
       lua_ideck, "flux", gideck.get< tag::flux >(),
       inciter::ctr::FluxType::AUSM);
+    storeIfSpecd< int >(
+      lua_ideck["multimat"], "plasticity",
+      gideck.get< tag::multimat, tag::plasticity >(), 0);
 
     // number of equations in PDE system are determined based on materials
   }

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -137,6 +137,8 @@ LuaParser::storeInputDeck(
     lua_ideck, "residual", gideck.get< tag::residual >(), 1.0e-8);
   storeIfSpecd< uint32_t >(
     lua_ideck, "rescomp", gideck.get< tag::rescomp >(), 1);
+  storeIfSpecd< uint32_t >(
+    lua_ideck, "imex_runge_kutta", gideck.get< tag::imex_runge_kutta >(), 0);
 
   if (gideck.get< tag::dt >() < 1e-12 && gideck.get< tag::cfl >() < 1e-12)
     Throw("No time step calculation policy has been selected in the "
@@ -328,9 +330,6 @@ LuaParser::storeInputDeck(
     storeOptIfSpecd< inciter::ctr::FluxType, inciter::ctr::Flux >(
       lua_ideck, "flux", gideck.get< tag::flux >(),
       inciter::ctr::FluxType::AUSM);
-    storeIfSpecd< int >(
-      lua_ideck["multimat"], "plasticity",
-      gideck.get< tag::multimat, tag::plasticity >(), 0);
 
     // number of equations in PDE system are determined based on materials
   }

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -185,6 +185,7 @@ DEFTAG(dt_sos_massavg);
 DEFTAG(depvar);
 DEFTAG(sys);
 DEFTAG(physics);
+DEFTAG(plasticity);
 
 DEFTAG(material);
 DEFTAG(eos);

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -157,6 +157,7 @@ DEFTAG(cweight);
 DEFTAG(shock_detector_coeff);
 DEFTAG(accuracy_test);
 DEFTAG(limsol_projection);
+DEFTAG(imex_runge_kutta);
 
 DEFTAG(ncomp);
 DEFTAG(pde);
@@ -185,7 +186,6 @@ DEFTAG(dt_sos_massavg);
 DEFTAG(depvar);
 DEFTAG(sys);
 DEFTAG(physics);
-DEFTAG(plasticity);
 
 DEFTAG(material);
 DEFTAG(eos);

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1377,7 +1377,7 @@ DG::solve( tk::real newdt )
   if (m_stage == 0) m_un = m_u;
 
   // Explicit or IMEX
-  const auto plasticity = g_inputdeck.get< tag::multimat, tag::plasticity >();
+  const auto imex_runge_kutta = g_inputdeck.get< tag::imex_runge_kutta >();
 
   // physical time at time-stage for computing exact source terms
   tk::real physT(d->T());
@@ -1388,7 +1388,7 @@ DG::solve( tk::real newdt )
     physT += 0.5*d->Dt();
   }
 
-  if (plasticity) {
+  if (imex_runge_kutta) {
     // Save previous rhs
     m_rhsprev = m_rhs;
   }
@@ -1397,7 +1397,7 @@ DG::solve( tk::real newdt )
     myGhosts()->m_fd, myGhosts()->m_inpoel, m_boxelems, myGhosts()->m_coord,
     m_u, m_p, m_ndof, d->Dt(), m_rhs );
 
-  if (plasticity == 0) {
+  if (!imex_runge_kutta) {
     // Explicit time-stepping using RK3 to discretize time-derivative
     for(std::size_t e=0; e<myGhosts()->m_nunk; ++e)
       for(std::size_t c=0; c<neq; ++c)

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -248,6 +248,7 @@ class DG : public CBase_DG {
       p | m_uNodalExtrmc;
       p | m_pNodalExtrmc;
       p | m_rhs;
+      p | m_rhsprev;
       p | m_npoin;
       p | m_diag;
       p | m_stage;
@@ -315,6 +316,8 @@ class DG : public CBase_DG {
     tk::Fields m_lhs;
     //! Vector of right-hand side
     tk::Fields m_rhs;
+    //! Vector of previous right-hand side values
+    tk::Fields m_rhsprev;
     //! Inverse of Taylor mass-matrix
     std::vector< std::vector< tk::real > > m_mtInv;
     //! Vector of nodal extrema for conservative variables


### PR DESCRIPTION
Keyword imex_runge_kutta was added to switch the time integrator from the usual explicit RK3 to another RK scheme that currently is explicit order 2, but will in the future be Implicit-Explicit to address plastic terms in multi-material problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/612)
<!-- Reviewable:end -->
