### PR TITLE
Imex runge kutta

### DIFF
--- a/src/Base/Vector.hpp
+++ b/src/Base/Vector.hpp
@@ -345,7 +345,7 @@ determinant( const std::array< std::array< tk::real, 3 >, 3 >& a )
 }
 
 //! Compute the inverse of 3x3 matrix
-//!  \param[in] a 3x3 matrix
+//!  \param[in] m 3x3 matrix
 //!  \return Inverse of the 3x3 matrix
 inline std::array< std::array< tk::real, 3 >, 3 >
 inverse( const std::array< std::array< tk::real, 3 >, 3 >& m )

--- a/src/Base/Vector.hpp
+++ b/src/Base/Vector.hpp
@@ -344,6 +344,32 @@ determinant( const std::array< std::array< tk::real, 3 >, 3 >& a )
          + a[0][2] * (a[1][0]*a[2][1]-a[1][1]*a[2][0]) );
 }
 
+//! Compute the inverse of 3x3 matrix
+//!  \param[in] a 3x3 matrix
+//!  \return Inverse of the 3x3 matrix
+inline std::array< std::array< tk::real, 3 >, 3 >
+inverse( const std::array< std::array< tk::real, 3 >, 3 >& m )
+{
+  tk::real det = m[0][0] * (m[1][1] * m[2][2] - m[2][1] * m[1][2]) -
+                 m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+                 m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+
+  tk::real invdet = 1.0 / det;
+
+  std::array< std::array< tk::real, 3 >, 3 > minv;
+  minv[0][0] = (m[1][1] * m[2][2] - m[2][1] * m[1][2]) * invdet;
+  minv[0][1] = (m[0][2] * m[2][1] - m[0][1] * m[2][2]) * invdet;
+  minv[0][2] = (m[0][1] * m[1][2] - m[0][2] * m[1][1]) * invdet;
+  minv[1][0] = (m[1][2] * m[2][0] - m[1][0] * m[2][2]) * invdet;
+  minv[1][1] = (m[0][0] * m[2][2] - m[0][2] * m[2][0]) * invdet;
+  minv[1][2] = (m[1][0] * m[0][2] - m[0][0] * m[1][2]) * invdet;
+  minv[2][0] = (m[1][0] * m[2][1] - m[2][0] * m[1][1]) * invdet;
+  minv[2][1] = (m[2][0] * m[0][1] - m[0][0] * m[2][1]) * invdet;
+  minv[2][2] = (m[0][0] * m[1][1] - m[1][0] * m[0][1]) * invdet;
+
+  return minv;
+}
+
 //! Solve a 3x3 system of equations using Cramer's rule
 //!  \param[in] a 3x3 lhs matrix
 //!  \param[in] b 3x1 rhs matrix
@@ -447,7 +473,7 @@ getRightCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
     3, 3, 3, 1.0, G, 3, G, 3, 0.0, C, 3);
 
   // get inv(g.g^T)
-  lapack_int ipiv[9];
+  lapack_int ipiv[3];
 
   #ifndef NDEBUG
   lapack_int ierr =
@@ -488,7 +514,7 @@ getLeftCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
     3, 3, 3, 1.0, G, 3, G, 3, 0.0, b, 3);
 
   // get inv(g^T.g)
-  lapack_int ipiv[9];
+  lapack_int ipiv[3];
 
   #ifndef NDEBUG
   lapack_int ierr =

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -111,6 +111,7 @@ using materialList = tk::TaggedTuple< brigand::list<
   tag::Pr_jwl,   std::vector< tk::real >,
   tag::mu,       std::vector< tk::real >,
   tag::rho0,     std::vector< tk::real >,
+  tag::yield,    std::vector< tk::real >,
   tag::cv,       std::vector< tk::real >,
   tag::k,        std::vector< tk::real >
 > >;
@@ -247,13 +248,16 @@ using ConfigMembers = brigand::list<
   tag::cmd, CmdLine,
 
   // time stepping options
-  tag::nstep, uint64_t,
-  tag::term,  tk::real,
-  tag::t0,    tk::real,
-  tag::dt,    tk::real,
-  tag::cfl,   tk::real,
-  tag::ttyi,  uint32_t,
+  tag::nstep,            uint64_t,
+  tag::term,             tk::real,
+  tag::t0,               tk::real,
+  tag::dt,               tk::real,
+  tag::cfl,              tk::real,
+  tag::ttyi,             uint32_t,
   tag::imex_runge_kutta, uint32_t,
+  tag::imex_maxiter,     uint32_t,
+  tag::imex_reltol,      tk::real,
+  tag::imex_abstol,      tk::real,
 
   // steady-state solver options
   tag::steady_state, bool,
@@ -459,10 +463,28 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keywords is used to turn IMEX integrator on/off for solid materials
         in a multimat run. Plastic terms are integrated implicitly in time. This
         flag will activate an Implicit-Explicit Runge-Kutta scheme to replace the
-        explicit one that is usually used. Scheme taken from Cavaglieri, D., & 
+        explicit one that is usually used. Scheme taken from Cavaglieri, D., &
         Bewley, T. (2015). Low-storage implicit/explicit Runge–Kutta schemes for
-        the simulation of stiff high-dimensional ODE systems. Journal of 
+        the simulation of stiff high-dimensional ODE systems. Journal of
         Computational Physics, 286, 172-193.)", "uint 0/1"});
+
+      keywords.insert({"imex_maxiter",
+        "Set maximum number of iterations for non-linear solver with IMEX-RK scheme",
+        R"(This keywords is used to specify the maximum number of iterations that
+        the non-linear solver uses to obtain the implicit unknowns within the
+        Implicit-Explicit Runge-Kutta scheme.)", "uint"});
+
+      keywords.insert({"imex_reltol",
+        "Set relative tolerance for non-linear solver with IMEX-RK scheme",
+        R"(This keywords is used to specify the relative tolerance that
+        the non-linear solver uses to obtain the implicit unknowns within the
+        Implicit-Explicit Runge-Kutta scheme.)", "real"});
+
+      keywords.insert({"imex_abstol",
+        "Set absolute tolerance for non-linear solver with IMEX-RK scheme",
+        R"(This keywords is used to specify the absolute tolerance that
+        the non-linear solver uses to obtain the implicit unknowns within the
+        Implicit-Explicit Runge-Kutta scheme.)", "real"});
 
       // -----------------------------------------------------------------------
       // steady-state solver options
@@ -946,6 +968,11 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
       keywords.insert({"rho0", "EoS rho0 parameter",
         R"(This keyword is used to specify the material property rho0, which is
         the density of initial state (units: kg/m3) of the material.)",
+        "vector of reals"});
+
+      keywords.insert({"yield", "Yield stress of solid material",
+        R"(This keyword is used to specify the material property yield stress,
+        which indicates the stress after which the material begins plastic flow.)",
         "vector of reals"});
 
       keywords.insert({"cv", "specific heat at constant volume",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -459,7 +459,10 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keywords is used to turn IMEX integrator on/off for solid materials
         in a multimat run. Plastic terms are integrated implicitly in time. This
         flag will activate an Implicit-Explicit Runge-Kutta scheme to replace the
-        explicit one that is usually used.)", "uint 0/1"});
+        explicit one that is usually used. Scheme taken from Cavaglieri, D., & 
+        Bewley, T. (2015). Low-storage implicit/explicit Runge–Kutta schemes for
+        the simulation of stiff high-dimensional ODE systems. Journal of 
+        Computational Physics, 286, 172-193.)", "uint 0/1"});
 
       // -----------------------------------------------------------------------
       // steady-state solver options

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -139,6 +139,12 @@ LuaParser::storeInputDeck(
     lua_ideck, "rescomp", gideck.get< tag::rescomp >(), 1);
   storeIfSpecd< uint32_t >(
     lua_ideck, "imex_runge_kutta", gideck.get< tag::imex_runge_kutta >(), 0);
+  storeIfSpecd< uint32_t >(
+    lua_ideck, "imex_maxiter", gideck.get< tag::imex_maxiter >(), 50);
+  storeIfSpecd< tk::real >(
+    lua_ideck, "imex_reltol", gideck.get< tag::imex_reltol >(), 1.0e-02);
+  storeIfSpecd< tk::real >(
+    lua_ideck, "imex_abstol", gideck.get< tag::imex_abstol >(), 1.0e-04);
 
   if (gideck.get< tag::dt >() < 1e-12 && gideck.get< tag::cfl >() < 1e-12)
     Throw("No time step calculation policy has been selected in the "
@@ -428,8 +434,16 @@ LuaParser::storeInputDeck(
           mati_deck.get< tag::mu >());
 
         // rho0
+        if (!sol_mat[i+1]["rho0"].valid())
+          sol_mat[i+1]["rho0"] = std::vector< tk::real >(ntype, 0.0);
         checkStoreMatProp(sol_mat[i+1], "rho0", ntype,
           mati_deck.get< tag::rho0 >());
+
+        // yield
+        if (!sol_mat[i+1]["yield"].valid())
+          sol_mat[i+1]["yield"] = std::vector< tk::real >(ntype, 300.0e+06);
+        checkStoreMatProp(sol_mat[i+1], "yield", ntype,
+          mati_deck.get< tag::yield >());
 
         // assign solid
         is_solid = true;

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -158,6 +158,9 @@ DEFTAG(shock_detector_coeff);
 DEFTAG(accuracy_test);
 DEFTAG(limsol_projection);
 DEFTAG(imex_runge_kutta);
+DEFTAG(imex_maxiter);
+DEFTAG(imex_reltol);
+DEFTAG(imex_abstol);
 
 DEFTAG(ncomp);
 DEFTAG(pde);
@@ -211,6 +214,7 @@ DEFTAG(matidxmap);
 DEFTAG(eosidx);
 DEFTAG(matidx);
 DEFTAG(solidx);
+DEFTAG(yield);
 
 DEFTAG(field_output);
 DEFTAG(interval);

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1975,7 +1975,7 @@ DG::imex_integrate()
       // Non-linear system f(u) = 0 to be solved
       // Broyden's method
       // Control parameters
-      std::size_t max_iter = 1000;
+      std::size_t max_iter = 100;
       tk::real tol = 1.0e-10;
       tk::real err = tol+1;
       std::size_t nstiff = m_nstiffeq*ndof;
@@ -2183,7 +2183,7 @@ DG::imex_integrate()
       }
   }
   else {
-    // For last stage there just use all previously computed stages
+    // For last stage just use all previously computed stages
     const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
     for (std::size_t e=0; e<nelem; ++e)
     {

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1425,7 +1425,7 @@ DG::solve( tk::real newdt )
           auto mark = c*ndof+k;
           m_u(e, rmark) =  m_un(e, rmark) + d->Dt() * (
                expl_rkcoef[0][m_stage] * m_rhsprev(e, mark)/m_lhs(e, mark)
-             + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/m_lhs(e, mark) );
+               + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/m_lhs(e, mark));
           if(fabs(m_u(e, rmark)) < 1e-16)
             m_u(e, rmark) = 0;
         }

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -1976,7 +1976,7 @@ DG::imex_integrate()
       // Broyden's method
       // Control parameters
       std::size_t max_iter = 100;
-      tk::real tol = 1.0e-10;
+      tk::real tol = 1.0e-06;
       tk::real err = tol+1;
       std::size_t nstiff = m_nstiffeq*ndof;
 
@@ -1984,7 +1984,7 @@ DG::imex_integrate()
       std::vector< std::vector< tk::real > >
         approx_jacob(nstiff, std::vector< tk::real >(nstiff, 0.0));
       for (std::size_t i=0; i<nstiff; ++i)
-        approx_jacob[i][i] = 1.0e-00;
+        approx_jacob[i][i] = 1.0e+00;
 
       // Save explicit terms to be re-used
       std::vector< tk::real > expl_terms(nstiff, 0.0);
@@ -2028,7 +2028,7 @@ DG::imex_integrate()
       for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
         for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
         {
-          u_old[ieq*ndof+idof] = m_u(e, m_stiffeq[ieq]*ndof+idof);
+          u_old[ieq*ndof+idof] = m_u(e, m_stiffeq[ieq]*rdof+idof);
           f_old[ieq*ndof+idof] = f[ieq*ndof+idof];
         }
 
@@ -2112,19 +2112,19 @@ DG::imex_integrate()
 
         // 3. Divide delta_u+approx_jacob*delta_f
         // by delta_u*(approx_jacob*delta_f)
-        if (std::abs(denom) < 1.0e-12)
+        if (std::abs(denom) < 1.0e-18)
         {
           if (denom < 0.0)
           {
             for (std::size_t jeq=0; jeq<m_nstiffeq; ++jeq)
               for (std::size_t jdof=0; jdof<m_numEqDof[jeq]; ++jdof)
-                auxvec1[jeq*ndof+jdof] /= -1.0e-12;
+                auxvec1[jeq*ndof+jdof] /= -1.0e-18;
           }
           else
           {
             for (std::size_t jeq=0; jeq<m_nstiffeq; ++jeq)
               for (std::size_t jdof=0; jdof<m_numEqDof[jeq]; ++jdof)
-                auxvec1[jeq*ndof+jdof] /= 1.0e-12; 
+                auxvec1[jeq*ndof+jdof] /= 1.0e-18; 
           }
         }
         else
@@ -2147,7 +2147,7 @@ DG::imex_integrate()
         for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
           for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
           {
-            u_old[ieq*ndof+idof] = m_u(e, m_stiffeq[ieq]*ndof+idof);
+            u_old[ieq*ndof+idof] = m_u(e, m_stiffeq[ieq]*rdof+idof);
             f_old[ieq*ndof+idof] = f[ieq*ndof+idof];
           }
 
@@ -2158,11 +2158,17 @@ DG::imex_integrate()
             err += f[ieq*ndof+idof]*f[ieq*ndof+idof];
         err = std::sqrt(err);
 
-        if (max_iter-1 == iter)
-          printf("In nonlinear solver: e, iter, err = %d, %d, %e \n", e, iter, err);
+        //if (max_iter-1 == iter)
+        if (iter > 1)
+          printf("(1) In nonlinear solver: e, iter, err = %d, %d, %e \n", e, iter, err);
       
         // Check if error condition is met and loop back
-        if (err < tol) break;
+        if (err < tol)
+        {
+          if (iter > 1)
+            printf("(2) In nonlinear solver: e, iter, err = %d, %d, %e \n", e, iter, err);
+          break;
+        }
       }
     }
 

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -2015,14 +2015,16 @@ DG::imex_integrate()
           m_u(e, rmark) = 0;
       }
     }
+
   // Then, solve for implicit-explicit ones
-  for (std::size_t e=0; e<myGhosts()->m_nunk; ++e)
+  const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
+  for (std::size_t e=0; e<nelem; ++e)
   {
     // Non-linear system f(u) = 0 to be solved
     // Broyden's method
     // Control parameters
-    std::size_t max_iter = 100;
-    tk::real tol = 1.0e-16;
+    std::size_t max_iter = 1000;
+    tk::real tol = 1.0e-10;
     tk::real err = tol+1;
     std::size_t nstiff = m_nstiffeq*ndof;
     
@@ -2030,7 +2032,7 @@ DG::imex_integrate()
     std::vector< std::vector< tk::real > >
       approx_jacob(nstiff, std::vector< tk::real >(nstiff, 0.0));
     for (std::size_t i=0; i<nstiff; ++i)
-      approx_jacob[i][i] = 1.0e+02;
+      approx_jacob[i][i] = 1.0e-00;
     
     // Save explicit terms to be re-used
     std::vector< tk::real > expl_terms(nstiff, 0.0);
@@ -2047,7 +2049,7 @@ DG::imex_integrate()
           + impl_rkcoef[0][m_stage]
           * m_stiffrhsprev(e,ieq*ndof+idof)/m_lhs(e,stiffmark) );
       }
-
+    
     // Compute stiff_rhs with initial u
     g_dgpde[d->MeshId()].stiff_rhs( e, myGhosts()->m_geoElem,
       myGhosts()->m_inpoel, myGhosts()->m_coord,
@@ -2239,6 +2241,8 @@ DG::imex_integrate()
       // {
       //   printf("In nonlinear solver: e, iter, err = %d, %d, %e \n", e, iter, err);
       // }
+      if (9999 < iter)
+        printf("In nonlinear solver: e, iter, err = %d, %d, %e \n", e, iter, err);
       
       // Check if error condition is met and loop back
       if (err < tol) break;

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -2149,7 +2149,7 @@ DG::imex_integrate()
       err = std::sqrt(err);
 
       // Check if error condition is met and loop back
-      if (iter == 0 || err < tol) break;
+      if (iter > 0 && err < tol) break;
     }
   }
 }

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -255,7 +255,9 @@ class DG : public CBase_DG {
       p | m_stiffrhs;
       p | m_stiffrhsprev;
       p | m_stiffeq;
+      p | m_nonstiffeq;
       p | m_nstiffeq;
+      p | m_nnonstiffeq;
       p | m_npoin;
       p | m_diag;
       p | m_stage;
@@ -311,8 +313,8 @@ class DG : public CBase_DG {
     //! \brief Counter signaling that we have received all our nodal extrema from
     //!   ghost chare partitions
     std::size_t m_nnodalExtrema;
-    //! Counter signaling how many stiff equations are in the system
-    std::size_t m_nstiffeq;
+    //! Counters signaling how many stiff and non-stiff equations in the system
+    std::size_t m_nstiffeq, m_nnonstiffeq;;
     //! Vector of unknown/solution average over each mesh element
     tk::Fields m_u;
     //! Vector of unknown at previous time-step
@@ -331,8 +333,8 @@ class DG : public CBase_DG {
     tk::Fields m_stiffrhs;
     //! Vector of previous right-hand side values for stiff equations
     tk::Fields m_stiffrhsprev;
-    //! Vector that indicates which equations are stiff
-    std::vector< std::size_t > m_stiffeq;
+    //! Vectors that indicates which equations are stiff and non-stiff
+  std::vector< std::size_t > m_stiffeq, m_nonstiffeq;
     //! Inverse of Taylor mass-matrix
     std::vector< std::vector< tk::real > > m_mtInv;
     //! Vector of nodal extrema for conservative variables

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -221,6 +221,9 @@ class DG : public CBase_DG {
     //! Evaluate whether to continue with next time step
     void step();
 
+    //! Compute the integration step for IMEX-RK
+    void imex_integrate();
+
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{
     //! \brief Pack/Unpack serialize member function
@@ -249,6 +252,10 @@ class DG : public CBase_DG {
       p | m_pNodalExtrmc;
       p | m_rhs;
       p | m_rhsprev;
+      p | m_stiffrhs;
+      p | m_stiffrhsprev;
+      p | m_stiffeq;
+      p | m_nstiffeq;
       p | m_npoin;
       p | m_diag;
       p | m_stage;
@@ -304,6 +311,8 @@ class DG : public CBase_DG {
     //! \brief Counter signaling that we have received all our nodal extrema from
     //!   ghost chare partitions
     std::size_t m_nnodalExtrema;
+    //! Counter signaling how many stiff equations are in the system
+    std::size_t m_nstiffeq;
     //! Vector of unknown/solution average over each mesh element
     tk::Fields m_u;
     //! Vector of unknown at previous time-step
@@ -318,6 +327,12 @@ class DG : public CBase_DG {
     tk::Fields m_rhs;
     //! Vector of previous right-hand side values
     tk::Fields m_rhsprev;
+    //! Vector of right-hand side for stiff equations
+    tk::Fields m_stiffrhs;
+    //! Vector of previous right-hand side values for stiff equations
+    tk::Fields m_stiffrhsprev;
+    //! Vector that indicates which equations are stiff
+    std::vector< std::size_t > m_stiffeq;
     //! Inverse of Taylor mass-matrix
     std::vector< std::vector< tk::real > > m_mtInv;
     //! Vector of nodal extrema for conservative variables

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -129,6 +129,20 @@ class CompFlow {
       tk::BoxElems< eq >(geoElem, nielem, inbox);
     }
 
+    //! Find how 'stiff equations', which we currently
+    //! have none for Compflow
+    //! \param[out] nstiffeq number of stiff equations
+    std::size_t nstiffeq() const
+    { return 0; }
+
+    //! Locate the stiff equations within the list of all
+    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    //! \param[out] stiffeq list with 0s and 1s
+    void stiffeq( std::vector< std::size_t >& stiffeq ) const
+    {
+      stiffeq.resize(0);
+    }
+
     //! Initalize the compressible flow equations, prepare for time integration
     //! \param[in] L Block diagonal mass matrix
     //! \param[in] inpoel Element-node connectivity
@@ -725,6 +739,25 @@ class CompFlow {
 
       return mindt;
     }
+
+    //! Compute stiff terms for a single element, not implemented here
+    //! \param[in] e Element number
+    //! \param[in] geoElem Element geometry array
+    //! \param[in] inpoel Element-node connectivity
+    //! \param[in] coord Array of nodal coordinates
+    //! \param[in] U Solution vector at recent time step
+    //! \param[in] P Primitive vector at recent time step
+    //! \param[in] ndofel Vector of local number of degrees of freedom
+    //! \param[in,out] R Right-hand side vector computed
+    void stiff_rhs( std::size_t /*e*/,
+                    const tk::Fields& /*geoElem*/,
+                    const std::vector< std::size_t >& /*inpoel*/,
+                    const tk::UnsMesh::Coords& /*coord*/,
+                    const tk::Fields& /*U*/,
+                    const tk::Fields& /*P*/,
+                    const std::vector< std::size_t >& /*ndofel*/,
+                    tk::Fields& /*R*/ ) const
+    {}
 
     //! Extract the velocity field at cell nodes. Currently unused.
     //! \param[in] U Solution vector at recent time step

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -135,12 +135,26 @@ class CompFlow {
     std::size_t nstiffeq() const
     { return 0; }
 
-    //! Locate the stiff equations within the list of all
-    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    //! Find how 'nonstiff equations', which we currently
+    //! don't use for Compflow
+    //! \param[out] nnonstiffeq number of stiff equations
+    std::size_t nnonstiffeq() const
+    { return 0; }
+  
+    //! Locate the stiff equations. Unused for compflow.
+    //! \param[in] neq number of equations
     //! \param[out] stiffeq list with 0s and 1s
     void stiffeq( std::vector< std::size_t >& stiffeq ) const
     {
       stiffeq.resize(0);
+    }
+
+    //! Locate the nonstiff equations. Unused for compflow.
+    //! \param[in] neq number of equations
+    //! \param[out] nonstiffeq list with 0s and 1s
+    void nonstiffeq( std::vector< std::size_t >& nonstiffeq ) const
+    {
+      nonstiffeq.resize(0);
     }
 
     //! Initalize the compressible flow equations, prepare for time integration

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -133,6 +133,16 @@ class DGPDE {
     void numEquationDofs(std::vector< std::size_t >& numEqDof) const
     { return self->numEquationDofs(numEqDof); }
 
+    //! Public interface to find how 'stiff equations', which are the inverse
+    //! deformation equations because of plasticity
+    std::size_t nstiffeq() const
+    { return self->nstiffeq(); }
+
+    //! Public function to locate the stiff equations within the list of all
+    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    void stiffeq( std::vector< std::size_t >& stiffeq ) const
+    { return self->stiffeq( stiffeq ); }
+  
     //! Public interface to determine elements that lie inside the IC box
     void IcBoxElems( const tk::Fields& geoElem,
       std::size_t nielem,
@@ -282,6 +292,17 @@ class DGPDE {
     { return self->dt( coord, inpoel, fd, geoFace, geoElem, ndofel, U,
                        P, nielem ); }
 
+    //! Public interface for computing stiff terms for an element
+    void stiff_rhs( std::size_t e,
+                    const tk::Fields& geoElem,
+                    const std::vector< std::size_t >& inpoel,
+                    const tk::UnsMesh::Coords& coord,
+                    const tk::Fields& U,
+                    const tk::Fields& P,
+                    const std::vector< std::size_t >& ndofel,
+                    tk::Fields& R ) const
+    { return self->stiff_rhs( e, geoElem, inpoel, coord, U, P, ndofel, R); }
+  
     //! Public interface to returning maps of output var functions
     std::map< std::string, tk::GetVarFn > OutVarFn() const
     { return self->OutVarFn(); }
@@ -347,6 +368,8 @@ class DGPDE {
       virtual std::size_t nprim() const = 0;
       virtual std::size_t nmat() const = 0;
       virtual void numEquationDofs(std::vector< std::size_t >&) const = 0;
+      virtual std::size_t nstiffeq() const = 0;
+      virtual void stiffeq( std::vector< std::size_t >& ) const = 0;
       virtual void IcBoxElems( const tk::Fields&,
         std::size_t,
         std::vector< std::unordered_set< std::size_t > >& ) const = 0;
@@ -441,6 +464,14 @@ class DGPDE {
                            const tk::Fields&,
                            const tk::Fields&,
                            const std::size_t ) const = 0;
+      virtual void stiff_rhs( std::size_t,
+                              const tk::Fields&,
+                              const std::vector< std::size_t >&,
+                              const tk::UnsMesh::Coords&,
+                              const tk::Fields&,
+                              const tk::Fields&,
+                              const std::vector< std::size_t >&,
+                              tk::Fields& ) const = 0;
       virtual std::map< std::string, tk::GetVarFn > OutVarFn() const = 0;
       virtual std::vector< std::string > analyticFieldNames() const = 0;
       virtual std::vector< std::string > histNames() const = 0;
@@ -474,6 +505,10 @@ class DGPDE {
       { return data.nmat(); }
       void numEquationDofs(std::vector< std::size_t >& numEqDof) const override
       { data.numEquationDofs(numEqDof); }
+      std::size_t nstiffeq() const override
+      { return data.nstiffeq(); }
+      void stiffeq( std::vector< std::size_t >& stiffeq ) const override
+      { data.stiffeq(stiffeq); }
       void IcBoxElems( const tk::Fields& geoElem,
         std::size_t nielem,
         std::vector< std::unordered_set< std::size_t > >& inbox )
@@ -598,6 +633,15 @@ class DGPDE {
                    const std::size_t nielem ) const override
       { return data.dt( coord, inpoel, fd, geoFace, geoElem, ndofel,
                         U, P, nielem ); }
+      void stiff_rhs( std::size_t e,
+                      const tk::Fields& geoElem,
+                      const std::vector< std::size_t >& inpoel,
+                      const tk::UnsMesh::Coords& coord,
+                      const tk::Fields& U,
+                      const tk::Fields& P,
+                      const std::vector< std::size_t >& ndofel,
+                      tk::Fields& R ) const override
+      { return data.stiff_rhs( e, geoElem, inpoel, coord, U, P, ndofel, R ); }
       std::map< std::string, tk::GetVarFn > OutVarFn() const override
       { return data.OutVarFn(); }
       std::vector< std::string > analyticFieldNames() const override

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -138,10 +138,18 @@ class DGPDE {
     std::size_t nstiffeq() const
     { return self->nstiffeq(); }
 
-    //! Public function to locate the stiff equations within the list of all
-    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    //! Public interface to find how 'nonstiff equations', which are the inverse
+    //! deformation equations because of plasticity
+    std::size_t nnonstiffeq() const
+    { return self->nnonstiffeq(); }
+
+    //! Public function to locate the stiff equations
     void stiffeq( std::vector< std::size_t >& stiffeq ) const
     { return self->stiffeq( stiffeq ); }
+
+    //! Public function to locate the nonstiff equations
+    void nonstiffeq( std::vector< std::size_t >& nonstiffeq ) const
+    { return self->nonstiffeq( nonstiffeq ); }
   
     //! Public interface to determine elements that lie inside the IC box
     void IcBoxElems( const tk::Fields& geoElem,
@@ -369,7 +377,9 @@ class DGPDE {
       virtual std::size_t nmat() const = 0;
       virtual void numEquationDofs(std::vector< std::size_t >&) const = 0;
       virtual std::size_t nstiffeq() const = 0;
+      virtual std::size_t nnonstiffeq() const = 0;
       virtual void stiffeq( std::vector< std::size_t >& ) const = 0;
+      virtual void nonstiffeq( std::vector< std::size_t >& ) const = 0;
       virtual void IcBoxElems( const tk::Fields&,
         std::size_t,
         std::vector< std::unordered_set< std::size_t > >& ) const = 0;
@@ -507,8 +517,12 @@ class DGPDE {
       { data.numEquationDofs(numEqDof); }
       std::size_t nstiffeq() const override
       { return data.nstiffeq(); }
+      std::size_t nnonstiffeq() const override
+      { return data.nnonstiffeq(); }
       void stiffeq( std::vector< std::size_t >& stiffeq ) const override
       { data.stiffeq(stiffeq); }
+      void nonstiffeq( std::vector< std::size_t >& nonstiffeq ) const override
+      { data.nonstiffeq(nonstiffeq); }
       void IcBoxElems( const tk::Fields& geoElem,
         std::size_t nielem,
         std::vector< std::unordered_set< std::size_t > >& inbox )

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -146,7 +146,7 @@ class MultiMat {
       tk::BoxElems< eq >(geoElem, nielem, inbox);
     }
 
-    //! Find how 'stiff equations', which are the inverse
+    //! Find how many 'stiff equations', which are the inverse
     //! deformation equations because of plasticity
     //! \param[out] nstiffeq number of stiff equations
     std::size_t nstiffeq() const
@@ -156,6 +156,15 @@ class MultiMat {
       return 9*numSolids(nmat, solidx);
     }
 
+    //! Find how many 'non-stiff equations', which are the inverse
+    //! deformation equations because of plasticity
+    //! \param[out] nnonstiffeq number of stiff equations
+    std::size_t nnonstiffeq() const
+    {
+      std::size_t nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
+      return 2*nmat+3+nmat;
+    }
+  
     //! Locate the stiff equations.
     //! \param[out] stiffeq list with pointers to stiff equations
     void stiffeq( std::vector< std::size_t >& stiffeq ) const
@@ -173,6 +182,16 @@ class MultiMat {
                 inciter::deformIdx(nmat, solidx[k], i, j);
               icnt++;
             }
+    }
+  
+    //! Locate the nonstiff equations.
+    //! \param[out] nonstiffeq list with pointers to nonstiff equations
+    void nonstiffeq( std::vector< std::size_t >& nonstiffeq ) const
+    {
+      nonstiffeq.resize(nstiffeq(), 0);
+      std::size_t nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
+      for (std::size_t icomp=0; icomp<2*nmat+3+nmat; icomp++)
+        nonstiffeq[icomp] = icomp;
     }
 
     //! Initalize the compressible flow equations, prepare for time integration
@@ -989,17 +1008,6 @@ class MultiMat {
         auto B = tk::eval_basis( ndofel[e], coordgp[0][igp], coordgp[1][igp],
                              coordgp[2][igp] );
 
-        // if (e == 703)
-        // {
-        //   printf("DEBUG\n");
-        //   for (std::size_t k=0; k<nmat; ++k)
-        //     if (solidx[k] > 0)
-        //       for (std::size_t i=0; i<3; ++i)
-        //         for (std::size_t j=0; j<3; ++j)
-        //           printf("g[%d][%d][%d] = %e \n", k, i, j,
-        //                  U(e, inciter::deformDofIdx(nmat, solidx[k], i, j, rdof, 0)));
-        // }
-        
         auto state = tk::evalPolynomialSol(m_mat_blk, intsharp, ncomp, nprim,
           rdof, nmat, e, ndofel[e], inpoel, coord, geoElem, gp, B, U, P);
         

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -997,6 +997,7 @@ class MultiMat {
         
         // compute source
         // Loop through materials
+        std::size_t ksld = 0;
         for (std::size_t k=0; k<nmat; ++k)
         {
           if (solidx[k] > 0)
@@ -1063,7 +1064,7 @@ class MultiMat {
             // 5. Divide by 2*mu*tau
             // 'Perfect' plasticity
             // HARDCODED: Yield Stress
-            tk::real yield_stress = 297.6e19;
+            tk::real yield_stress = 297.6e06;
             tk::real equiv_stress = 0.0;
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)
@@ -1092,14 +1093,17 @@ class MultiMat {
 
             auto wt = wgp[igp] * geoElem(e, 0);
 
+            // Contribute to the right-hand-side
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)
                 for (std::size_t idof=0; idof<ndof; ++idof)
                 {
-                  std::size_t dofId = (i*3+j)*ndof+idof;
-                  R(e, dofId) += wt * s[dofId];
+                  std::size_t srcId = (i*3+j)*ndof+idof;
+                  std::size_t dofId = 9*ndof*ksld+(i*3+j)*ndof+idof;
+                  R(e, dofId) += wt * s[srcId];
                 }
 
+            ksld++;
           }
         }
 

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1054,6 +1054,9 @@ class MultiMat {
                 Lp[i][j] = sum;
               }
             // 5. Divide by 2*mu*tau
+            // 'Perfect' plasticity
+            // HARDCODED: Yield Stress 2e11
+            //if (sigma ..
             tk::real rel_time = 1.0; // temp
             tk::real mu = getmatprop< tag::mu >(k);
             for (std::size_t i=0; i<3; ++i)

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1080,15 +1080,16 @@ class MultiMat {
             // 5. Divide by 2*mu*tau
             // 'Perfect' plasticity
             // HARDCODED: Yield Stress
-            tk::real yield_stress = 297.6e06;
+            tk::real yield_stress = getmatprop< tag::yield >(k);
             tk::real equiv_stress = 0.0;
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)
                 equiv_stress += sigma_dev[i][j]*sigma_dev[i][j];
             equiv_stress = std::sqrt(3.0*equiv_stress/2.0);
+            // rel_factor = 1/tau <- Perfect plasticity for now.
             tk::real rel_factor = 0.0;
             if (equiv_stress >= yield_stress)
-              rel_factor = 1.0e+08;
+              rel_factor = yield_stress;
             tk::real mu = getmatprop< tag::mu >(k);
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1080,7 +1080,7 @@ class MultiMat {
             equiv_stress = std::sqrt(3.0*equiv_stress/2.0);
             tk::real rel_factor = 0.0;
             if (equiv_stress >= yield_stress)
-              rel_factor = 1.0e+04;
+              rel_factor = 1.0e+00;
             else
               rel_factor = 0.0;
             tk::real mu = getmatprop< tag::mu >(k);
@@ -1115,7 +1115,7 @@ class MultiMat {
           }
         }
 
-      }
+        }
     }
 
     //! Extract the velocity field at cell nodes. Currently unused.

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -150,7 +150,11 @@ class MultiMat {
     //! deformation equations because of plasticity
     //! \param[out] nstiffeq number of stiff equations
     std::size_t nstiffeq() const
-    { return 9*g_inputdeck.get< tag::multimat, tag::nmat >(); }
+    {
+      const auto& solidx = g_inputdeck.get< tag::matidxmap, tag::solidx >();
+      std::size_t nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
+      return 9*numSolids(nmat, solidx);
+    }
 
     //! Locate the stiff equations.
     //! \param[out] stiffeq list with pointers to stiff equations
@@ -985,12 +989,16 @@ class MultiMat {
         auto B = tk::eval_basis( ndofel[e], coordgp[0][igp], coordgp[1][igp],
                              coordgp[2][igp] );
 
-        // printf("DEBUG\n");
-        // for (std::size_t k=0; k<nmat; ++k)
-        //   for (std::size_t i=0; i<3; ++i)
-        //     for (std::size_t j=0; j<3; ++j)
-        //       printf("g[%d][%d][%d] = %e \n", k, i, j,
-        //              U(e, inciter::deformDofIdx(nmat, solidx[k], i, j, rdof, 0)));
+        // if (e == 703)
+        // {
+        //   printf("DEBUG\n");
+        //   for (std::size_t k=0; k<nmat; ++k)
+        //     if (solidx[k] > 0)
+        //       for (std::size_t i=0; i<3; ++i)
+        //         for (std::size_t j=0; j<3; ++j)
+        //           printf("g[%d][%d][%d] = %e \n", k, i, j,
+        //                  U(e, inciter::deformDofIdx(nmat, solidx[k], i, j, rdof, 0)));
+        // }
         
         auto state = tk::evalPolynomialSol(m_mat_blk, intsharp, ncomp, nprim,
           rdof, nmat, e, ndofel[e], inpoel, coord, geoElem, gp, B, U, P);
@@ -1072,7 +1080,7 @@ class MultiMat {
             equiv_stress = std::sqrt(3.0*equiv_stress/2.0);
             tk::real rel_factor = 0.0;
             if (equiv_stress >= yield_stress)
-              rel_factor = 1.0;
+              rel_factor = 1.0e+04;
             else
               rel_factor = 0.0;
             tk::real mu = getmatprop< tag::mu >(k);

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1044,7 +1044,7 @@ class MultiMat {
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)
                 ginv[3*i+j] = g[i][j];
-            lapack_int ipiv[9];
+            lapack_int ipiv[3];
             #ifndef NDEBUG
             lapack_int ierr =
             #endif
@@ -1088,9 +1088,7 @@ class MultiMat {
             equiv_stress = std::sqrt(3.0*equiv_stress/2.0);
             tk::real rel_factor = 0.0;
             if (equiv_stress >= yield_stress)
-              rel_factor = 1.0e+00;
-            else
-              rel_factor = 0.0;
+              rel_factor = 1.0e+08;
             tk::real mu = getmatprop< tag::mu >(k);
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1061,11 +1061,11 @@ class MultiMat {
             // 'Perfect' plasticity
             // HARDCODED: Yield Stress 2e11
             //if (sigma ..?
-            tk::real rel_time = 1.0; // temp
+            tk::real rel_factor = 1.0e-12; // temp
             tk::real mu = getmatprop< tag::mu >(k);
             for (std::size_t i=0; i<3; ++i)
               for (std::size_t j=0; j<3; ++j)
-                Lp[i][j] /= 2.0*mu*rel_time;
+                Lp[i][j] *= rel_factor/2.0*mu;
 
             // Compute the source terms
             std::vector< tk::real > s(9*ndof, 0.0);

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -104,6 +104,21 @@ class Transport {
       }
     }
 
+    //! Find how 'stiff equations', which we currently
+    //! have none for Transport
+    //! \param[out] nstiffeq number of stiff equations
+    std::size_t nstiffeq() const
+    { return 0; }
+
+    //! Locate the stiff equations within the list of all
+    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    //! \param[in] neq number of equations
+    //! \param[out] stiffeq list with 0s and 1s
+    void stiffeq( std::vector< std::size_t >& stiffeq ) const
+    {
+      stiffeq.resize(0);
+    }
+
     //! Determine elements that lie inside the user-defined IC box
     void IcBoxElems( const tk::Fields&,
       std::size_t,
@@ -439,6 +454,25 @@ class Transport {
       return mindt;
     }
 
+    //! Compute stiff terms for a single element, not implemented here
+    //! \param[in] e Element number
+    //! \param[in] geoElem Element geometry array
+    //! \param[in] inpoel Element-node connectivity
+    //! \param[in] coord Array of nodal coordinates
+    //! \param[in] U Solution vector at recent time step
+    //! \param[in] P Primitive vector at recent time step
+    //! \param[in] ndofel Vector of local number of degrees of freedom
+    //! \param[in,out] R Right-hand side vector computed
+    void stiff_rhs( std::size_t /*e*/,
+                    const tk::Fields& /*geoElem*/,
+                    const std::vector< std::size_t >& /*inpoel*/,
+                    const tk::UnsMesh::Coords& /*coord*/,
+                    const tk::Fields& /*U*/,
+                    const tk::Fields& /*P*/,
+                    const std::vector< std::size_t >& /*ndofel*/,
+                    tk::Fields& /*R*/ ) const
+    {}
+  
     //! Return a map that associates user-specified strings to functions
     //! \return Map that associates user-specified strings to functions that
     //!  compute relevant quantities to be output to file

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -110,13 +110,26 @@ class Transport {
     std::size_t nstiffeq() const
     { return 0; }
 
-    //! Locate the stiff equations within the list of all
-    //! equations. Places a 1 if equation is stiff, 0 otherwise.
+    //! Find how 'nonstiff equations', which we currently
+    //! don't use for Transport
+    //! \param[out] nnonstiffeq number of stiff equations
+    std::size_t nnonstiffeq() const
+    { return 0; }
+  
+    //! Locate the stiff equations. Unused for transport.
     //! \param[in] neq number of equations
     //! \param[out] stiffeq list with 0s and 1s
     void stiffeq( std::vector< std::size_t >& stiffeq ) const
     {
       stiffeq.resize(0);
+    }
+
+    //! Locate the nonstiff equations. Unused for transport.
+    //! \param[in] neq number of equations
+    //! \param[out] nonstiffeq list with 0s and 1s
+    void nonstiffeq( std::vector< std::size_t >& nonstiffeq ) const
+    {
+      nonstiffeq.resize(0);
     }
 
     //! Determine elements that lie inside the user-defined IC box


### PR DESCRIPTION
Implemented Implicit-Explicit Runge-Kutta method. Applied it to deal with plasticity in the inverse deformation equations.

In order to compute the implicit steps, the Broyden's method was implemented to deal with the resulting non-linear systems.

Perfect plasticity was implemented in DGMultimat's stiff_rhs function.

Inputs added:
- imex_maxiter
- imex_reltol
- imex_abstol
- yield

Also made it so rho0 is now an optional input.