### PR TITLE
change where and how rho0 is stored

### DIFF
--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -134,8 +134,7 @@ DG::DG( const CProxy_Discretization& disc,
   m_pNodefieldsc(),
   m_outmesh(),
   m_boxelems(),
-  m_shockmarker(m_u.nunk(), 1),
-  m_rho0mat()
+  m_shockmarker(m_u.nunk(), 1)
 // *****************************************************************************
 //  Constructor
 //! \param[in] disc Discretization proxy
@@ -319,8 +318,6 @@ DG::box( tk::real v, const std::vector< tk::real >& )
     myGhosts()->m_fd.Esuel().size()/4 );
   g_dgpde[d->MeshId()].updatePrimitives( m_u, m_lhs, myGhosts()->m_geoElem, m_p,
     myGhosts()->m_fd.Esuel().size()/4 );
-  // Save initial densities of all materials
-  g_dgpde[d->MeshId()].setRho0mat( m_rho0mat );
 
   m_un = m_u;
 
@@ -1441,7 +1438,7 @@ DG::solve( tk::real newdt )
 
   g_dgpde[d->MeshId()].rhs( physT, myGhosts()->m_geoFace, myGhosts()->m_geoElem,
     myGhosts()->m_fd, myGhosts()->m_inpoel, m_boxelems, myGhosts()->m_coord,
-    m_u, m_p, m_ndof, m_rho0mat, d->Dt(), m_rhs );
+    m_u, m_p, m_ndof, d->Dt(), m_rhs );
 
   if (!imex_runge_kutta) {
     // Explicit time-stepping using RK3 to discretize time-derivative
@@ -1768,8 +1765,7 @@ DG::writeFields(
   // Add rho0*det(g)/rho to make sure it is staying close to 1,
   // averaged for all materials
   std::vector< tk::real > densityConstr(nelem);
-  g_dgpde[d->MeshId()].computeDensityConstr(nelem, m_u, m_rho0mat,
-                                            densityConstr);
+  g_dgpde[d->MeshId()].computeDensityConstr(nelem, m_u, densityConstr);
   for (const auto& [child,parent] : addedTets)
     densityConstr[child] = 0.0;
   if (densityConstr.size() > 0) elemfields.push_back( densityConstr );

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -273,7 +273,6 @@ class DG : public CBase_DG {
       p | m_outmesh;
       p | m_boxelems;
       p | m_shockmarker;
-      p | m_rho0mat;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -386,8 +385,6 @@ class DG : public CBase_DG {
     std::vector< std::unordered_set< std::size_t > > m_boxelems;
     //! Shock detection marker for field output
     std::vector< std::size_t > m_shockmarker;
-    //! Initial densities of each material
-    std::vector< tk::real > m_rho0mat;
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -218,21 +218,12 @@ class CompFlow {
       }
     }
 
-    //! Save initial densities for all materials
-    //! \param[out] rho0mat List of initial densities
-    void setRho0mat( std::vector< tk::real >& rho0mat ) const
-    {
-      rho0mat.resize(0);
-    }
-
     //! Compute density constraint for a given material
     // //! \param[in] nelem Number of elements
     // //! \param[in] unk Array of unknowns
-    // //! \param[in] rho0mat List of initial densities
     //! \param[out] densityConstr Density Constraint: rho/(rho0*det(g))
     void computeDensityConstr( std::size_t /*nelem*/,
                                tk::Fields& /*unk*/,
-                               std::vector< tk::real >& /*rho0mat*/,
                                std::vector< tk::real >& densityConstr) const
     {
       densityConstr.resize(0);
@@ -419,7 +410,6 @@ class CompFlow {
     //! \param[in] U Solution vector at recent time step
     //! \param[in] P Primitive vector at recent time step
     //! \param[in] ndofel Vector of local number of degrees of freedom
-    // //! \param[in] rho0mat Initial densities of all materials
     //! \param[in] dt Delta time
     //! \param[in,out] R Right-hand side vector computed
     void rhs( tk::real t,
@@ -432,7 +422,6 @@ class CompFlow {
               const tk::Fields& U,
               const tk::Fields& P,
               const std::vector< std::size_t >& ndofel,
-              const std::vector< tk::real >& /*rho0mat*/,
               const tk::real dt,
               tk::Fields& R ) const
     {

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -170,16 +170,11 @@ class DGPDE {
       const std::size_t nielem ) const
     { self->initialize( L, inpoel, coord, inbox, elemblkid, unk, t, nielem ); }
 
-    //! Public interface for saving initial densities of materials
-    void setRho0mat( std::vector< tk::real >& rho0mat) const
-    { return self->setRho0mat( rho0mat ); }
-
     //! Public interface for computing density constraint
     void computeDensityConstr( std::size_t nelem,
                                tk::Fields& unk,
-                               std::vector< tk::real >& rho0mat,
                                std::vector< tk::real >& densityConstr) const
-    { self->computeDensityConstr( nelem, unk, rho0mat, densityConstr); }
+    { self->computeDensityConstr( nelem, unk, densityConstr); }
 
     //! Public interface to computing the left-hand side matrix for the diff eq
     void lhs( const tk::Fields& geoElem, tk::Fields& l ) const
@@ -274,12 +269,11 @@ class DGPDE {
               const tk::Fields& U,
               const tk::Fields& P,
               const std::vector< std::size_t >& ndofel,
-              const std::vector< tk::real >& rho0mat,
               const tk::real dt,
               tk::Fields& R ) const
     {
       self->rhs( t, geoFace, geoElem, fd, inpoel, boxelems, coord, U, P,
-                 ndofel, rho0mat, dt, R );
+                 ndofel, dt, R );
     }
 
     //! Evaluate the adaptive indicator and mark the ndof for each element
@@ -404,10 +398,8 @@ class DGPDE {
         tk::Fields&,
         tk::real,
         const std::size_t nielem ) const = 0;
-      virtual void setRho0mat( std::vector< tk::real >& ) const = 0;
       virtual void computeDensityConstr( std::size_t nelem,
                                          tk::Fields& unk,
-                                         std::vector< tk::real >& rho0mat,
                                          std::vector< tk::real >& densityConstr)
                                          const = 0;
       virtual void lhs( const tk::Fields&, tk::Fields& ) const = 0;
@@ -470,7 +462,6 @@ class DGPDE {
                         const tk::Fields&,
                         const tk::Fields&,
                         const std::vector< std::size_t >&,
-                        const std::vector< tk::real >&,
                         const tk::real,
                         tk::Fields& ) const = 0;
       virtual void eval_ndof( std::size_t,
@@ -558,14 +549,11 @@ class DGPDE {
         const std::size_t nielem )
       const override { data.initialize( L, inpoel, coord, inbox, elemblkid, unk,
         t, nielem ); }
-      void setRho0mat( std::vector< tk::real >& rho0mat ) const override
-      { data.setRho0mat( rho0mat ); }
       void computeDensityConstr( std::size_t nelem,
                                  tk::Fields& unk,
-                                 std::vector< tk::real >& rho0mat,
                                  std::vector< tk::real >& densityConstr)
                                  const override
-      { data.computeDensityConstr( nelem, unk, rho0mat, densityConstr ); }
+      { data.computeDensityConstr( nelem, unk, densityConstr ); }
       void lhs( const tk::Fields& geoElem, tk::Fields& l ) const override
       { data.lhs( geoElem, l ); }
       void updateInterfaceCells( tk::Fields& unk,
@@ -644,12 +632,11 @@ class DGPDE {
         const tk::Fields& U,
         const tk::Fields& P,
         const std::vector< std::size_t >& ndofel,
-        const std::vector< tk::real >& rho0mat,
         const tk::real dt,
         tk::Fields& R ) const override
       {
         data.rhs( t, geoFace, geoElem, fd, inpoel, boxelems, coord, U, P,
-                  ndofel, rho0mat, dt, R );
+                  ndofel, dt, R );
       }
       void eval_ndof( std::size_t nunk,
                       const tk::UnsMesh::Coords& coord,

--- a/src/PDE/EoS/EOS.hpp
+++ b/src/PDE/EoS/EOS.hpp
@@ -54,6 +54,7 @@ class EOS {
     struct min_eff_pressure {};
     struct refDensity {};
     struct refPressure {};
+    struct rho0 {};
     //! Call EOS function
     //! \tparam Fn Function tag identifying the function to call
     //! \tparam Args Types of arguments to pass to function
@@ -89,6 +90,9 @@ class EOS {
 
           else if constexpr( std::is_same_v< Fn, refPressure > )
             return m.refPressure( std::forward< Args >( args )... );
+
+          else if constexpr( std::is_same_v< Fn, rho0 > )
+            return m.rho0( std::forward< Args >( args )... );
         }, m_material );
     }
 
@@ -108,6 +112,22 @@ class EOS {
           if constexpr( std::is_same_v< Fn, CauchyStress > )
             return m.CauchyStress( std::forward< Args >( args )... );
 
+        }, m_material );
+    }
+
+    //! Entry method tags for specific EOS classes to use with set()
+    struct setRho0 {};
+    //! Call EOS function
+    //! \tparam Fn Function tag identifying the function to call
+    //! \tparam Args Types of arguments to pass to function
+    //! \param[in] args Arguments to member function to be called
+    //! \details This function issues a call to a member function of the
+    //!   EOS vector and is thus equivalent to mat_blk[imat].Fn(...).
+    template< typename Fn, typename... Args >
+    void set( Args&&... args ) {
+      std::visit( [&]( auto& m )-> void {
+          if constexpr( std::is_same_v< Fn, setRho0 > )
+            m.setRho0( std::forward< Args >( args )... );
         }, m_material );
     }
 

--- a/src/PDE/EoS/JWL.hpp
+++ b/src/PDE/EoS/JWL.hpp
@@ -43,6 +43,9 @@ class JWL {
          tk::real tr, tk::real pr, tk::real A, tk::real B, tk::real R1,
          tk::real R2 );
 
+    //! Set rho0 EOS parameter. No-op since rho0 is set in JWL ctor
+    void setRho0(tk::real) {}
+
     //! Calculate density from the material pressure and temperature
     tk::real density( tk::real pr,
                       tk::real temp ) const;
@@ -117,6 +120,9 @@ class JWL {
     //! Compute the reference pressure
     //! \details Returns the reference pressure
     tk::real refPressure() const { return m_pr; }
+
+    //! Return initial density
+    tk::real rho0() const { return m_rho0; }
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/EoS/SmallShearSolid.cpp
+++ b/src/PDE/EoS/SmallShearSolid.cpp
@@ -53,6 +53,16 @@ SmallShearSolid::SmallShearSolid(
 // *************************************************************************
 { }
 
+void
+SmallShearSolid::setRho0( tk::real rho0 )
+// *************************************************************************
+//  Set rho0 EOS parameter; i.e. the initial density
+//! \param[in] rho0 Initial material density that needs to be stored
+// *************************************************************************
+{
+  m_rho0 = rho0;
+}
+
 tk::real
 SmallShearSolid::density(
   tk::real pr,

--- a/src/PDE/EoS/SmallShearSolid.hpp
+++ b/src/PDE/EoS/SmallShearSolid.hpp
@@ -133,6 +133,7 @@ class SmallShearSolid {
       p | m_pstiff;
       p | m_cv;
       p | m_mu;
+      p | m_rho0;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference

--- a/src/PDE/EoS/SmallShearSolid.hpp
+++ b/src/PDE/EoS/SmallShearSolid.hpp
@@ -25,7 +25,7 @@ namespace inciter {
 class SmallShearSolid {
 
   private:
-    tk::real m_gamma, m_pstiff, m_cv, m_mu;
+    tk::real m_gamma, m_pstiff, m_cv, m_mu, m_rho0;
 
     //! \brief Calculate elastic contribution to material energy from the
     //!   material density, and deformation gradient tensor
@@ -40,6 +40,8 @@ class SmallShearSolid {
     //! Constructor
     SmallShearSolid(tk::real gamma, tk::real pstiff, tk::real cv, tk::real mu );
 
+    //! Set rho0 EOS parameter; i.e. the initial density
+    void setRho0(tk::real rho0);
 
     //! Calculate density from the material pressure and temperature
     tk::real density( tk::real pr,
@@ -118,6 +120,9 @@ class SmallShearSolid {
 
     //! Compute the reference pressure
     tk::real refPressure() const { return 1.0e5; }
+
+    //! Return initial density
+    tk::real rho0() const { return m_rho0; }
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/EoS/StiffenedGas.hpp
+++ b/src/PDE/EoS/StiffenedGas.hpp
@@ -29,6 +29,8 @@ class StiffenedGas {
     //! Constructor
     StiffenedGas(tk::real gamma, tk::real pstiff, tk::real cv );
 
+    //! Set rho0 EOS parameter. No-op.
+    void setRho0(tk::real) {}
 
     //! Calculate density from the material pressure and temperature
     tk::real density( tk::real pr,
@@ -102,6 +104,9 @@ class StiffenedGas {
 
     //! Compute the reference pressure
     tk::real refPressure() const { return 1.0e5; }
+
+    //! Return initial density
+    tk::real rho0() const { return density(1.0e5, 300.0); }
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/Integrate/SolidTerms.cpp
+++ b/src/PDE/Integrate/SolidTerms.cpp
@@ -45,7 +45,6 @@ solidTermsVolInt(
                const Fields& U,
                const Fields& P,
                const std::vector< std::size_t >& ndofel,
-               const std::vector< tk::real >& rho0mat,
                const tk::real dt,
                Fields& R,
                int intsharp )
@@ -63,7 +62,6 @@ solidTermsVolInt(
 //! \param[in] U Solution vector at recent time step
 //! \param[in] P Vector of primitives at recent time step
 //! \param[in] ndofel Vector of local number of degrees of freedom
-//! \param[in] rho0mat Initial densities of all materials
 //! \param[in] dt Delta time
 //! \param[in,out] R Right-hand side vector computed
 //! \param[in] intsharp Interface compression tag, an optional argument, with
@@ -138,7 +136,7 @@ solidTermsVolInt(
 
           // Compute rhs factor
           tk::real rho = state[inciter::densityIdx(nmat, k)]/alpha;
-          tk::real rho0 = rho0mat[k];
+          tk::real rho0 = mat_blk[k].compute< inciter::EOS::rho0 >();
           tk::real rfact = eta*(rho/(rho0*tk::determinant(g))-1.0);
 
           // Compute the source terms

--- a/src/PDE/Integrate/SolidTerms.hpp
+++ b/src/PDE/Integrate/SolidTerms.hpp
@@ -37,7 +37,6 @@ solidTermsVolInt( std::size_t nmat,
                   const Fields& U,
                   const Fields& P,
                   const std::vector< std::size_t >& ndofel,
-                  const std::vector< tk::real >& rho0mat,
                   const tk::real dt,
                   Fields& R,
                   int intcompr=0 );

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -279,52 +279,12 @@ class MultiMat {
       }
     }
 
-    //! Save initial densities for all materials
-    //! \param[out] rho0mat List of initial densities
-    void setRho0mat( std::vector< tk::real >& rho0mat ) const
-    {
-      std::size_t nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
-      rho0mat.resize( nmat, 0.0 );
-      const auto& ic = g_inputdeck.get< tag::ic >();
-      const auto& icbox = ic.get< tag::box >();
-      const auto& icmbk = ic.get< tag::meshblock >();
-      // Get background properties
-      std::size_t k = ic.get< tag::materialid >() - 1;
-      tk::real pr = ic.get< tag::pressure >();
-      tk::real tmp = ic.get< tag::temperature >();
-      rho0mat[k] = m_mat_blk[k].compute< EOS::density >(pr, tmp);
-
-      // Check inside used defined box
-      if (!icbox.empty())
-      {
-        for (const auto& b : icbox) {   // for all boxes
-          k = b.template get< tag::materialid >() - 1;
-          pr = b.template get< tag::pressure >();
-          tmp = b.template get< tag::temperature >();
-          rho0mat[k] = m_mat_blk[k].compute< EOS::density >(pr, tmp);
-        }
-      }
-
-      // Check inside user-specified mesh blocks
-      if (!icmbk.empty())
-      {
-        for (const auto& b : icmbk) { // for all blocks
-          k = b.template get< tag::materialid >() - 1;
-          pr = b.template get< tag::pressure >();
-          tmp = b.template get< tag::temperature >();
-          rho0mat[k] = m_mat_blk[k].compute< EOS::density >(pr, tmp);
-        }
-      }
-    }
-
     //! Compute density constraint for a given material
     //! \param[in] nelem Number of elements
     //! \param[in] unk Array of unknowns
-    //! \param[in] rho0mat List of initial densities
     //! \param[out] densityConstr Density Constraint: rho/(rho0*det(g))
     void computeDensityConstr( std::size_t nelem,
                                tk::Fields& unk,
-                               std::vector< tk::real >& rho0mat,
                                std::vector< tk::real >& densityConstr) const
     {
       const auto& solidx = g_inputdeck.get< tag::matidxmap, tag::solidx >();
@@ -346,7 +306,7 @@ class MultiMat {
             // Compute determinant of g
             tk::real detg = tk::determinant(g);
             // Compute constraint measure
-            densityConstr[e] += arho/(rho0mat[imat]*detg);
+            densityConstr[e] += arho/(m_mat_blk[imat].compute< EOS::rho0 >()*detg);
           }
         }
         else
@@ -809,7 +769,6 @@ class MultiMat {
     //! \param[in] U Solution vector at recent time step
     //! \param[in] P Primitive vector at recent time step
     //! \param[in] ndofel Vector of local number of degrees of freedom
-    //! \param[in] rho0mat Initial densities of all materials
     //! \param[in] dt Delta time
     //! \param[in,out] R Right-hand side vector computed
     void rhs( tk::real t,
@@ -822,7 +781,6 @@ class MultiMat {
               const tk::Fields& U,
               const tk::Fields& P,
               const std::vector< std::size_t >& ndofel,
-              const std::vector< tk::real >& rho0mat,
               const tk::real dt,
               tk::Fields& R ) const
     {
@@ -919,7 +877,7 @@ class MultiMat {
         g_inputdeck.get< tag::multimat, tag::rho0constraint >())
         tk::solidTermsVolInt( nmat, m_mat_blk, ndof, rdof, nelem,
                               inpoel, coord, geoElem, U, P, ndofel,
-                              rho0mat, dt, R);
+                              dt, R);
 
       // compute finite pressure relaxation terms
       if (g_inputdeck.get< tag::multimat, tag::prelax >())

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -158,21 +158,12 @@ class Transport {
                       Problem::initialize, unk, t, nielem );
     }
 
-    //! Save initial densities for all materials
-    //! \param[out] rho0mat List of initial densities
-    void setRho0mat( std::vector< tk::real >& rho0mat ) const
-    {
-      rho0mat.resize(0);
-    }
-
     //! Compute density constraint for a given material
     // //! \param[in] nelem Number of elements
     // //! \param[in] unk Array of unknowns
-    // //! \param[in] rho0mat List of initial densities
     //! \param[out] densityConstr Density Constraint: rho/(rho0*det(g))
     void computeDensityConstr( std::size_t /*nelem*/,
                                tk::Fields& /*unk*/,
-                               std::vector< tk::real >& /*rho0mat*/,
                                std::vector< tk::real >& densityConstr) const
     {
       densityConstr.resize(0);
@@ -368,7 +359,6 @@ class Transport {
     //! \param[in] U Solution vector at recent time step
     //! \param[in] P Primitive vector at recent time step
     //! \param[in] ndofel Vector of local number of degrees of freedom
-    // //! \param[in] rho0mat Initial densities of all materials
     //! \param[in] dt Delta time
     //! \param[in,out] R Right-hand side vector computed
     void rhs( tk::real t,
@@ -381,7 +371,6 @@ class Transport {
               const tk::Fields& U,
               const tk::Fields& P,
               const std::vector< std::size_t >& ndofel,
-              const std::vector< tk::real >& /*rho0mat*/,
               const tk::real dt,
               tk::Fields& R ) const
     {


### PR DESCRIPTION
This commit changes the storage of `rho0mat` from DG to the `mat_blk` (i.e. EOS-block). This is appropriate since EOS may require access to `rho0`, which shouldn't have to be passed to the EOS, but stored in it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/619)
<!-- Reviewable:end -->
