### PR TITLE
remove inlet from BC config loop in MultiSpecies

### DIFF
--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -78,7 +78,6 @@ class MultiSpecies {
         // BC State functions
         { dirichlet
         , symmetry
-        , invalidBC         // Inlet BC not implemented
         , invalidBC         // Outlet BC not implemented
         , farfield
         , extrapolate
@@ -86,7 +85,6 @@ class MultiSpecies {
         // BC Gradient functions
         { noOpGrad
         , symmetryGrad
-        , noOpGrad
         , noOpGrad
         , noOpGrad
         , noOpGrad


### PR DESCRIPTION
Fixes bug where MultiSpecies has wrong BCs and fails tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/639)
<!-- Reviewable:end -->
