### PR TITLE
Fix multispecies index error (dgp1)

### DIFF
--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -851,9 +851,9 @@ class MultiSpecies {
         rhob += ugp[multispecies::densityIdx(nspec, k)];
 
       std::array< tk::real, 3 > u{{
+        ugp[multispecies::momentumIdx(nspec,0)] / rhob,
         ugp[multispecies::momentumIdx(nspec,1)] / rhob,
-        ugp[multispecies::momentumIdx(nspec,2)] / rhob,
-        ugp[multispecies::momentumIdx(nspec,3)] / rhob }};
+        ugp[multispecies::momentumIdx(nspec,2)] / rhob }};
       auto rhoE0 = ugp[multispecies::energyIdx(nspec,0)];
       auto p = mat_blk[0].compute< EOS::pressure >( rhob, u[0], u[1], u[2],
         rhoE0 );


### PR DESCRIPTION
Bug in indexing the state vector (with momentumIdx) when running multispecies, dgp1.

After fixing, can run the standing Mach 8 normal shock problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/649)
<!-- Reviewable:end -->
