### PR TITLE
tpg handle wider temperature bounds, add clipping

### DIFF
--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -188,7 +188,7 @@ ThermallyPerfectGas::temperature(
 
   // Solve for temperature - Newton's method
   tk::real temp = 1500;     // Starting guess
-  tk::real tol = std::max(1e-8, 1e-8 * std::abs(e)); // Stopping condition
+  tk::real tol = std::max(1e-8, 1e-8 * e); // Stopping condition
   tk::real err;
   std::size_t maxiter = 10;
   std::size_t i(0);

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -153,17 +153,10 @@ ThermallyPerfectGas::totalenergy(
   auto R = m_R;
 
   tk::real temp = pr / (rho * R);
-  // Identify what temperature range this falls in
-  std::size_t t_rng_idx = get_t_range(temp);
 
   // h = h_poly(T) + h_ref = e + R T (perfect gas)
-  tk::real e = R * (-m_cp_coeff[t_rng_idx][0] * std::pow(temp, -1) +
-      m_cp_coeff[t_rng_idx][1] * std::log(temp) + (m_cp_coeff[t_rng_idx][2] - 1) * temp +
-      m_cp_coeff[t_rng_idx][3] * std::pow(temp, 2) / 2 +
-      m_cp_coeff[t_rng_idx][4] * std::pow(temp, 3) / 3 +
-      m_cp_coeff[t_rng_idx][5] * std::pow(temp, 4) / 4 +
-      m_cp_coeff[t_rng_idx][6] * std::pow(temp, 5) / 5 + m_cp_coeff[t_rng_idx][7]) +
-      m_dH_ref;
+  auto h = calc_h(temp) * R * temp; // dimensionalize the results out of the calc_h func
+  tk::real e = h - R * temp;
 
   return (rho * e + 0.5 * rho * (u*u + v*v + w*w));
 }
@@ -199,30 +192,15 @@ ThermallyPerfectGas::temperature(
   std::size_t maxiter = 10;
   std::size_t i(0);
   while (i < maxiter) {
-    // Identify what temperature range the current guess is in
-    std::size_t t_rng_idx = get_t_range(temp);
-
-    // With correct polynomial coefficients, construct e(temp) and de(temp)/dT
-    tk::real f_T = R * (-m_cp_coeff[t_rng_idx][0] * std::pow(temp, -1) +
-      m_cp_coeff[t_rng_idx][1] * std::log(temp) + (m_cp_coeff[t_rng_idx][2] - 1) * temp +
-      m_cp_coeff[t_rng_idx][3] * std::pow(temp, 2) / 2 +
-      m_cp_coeff[t_rng_idx][4] * std::pow(temp, 3) / 3 +
-      m_cp_coeff[t_rng_idx][5] * std::pow(temp, 4) / 4 +
-      m_cp_coeff[t_rng_idx][6] * std::pow(temp, 5) / 5 + m_cp_coeff[t_rng_idx][7]) +
-      m_dH_ref - e;
+    // Construct e(temp) and de(temp)/dT
+    tk::real h = calc_h(temp) * R * temp;
+    tk::real f_T = h - R * temp - e;
 
     err = abs(f_T);
 
-    // Get derivative - df/dT. For loop is working through polynomial.
-    tk::real fp_T = 0;
-    tk::real power = -2;
-    for (std::size_t k=0; k<m_cp_coeff[t_rng_idx].size()-1; ++k)
-    {
-      fp_T += m_cp_coeff[t_rng_idx][k] * std::pow(temp, power);
-      if (k == 2) fp_T += -1;
-      power += 1;
-    }
-    fp_T = fp_T * R;
+    // Get derivative - df/dT.
+    tk::real cp = calc_cp(temp) * R;
+    tk::real fp_T = cp - R;
 
     // Calculate next guess
     temp = temp - f_T / fp_T;

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -187,7 +187,7 @@ ThermallyPerfectGas::temperature(
 
   // Solve for temperature - Newton's method
   tk::real temp = 1500;     // Starting guess
-  tk::real tol = 1e-8 * std::abs(e); // Stopping condition
+  tk::real tol = std::max(1e-8, 1e-8 * std::abs(e)); // Stopping condition
   tk::real err;
   std::size_t maxiter = 10;
   std::size_t i(0);

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -125,7 +125,8 @@ ThermallyPerfectGas::soundspeed(
 {
   auto g = m_gamma;
 
-  tk::real a = std::sqrt( g * pr / rho );
+  auto p_eff = std::max( 1.0e-15, pr );
+  tk::real a = std::sqrt( g * p_eff / rho );
 
   return a;
 }

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -193,7 +193,7 @@ ThermallyPerfectGas::temperature(
 
   // Solve for temperature - Newton's method
   tk::real temp = 1500;     // Starting guess
-  tk::real tol = 1e-8 * e; // Stopping condition
+  tk::real tol = 1e-8 * std::abs(e); // Stopping condition
   tk::real err;
   std::size_t maxiter = 10;
   std::size_t i(0);

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -184,6 +184,7 @@ ThermallyPerfectGas::temperature(
 
   // Solve for internal energy
   tk::real e = rhoE / rho - 0.5 * (u*u + v*v + w*w);
+  if (e < 1e-8) e = 1e-8; // TODO: standin until positivity is implemented
 
   // Solve for temperature - Newton's method
   tk::real temp = 1500;     // Starting guess

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -155,7 +155,7 @@ ThermallyPerfectGas::totalenergy(
   tk::real temp = pr / (rho * R);
 
   // h = h_poly(T) + h_ref = e + R T (perfect gas)
-  auto h = calc_h(temp) * R * temp; // dimensionalize the results out of the calc_h func
+  auto h = calc_h(temp) * R * temp + m_dH_ref; // dimensionalize the results out of the calc_h func
   tk::real e = h - R * temp;
 
   return (rho * e + 0.5 * rho * (u*u + v*v + w*w));
@@ -194,7 +194,7 @@ ThermallyPerfectGas::temperature(
   std::size_t i(0);
   while (i < maxiter) {
     // Construct e(temp) and de(temp)/dT
-    tk::real h = calc_h(temp) * R * temp;
+    tk::real h = calc_h(temp) * R * temp + m_dH_ref;
     tk::real f_T = h - R * temp - e;
 
     err = abs(f_T);

--- a/src/PDE/EoS/ThermallyPerfectGas.hpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.hpp
@@ -77,7 +77,7 @@ class ThermallyPerfectGas {
           m_cp_coeff[t_rng_idx][4] * std::pow(temp_poly, 2) / 3. +
           m_cp_coeff[t_rng_idx][5] * std::pow(temp_poly, 3) / 4. +
           m_cp_coeff[t_rng_idx][6] * std::pow(temp_poly, 4) / 5. +
-          m_cp_coeff[t_rng_idx][7] / temp_poly + m_dH_ref;
+          m_cp_coeff[t_rng_idx][7] / temp_poly;
 
       // If bounds exceeded, apply correction to enthalpy
       if (correction_needed) {

--- a/src/PDE/EoS/ThermallyPerfectGas.hpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.hpp
@@ -28,9 +28,9 @@ class ThermallyPerfectGas {
 
     std::size_t get_t_range(tk::real temp) const
     // *************************************************************************
-    //! Check what temperature range the given temperature is in.
-    //! A check should be performed before this to make sure the bounds are not
-    //! violated.
+    //! \brief Check what temperature range the given temperature is in.
+    //!   A check should be performed before this to make sure the bounds
+    //!   are not violated.
     //! \param[in] temp Given temperature to be checked for range
     //! \return Index of temperature range the given temperature is in
     // *************************************************************************

--- a/src/PDE/EoS/ThermallyPerfectGas.hpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.hpp
@@ -35,7 +35,7 @@ class ThermallyPerfectGas {
     {
       tk::real fdg = 0.1; // Fudge factor to accomodate numerical overshoot
       if (temp < m_t_range[0] * (1 - fdg) || temp > m_t_range.back() * (1 + fdg)) {
-        Throw("ThermallyPerfectGas totalenergy temperature outside t_range bounds: "
+        Throw("ThermallyPerfectGas temperature outside t_range bounds: "
         + std::to_string(temp));
       }
 

--- a/src/PDE/EoS/ThermallyPerfectGas.hpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.hpp
@@ -56,6 +56,49 @@ class ThermallyPerfectGas {
       return t_rng_idx;
     }
 
+    tk::real calc_h(tk::real temp) const
+    // *************************************************************************
+    //! Calculate dimensionless enthalpy according to the NASA-9 polynomial
+    //! \param[in] temp temperature at which to calculate enthalpy
+    //! \return dimensionless enthalpy, h / (R * T)
+    // *************************************************************************
+    {
+      // Identify what temperature range this falls in
+      std::size_t t_rng_idx = get_t_range(temp);
+
+      // h = h_poly(T) + h_ref
+      tk::real h = -m_cp_coeff[t_rng_idx][0] * std::pow(temp, -2) +
+          m_cp_coeff[t_rng_idx][1] * std::log(temp) / temp +
+          m_cp_coeff[t_rng_idx][2] +
+          m_cp_coeff[t_rng_idx][3] * temp / 2. +
+          m_cp_coeff[t_rng_idx][4] * std::pow(temp, 2) / 3. +
+          m_cp_coeff[t_rng_idx][5] * std::pow(temp, 3) / 4. +
+          m_cp_coeff[t_rng_idx][6] * std::pow(temp, 4) / 5. +
+          m_cp_coeff[t_rng_idx][7] / temp + m_dH_ref;
+
+      return h;
+    }
+
+    tk::real calc_cp(tk::real temp) const
+    // *************************************************************************
+    //! Calculate dimensionless specific heat according to the NASA-9 polynomial
+    //! \param[in] temp temperature at which to calculate specific heat
+    //! \return dimensionless enthalpy, c_p / R
+    // *************************************************************************
+    {
+      // Identify what temperature range this falls in
+      std::size_t t_rng_idx = get_t_range(temp);
+
+      tk::real cp = m_cp_coeff[t_rng_idx][0] * std::pow(temp, -2) +
+          m_cp_coeff[t_rng_idx][1] / temp +
+          m_cp_coeff[t_rng_idx][2] +
+          m_cp_coeff[t_rng_idx][3] * temp +
+          m_cp_coeff[t_rng_idx][4] * std::pow(temp, 2) +
+          m_cp_coeff[t_rng_idx][5] * std::pow(temp, 3) +
+          m_cp_coeff[t_rng_idx][6] * std::pow(temp, 4);
+
+      return cp;
+    }
 
   public:
     //! Default constructor


### PR DESCRIPTION
Addresses some necessary changes to get more difficult TPG cases to run (hypersonic cylinder). In those cases, the energy dips significantly when initializing the run. To address this:

1) The hard bounds on the temperature range are removed. Instead, corrections are applied cp, enthalpy, to avoid a poor extrapolation of the NASA polynomials. The implementation follows what is described in the FUN3D manual:
![image](https://github.com/user-attachments/assets/552cbc4f-d183-4a7d-9d9c-7d583f872455)
To avoid repeating code, the functions for cp and enthalpy are moved into the .hpp file, where they are now treated in nondimensional form (which is the form originally given in the McBride paper with the NASA coefficients).

2) Clipping is applied to negative internal energies when calculating temperature. This is intended as a standin until a positivity preserver is implemented elsewhere in the code. Clipping is also applied to negative pressures when calculating sound speed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/650)
<!-- Reviewable:end -->
