### PR TITLE
Overset symmetry bug

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -50,7 +50,8 @@ using bclist = tk::TaggedTuple< brigand::list<
   tag::outlet,      std::vector< std::size_t >,
   tag::farfield,    std::vector< std::size_t >,
   tag::extrapolate, std::vector< std::size_t >,
-  tag::noslipwall,  std::vector< std::size_t >
+  tag::noslipwall,  std::vector< std::size_t >,
+  tag::slipwall,    std::vector< std::size_t >
 > >;
 
 // Transport
@@ -146,6 +147,7 @@ using bcList = tk::TaggedTuple< brigand::list<
   tag::farfield,    std::vector< std::size_t >,
   tag::extrapolate, std::vector< std::size_t >,
   tag::noslipwall,  std::vector< std::size_t >,
+  tag::slipwall,    std::vector< std::size_t >,
   tag::velocity,    std::vector< tk::real >,
   tag::pressure,    tk::real,
   tag::density,     tk::real,
@@ -1728,6 +1730,11 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
       keywords.insert({"noslipwall",
         "List sidesets with no-slip wall boundary conditions",
         R"(This keyword is used to list (multiple) no-slip wall BC sidesets.)",
+        "vector of uint(s)"});
+
+      keywords.insert({"slipwall",
+        "List sidesets with slip wall boundary conditions",
+        R"(This keyword is used to list (multiple) slip wall BC sidesets.)",
         "vector of uint(s)"});
 
       keywords.insert({"timedep",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -50,7 +50,8 @@ using bclist = tk::TaggedTuple< brigand::list<
   tag::outlet,      std::vector< std::size_t >,
   tag::farfield,    std::vector< std::size_t >,
   tag::extrapolate, std::vector< std::size_t >,
-  tag::noslipwall,  std::vector< std::size_t >
+  tag::noslipwall,  std::vector< std::size_t >,
+  tag::slipwall,    std::vector< std::size_t >
 > >;
 
 // Transport

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -50,8 +50,7 @@ using bclist = tk::TaggedTuple< brigand::list<
   tag::outlet,      std::vector< std::size_t >,
   tag::farfield,    std::vector< std::size_t >,
   tag::extrapolate, std::vector< std::size_t >,
-  tag::noslipwall,  std::vector< std::size_t >,
-  tag::slipwall,    std::vector< std::size_t >
+  tag::noslipwall,  std::vector< std::size_t >
 > >;
 
 // Transport

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -1253,6 +1253,9 @@ LuaParser::storeInputDeck(
       storeVecIfSpecd< uint64_t >(sol_bc[i+1], "noslipwall",
         bc_deck[i].get< tag::noslipwall >(), {});
 
+      storeVecIfSpecd< uint64_t >(sol_bc[i+1], "slipwall",
+        bc_deck[i].get< tag::slipwall >(), {});
+
       // Time-dependent BC
       if (sol_bc[i+1]["timedep"].valid()) {
         const sol::table& sol_tdbc = sol_bc[i+1]["timedep"];

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -291,6 +291,7 @@ DEFTAG(farfield);
 DEFTAG(extrapolate);
 DEFTAG(noslipwall);
 DEFTAG(timedep);
+DEFTAG(slipwall);
 
 DEFTAG(rigid_body_motion);
 DEFTAG(rigid_body_movt);

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -81,6 +81,7 @@ ALECG::ALECG( const CProxy_Discretization& disc,
   m_bnormc(),
   m_symbcnodes(),
   m_farfieldbcnodes(),
+  m_slipwallbcnodes(),
   m_symbctri(),
   m_timedepbcnodes(),
   m_timedepbcFn(),
@@ -173,13 +174,28 @@ ALECG::queryBnd()
   for (const auto& [s,nodes] : far)
     m_farfieldbcnodes.insert( begin(nodes), end(nodes) );
 
-  // If farfield BC is set on a node, will not also set symmetry BC
-  for (auto fn : m_farfieldbcnodes) m_symbcnodes.erase(fn);
+  // Prepare unique set of slip wall BC nodes
+  auto slip = d->bcnodes< tag::slipwall >( m_bface, m_triinpoel );
+  for (const auto& [s,nodes] : slip)
+    m_slipwallbcnodes.insert( begin(nodes), end(nodes) );
 
-  // Prepare boundary nodes contiguously accessible from a triangle-face loop
+  // If farfield BC is set on a node, will not also set symmetry and slip BC
+  for (auto fn : m_farfieldbcnodes) {
+    m_symbcnodes.erase(fn);
+    m_slipwallbcnodes.erase(fn);
+  }
+
+  // If symmetry BC is set on a node, will not also set slip BC
+  for (auto fn : m_symbcnodes) {
+    m_slipwallbcnodes.erase(fn);
+  }
+
+  // Prepare boundary nodes contiguously accessible from a triangle-face loop,
+  // which contain both symmetry and no slip walls
   m_symbctri.resize( m_triinpoel.size()/3, 0 );
   for (std::size_t e=0; e<m_triinpoel.size()/3; ++e)
-    if (m_symbcnodes.find(m_triinpoel[e*3+0]) != end(m_symbcnodes))
+    if (m_symbcnodes.find(m_triinpoel[e*3+0]) != end(m_symbcnodes) ||
+        m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes))
       m_symbctri[e] = 1;
 
   // Prepare unique set of time dependent BC nodes
@@ -874,6 +890,10 @@ ALECG::BC()
   // Apply farfield BCs
   g_cgpde[d->MeshId()].farfieldbc( m_u, coord, m_bnorm, m_farfieldbcnodes );
 
+  // Apply slip wall BCs
+  g_cgpde[d->MeshId()].slipwallbc( m_u, d->meshvel(), coord, m_bnorm,
+    m_slipwallbcnodes );
+
   // Apply user defined time dependent BCs
   g_cgpde[d->MeshId()].timedepbc( d->T(), m_u, m_timedepbcnodes,
     m_timedepbcFn );
@@ -1201,7 +1221,8 @@ ALECG::ale()
     conserved( m_u, Disc()->Vol() );
     conserved( m_un, Disc()->Voln() );
     auto diag_computed = m_diag.compute( *d, m_u, m_un, m_bnorm,
-                                         m_symbcnodes, m_farfieldbcnodes );
+                                          m_symbcnodes, m_farfieldbcnodes,
+                                          m_slipwallbcnodes );
     volumetric( m_u, Disc()->Vol() );
     volumetric( m_un, Disc()->Voln() );
     // Increase number of iterations and physical time

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -869,7 +869,7 @@ ALECG::BC()
       if (bc[c].first) m_u(b,c) = bc[c].second;
 
   // Apply symmetry BCs
-  g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
+  g_cgpde[d->MeshId()].symbc( m_u, d->meshvel(), coord, m_bnorm, m_symbcnodes );
 
   // Apply farfield BCs
   g_cgpde[d->MeshId()].farfieldbc( m_u, coord, m_bnorm, m_farfieldbcnodes );

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -869,7 +869,7 @@ ALECG::BC()
       if (bc[c].first) m_u(b,c) = bc[c].second;
 
   // Apply symmetry BCs
-  g_cgpde[d->MeshId()].symbc( m_u, coord, m_bnorm, m_symbcnodes );
+  g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
 
   // Apply farfield BCs
   g_cgpde[d->MeshId()].farfieldbc( m_u, coord, m_bnorm, m_farfieldbcnodes );

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -885,7 +885,7 @@ ALECG::BC()
       if (bc[c].first) m_u(b,c) = bc[c].second;
 
   // Apply symmetry BCs
-  g_cgpde[d->MeshId()].symbc( m_u, d->meshvel(), coord, m_bnorm, m_symbcnodes );
+  g_cgpde[d->MeshId()].symbc( m_u, coord, m_bnorm, m_symbcnodes );
 
   // Apply farfield BCs
   g_cgpde[d->MeshId()].farfieldbc( m_u, coord, m_bnorm, m_farfieldbcnodes );

--- a/src/Inciter/ALECG.hpp
+++ b/src/Inciter/ALECG.hpp
@@ -234,6 +234,7 @@ class ALECG : public CBase_ALECG {
       p | m_bnormc;
       p | m_symbcnodes;
       p | m_farfieldbcnodes;
+      p | m_slipwallbcnodes;
       p | m_symbctri;
       p | m_timedepbcnodes;
       p | m_timedepbcFn;
@@ -334,6 +335,8 @@ class ALECG : public CBase_ALECG {
     std::unordered_set< std::size_t > m_symbcnodes;
     //! Unique set of nodes at which farfield BCs are set
     std::unordered_set< std::size_t > m_farfieldbcnodes;
+    //! Unique set of nodes at which slip wall BCs are set
+    std::unordered_set< std::size_t > m_slipwallbcnodes;
     //! Vector with 1 at symmetry BC boundary triangles
     std::vector< int > m_symbctri;
     //! \brief Unique set of nodes at which time dependent BCs are set

--- a/src/Inciter/ALECG.hpp
+++ b/src/Inciter/ALECG.hpp
@@ -236,6 +236,7 @@ class ALECG : public CBase_ALECG {
       p | m_farfieldbcnodes;
       p | m_slipwallbcnodes;
       p | m_symbctri;
+      p | m_slipwallbctri;
       p | m_timedepbcnodes;
       p | m_timedepbcFn;
       p | m_stage;
@@ -339,6 +340,8 @@ class ALECG : public CBase_ALECG {
     std::unordered_set< std::size_t > m_slipwallbcnodes;
     //! Vector with 1 at symmetry BC boundary triangles
     std::vector< int > m_symbctri;
+    //! Vector with 1 at slip wall BC boundary triangles
+    std::vector< int > m_slipwallbctri;
     //! \brief Unique set of nodes at which time dependent BCs are set
     //    for each time dependent BC
     std::vector< std::unordered_set< std::size_t > > m_timedepbcnodes;

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -107,7 +107,7 @@ NodeDiagnostics::compute(
       for (std::size_t c=0; c<an.nprop(); ++c) an(i,c) = a[c];
     }
     // Apply symmetry BCs on analytic solution (if exist, if not, IC)
-    g_cgpde[d.MeshId()].symbc( an, mv, coord, bnorm, symbcnodes );
+    g_cgpde[d.MeshId()].symbc( an, coord, bnorm, symbcnodes );
     // Apply farfield BCs on analytic solution (if exist, if not, IC)
     g_cgpde[d.MeshId()].farfieldbc( an, coord, bnorm, farfieldbcnodes );
     // Apply slip wall BCs on analytic solution (if exist, if not, IC)

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -95,6 +95,7 @@ NodeDiagnostics::compute(
 
     // Evaluate analytic solution (if exist, if not, IC)
     auto an = u;
+    auto mv = d.MeshVel();
     for (std::size_t i=0; i<an.nunk(); ++i) {
       // Query analytic solution for all components of all PDEs integrated
       std::vector< tk::real > a;
@@ -104,7 +105,7 @@ NodeDiagnostics::compute(
       for (std::size_t c=0; c<an.nprop(); ++c) an(i,c) = a[c];
     }
     // Apply symmetry BCs on analytic solution (if exist, if not, IC)
-    g_cgpde[d.MeshId()].symbc( an, coord, bnorm, symbcnodes );
+    g_cgpde[d.MeshId()].symbc( an, mv, coord, bnorm, symbcnodes );
     // Apply farfield BCs on analytic solution (if exist, if not, IC)
     g_cgpde[d.MeshId()].farfieldbc( an, coord, bnorm, farfieldbcnodes );
 

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -95,7 +95,7 @@ NodeDiagnostics::compute(
 
     // Evaluate analytic solution (if exist, if not, IC)
     auto an = u;
-    auto mv = d.meshvel();
+    auto mv = d.MeshVel();
     for (std::size_t i=0; i<an.nunk(); ++i) {
       // Query analytic solution for all components of all PDEs integrated
       std::vector< tk::real > a;

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -95,7 +95,7 @@ NodeDiagnostics::compute(
 
     // Evaluate analytic solution (if exist, if not, IC)
     auto an = u;
-    auto mv = d.MeshVel();
+    auto mv = d.meshvel();
     for (std::size_t i=0; i<an.nunk(); ++i) {
       // Query analytic solution for all components of all PDEs integrated
       std::vector< tk::real > a;

--- a/src/Inciter/NodeDiagnostics.cpp
+++ b/src/Inciter/NodeDiagnostics.cpp
@@ -53,7 +53,8 @@ NodeDiagnostics::compute(
   const std::unordered_map< int,
           std::unordered_map< std::size_t, std::array< tk::real, 4 > > >& bnorm,
   const std::unordered_set< std::size_t >& symbcnodes,
-  const std::unordered_set< std::size_t >& farfieldbcnodes ) const
+  const std::unordered_set< std::size_t >& farfieldbcnodes,
+  const std::unordered_set< std::size_t >& slipwallbcnodes ) const
 // *****************************************************************************
 //  Compute diagnostics, e.g., residuals, norms of errors, etc.
 //! \param[in] d Discretization proxy to read from
@@ -64,6 +65,7 @@ NodeDiagnostics::compute(
 //! \param[in] symbcnodes Unique set of node ids at which to set symmetry BCs
 //! \param[in] farfieldbcnodes Unique set of node ids at which to set farfield
 //!   BCs
+//! \param[in] slipwallbcnodes Unique set of node ids at which to set slip BCs
 //! \return True if diagnostics have been computed
 //! \details Diagnostics are defined as some norm, e.g., L2 norm, of a quantity,
 //!   computed in mesh nodes, A, as ||A||_2 = sqrt[ sum_i(A_i)^2 V_i ],
@@ -108,6 +110,8 @@ NodeDiagnostics::compute(
     g_cgpde[d.MeshId()].symbc( an, mv, coord, bnorm, symbcnodes );
     // Apply farfield BCs on analytic solution (if exist, if not, IC)
     g_cgpde[d.MeshId()].farfieldbc( an, coord, bnorm, farfieldbcnodes );
+    // Apply slip wall BCs on analytic solution (if exist, if not, IC)
+    g_cgpde[d.MeshId()].slipwallbc( an, mv, coord, bnorm, slipwallbcnodes );
 
     // Put in norms sweeping our mesh chunk
     for (std::size_t i=0; i<u.nunk(); ++i) {

--- a/src/Inciter/NodeDiagnostics.hpp
+++ b/src/Inciter/NodeDiagnostics.hpp
@@ -36,7 +36,8 @@ class NodeDiagnostics {
       const std::unordered_map< int,
         std::unordered_map< std::size_t, std::array< tk::real, 4 > > >& bnorm,
       const std::unordered_set< std::size_t >& symbcnodes,
-      const std::unordered_set< std::size_t >& farfieldbcnodes ) const;
+      const std::unordered_set< std::size_t >& farfieldbcnodes,
+      const std::unordered_set< std::size_t >& slipwallbcnodes ) const;
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -1300,9 +1300,9 @@ OversetFE::solve()
         // rotation (this is currently only configured for planar motion)
         // ---------------------------------------------------------------------
         std::array< tk::real, 3 > rCM{{
-          d->Coord()[0][p] - m_centMassn[0],
-          d->Coord()[1][p] - m_centMassn[1],
-          d->Coord()[2][p] - m_centMassn[2] }};
+          d->Coordn()[0][p] - m_centMassn[0],
+          d->Coordn()[1][p] - m_centMassn[1],
+          d->Coordn()[2][p] - m_centMassn[2] }};
 
         // obtain tangential velocity
         tk::real r_mag(0.0);

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -928,7 +928,7 @@ OversetFE::BC()
             if (bc[c].first) m_u(b,c) = bc[c].second;
 
         // Apply symmetry BCs
-        g_cgpde[d->MeshId()].symbc( m_u, coord, m_bnorm, m_symbcnodes );
+        g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
 
         // Apply farfield BCs
         if (bci.get< tag::farfield >().empty() || (d->MeshId() == 0)) {

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -928,7 +928,7 @@ OversetFE::BC()
             if (bc[c].first) m_u(b,c) = bc[c].second;
 
         // Apply symmetry BCs
-        g_cgpde[d->MeshId()].symbc( m_u, d->meshvel(), coord, m_bnorm, m_symbcnodes );
+        g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
 
         // Apply farfield BCs
         if (bci.get< tag::farfield >().empty() || (d->MeshId() == 0)) {
@@ -1130,7 +1130,7 @@ OversetFE::rhs()
   g_cgpde[d->MeshId()].rhs( d->T() + prev_rkcoef * d->Dt(), d->Coord(), d->Inpoel(),
           m_triinpoel, d->Gid(), d->Bid(), d->Lid(), m_dfn, m_psup, m_esup,
           m_symbctri, d->Vol(), m_edgenode, m_edgeid,
-          m_boxnodes, m_chBndGrad, m_u, d->meshvel(), m_tp, d->Boxvol(),
+          m_boxnodes, m_chBndGrad, m_u, d->MeshVel(), m_tp, d->Boxvol(),
           m_rhs );
   if (steady)
     for (std::size_t p=0; p<m_tp.size(); ++p) m_tp[p] -= prev_rkcoef * m_dtp[p];

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -955,7 +955,7 @@ OversetFE::BC()
             if (bc[c].first) m_u(b,c) = bc[c].second;
 
         // Apply symmetry BCs
-        g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
+        g_cgpde[d->MeshId()].symbc( m_u, coord, m_bnorm, m_symbcnodes );
 
         // Apply farfield BCs
         if (bci.get< tag::farfield >().empty() || (d->MeshId() == 0)) {

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -203,8 +203,7 @@ OversetFE::getBCNodes()
   // which contain both symmetry and no slip walls
   m_symbctri.resize( m_triinpoel.size()/3, 0 );
   for (std::size_t e=0; e<m_triinpoel.size()/3; ++e)
-    if (m_symbcnodes.find(m_triinpoel[e*3+0]) != end(m_symbcnodes) ||
-        m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes))
+    if (m_symbcnodes.find(m_triinpoel[e*3+0]) != end(m_symbcnodes))
       m_symbctri[e] = 1;
 
   // Prepare the above for slip walls, which are needed for pressure integrals
@@ -1171,7 +1170,7 @@ OversetFE::rhs()
     for (std::size_t p=0; p<m_tp.size(); ++p) m_tp[p] += prev_rkcoef * m_dtp[p];
   g_cgpde[d->MeshId()].rhs( d->T() + prev_rkcoef * d->Dt(), d->Coord(), d->Inpoel(),
           m_triinpoel, d->Gid(), d->Bid(), d->Lid(), m_dfn, m_psup, m_esup,
-          m_symbctri, d->Vol(), m_edgenode, m_edgeid,
+          m_symbctri, m_slipwallbctri, d->Vol(), m_edgenode, m_edgeid,
           m_boxnodes, m_chBndGrad, m_u, d->MeshVel(), m_tp, d->Boxvol(),
           m_rhs );
   if (steady)

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -928,7 +928,7 @@ OversetFE::BC()
             if (bc[c].first) m_u(b,c) = bc[c].second;
 
         // Apply symmetry BCs
-        g_cgpde[d->MeshId()].symbc( m_u, d->MeshVel(), coord, m_bnorm, m_symbcnodes );
+        g_cgpde[d->MeshId()].symbc( m_u, d->meshvel(), coord, m_bnorm, m_symbcnodes );
 
         // Apply farfield BCs
         if (bci.get< tag::farfield >().empty() || (d->MeshId() == 0)) {
@@ -1130,7 +1130,7 @@ OversetFE::rhs()
   g_cgpde[d->MeshId()].rhs( d->T() + prev_rkcoef * d->Dt(), d->Coord(), d->Inpoel(),
           m_triinpoel, d->Gid(), d->Bid(), d->Lid(), m_dfn, m_psup, m_esup,
           m_symbctri, d->Vol(), m_edgenode, m_edgeid,
-          m_boxnodes, m_chBndGrad, m_u, d->MeshVel(), m_tp, d->Boxvol(),
+          m_boxnodes, m_chBndGrad, m_u, d->meshvel(), m_tp, d->Boxvol(),
           m_rhs );
   if (steady)
     for (std::size_t p=0; p<m_tp.size(); ++p) m_tp[p] -= prev_rkcoef * m_dtp[p];

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -1311,7 +1311,7 @@ OversetFE::solve()
           // mesh displacement from translation
           dsT = m_centMassVel[i]*dtp + 0.5*a_mesh[i]*dtp*dtp;
           // mesh displacement from rotation
-          dsR = rCM[i] + m_centMass[i] - d->Coord()[i][p];
+          dsR = rCM[i] + m_centMass[i] - d->Coordn()[i][p];
           // add both contributions
           d->Coord()[i][p] = d->Coordn()[i][p] + dsT + dsR;
           // mesh velocity change from translation

--- a/src/Inciter/OversetFE.hpp
+++ b/src/Inciter/OversetFE.hpp
@@ -222,7 +222,9 @@ class OversetFE : public CBase_OversetFE {
       p | m_bnormc;
       p | m_symbcnodes;
       p | m_farfieldbcnodes;
+      p | m_slipwallbcnodes;
       p | m_symbctri;
+      p | m_slipwallbctri;
       p | m_timedepbcnodes;
       p | m_timedepbcFn;
       p | m_stage;
@@ -338,8 +340,12 @@ class OversetFE : public CBase_OversetFE {
     std::unordered_set< std::size_t > m_symbcnodes;
     //! Unique set of nodes at which farfield BCs are set
     std::unordered_set< std::size_t > m_farfieldbcnodes;
+    //! Unique set of nodes at which slip wall BCs are set
+    std::unordered_set< std::size_t > m_slipwallbcnodes;
     //! Vector with 1 at symmetry BC boundary triangles
     std::vector< int > m_symbctri;
+    //! Vector with 1 at slip wall BC boundary triangles
+    std::vector< int > m_slipwallbctri;
     //! \brief Unique set of nodes at which time dependent BCs are set
     //    for each time dependent BC
     std::vector< std::unordered_set< std::size_t > > m_timedepbcnodes;

--- a/src/Inciter/OversetFE.hpp
+++ b/src/Inciter/OversetFE.hpp
@@ -242,6 +242,9 @@ class OversetFE : public CBase_OversetFE {
       p | m_centMass;
       p | m_centMassVel;
       p | m_angVelMesh;
+      p | m_centMassn;
+      p | m_centMassVeln;
+      p | m_angVelMeshn;
     }
     //! \brief Pack/Unpack serialize operator|
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
@@ -381,6 +384,12 @@ class OversetFE : public CBase_OversetFE {
     std::array< tk::real, 3 > m_centMassVel;
     //! Angular velocity of the rigid body
     tk::real m_angVelMesh;
+    //! Center of mass of rigid body at time n
+    std::array< tk::real, 3 > m_centMassn;
+    //! Velocity of the center of mass of rigid body at time n
+    std::array< tk::real, 3 > m_centMassVeln;
+    //! Angular velocity of the rigid body at time n
+    tk::real m_angVelMeshn;
 
     //! Access bound Discretization class pointer
     Discretization* Disc() const {
@@ -453,6 +462,9 @@ class OversetFE : public CBase_OversetFE {
 
     //! Apply boundary conditions
     void BC();
+
+    //! Update quantities associated with the center of mass at a new time step
+    void UpdateCenterOfMass();
 };
 
 } // inciter::

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -218,12 +218,13 @@ class CGPDE {
     //! Public interface to set symmetry boundary conditions at nodes
     void
     symbc( tk::Fields& U,
+           tk::Fields& W,
            const std::array< std::vector< real >, 3 >& coord,
            const std::unordered_map< int,
                    std::unordered_map< std::size_t,
                      std::array< real, 4 > > >& bnorm,
            const std::unordered_set< std::size_t >& nodes ) const
-    { self->symbc( U, coord, bnorm, nodes ); }
+    { self->symbc( U, W, coord, bnorm, nodes ); }
 
     //! Public interface to set farfield boundary conditions at nodes
     void
@@ -385,6 +386,7 @@ class CGPDE {
              bool ) const = 0;
       virtual void symbc(
         tk::Fields& U,
+        tk::Fields& W,
         const std::array< std::vector< real >, 3 >&,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
@@ -520,12 +522,13 @@ class CGPDE {
                                       increment ); }
       void symbc(
         tk::Fields& U,
+        tk::Fields& W,
         const std::array< std::vector< real >, 3 >& coord,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
                   std::array< real, 4 > > >& bnorm,
         const std::unordered_set< std::size_t >& nodes ) const override
-      { data.symbc( U, coord, bnorm, nodes ); }
+      { data.symbc( U, W, coord, bnorm, nodes ); }
       void farfieldbc(
         tk::Fields& U,
         const std::array< std::vector< real >, 3 >& coord,

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -218,13 +218,12 @@ class CGPDE {
     //! Public interface to set symmetry boundary conditions at nodes
     void
     symbc( tk::Fields& U,
-           const tk::Fields& W,
            const std::array< std::vector< real >, 3 >& coord,
            const std::unordered_map< int,
                    std::unordered_map< std::size_t,
                      std::array< real, 4 > > >& bnorm,
            const std::unordered_set< std::size_t >& nodes ) const
-    { self->symbc( U, W, coord, bnorm, nodes ); }
+    { self->symbc( U, coord, bnorm, nodes ); }
 
     //! Public interface to set farfield boundary conditions at nodes
     void
@@ -397,7 +396,6 @@ class CGPDE {
              bool ) const = 0;
       virtual void symbc(
         tk::Fields& U,
-        const tk::Fields& W,
         const std::array< std::vector< real >, 3 >&,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
@@ -541,13 +539,12 @@ class CGPDE {
                                       increment ); }
       void symbc(
         tk::Fields& U,
-        const tk::Fields& W,
         const std::array< std::vector< real >, 3 >& coord,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
                   std::array< real, 4 > > >& bnorm,
         const std::unordered_set< std::size_t >& nodes ) const override
-      { data.symbc( U, W, coord, bnorm, nodes ); }
+      { data.symbc( U, coord, bnorm, nodes ); }
       void farfieldbc(
         tk::Fields& U,
         const std::array< std::vector< real >, 3 >& coord,

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -236,6 +236,17 @@ class CGPDE {
                 const std::unordered_set< std::size_t >& nodes ) const
     { self->farfieldbc( U, coord, bnorm, nodes ); }
 
+    //! Public interface to set slip wall boundary conditions at nodes
+    void
+    slipwallbc( tk::Fields& U,
+           const tk::Fields& W,
+           const std::array< std::vector< real >, 3 >& coord,
+           const std::unordered_map< int,
+                   std::unordered_map< std::size_t,
+                     std::array< real, 4 > > >& bnorm,
+           const std::unordered_set< std::size_t >& nodes ) const
+    { self->slipwallbc( U, W, coord, bnorm, nodes ); }
+
     //! Public interface to applying time dependent boundary conditions at nodes
     void
     timedepbc( tk::real t,
@@ -399,6 +410,14 @@ class CGPDE {
                 std::unordered_map< std::size_t,
                   std::array< real, 4 > > >&,
         const std::unordered_set< std::size_t >& ) const = 0;
+      virtual void slipwallbc(
+        tk::Fields& U,
+        const tk::Fields& W,
+        const std::array< std::vector< real >, 3 >&,
+        const std::unordered_map< int,
+                std::unordered_map< std::size_t,
+                  std::array< real, 4 > > >&,
+        const std::unordered_set< std::size_t >& ) const = 0;
       virtual void timedepbc(
         tk::real,
         tk::Fields&,
@@ -537,6 +556,15 @@ class CGPDE {
                   std::array< real, 4 > > >& bnorm,
         const std::unordered_set< std::size_t >& nodes ) const override
       { data.farfieldbc( U, coord, bnorm, nodes ); }
+      void slipwallbc(
+        tk::Fields& U,
+        const tk::Fields& W,
+        const std::array< std::vector< real >, 3 >& coord,
+        const std::unordered_map< int,
+                std::unordered_map< std::size_t,
+                  std::array< real, 4 > > >& bnorm,
+        const std::unordered_set< std::size_t >& nodes ) const override
+      { data.slipwallbc( U, W, coord, bnorm, nodes ); }
       void
       timedepbc(
         tk::real t,

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -162,6 +162,7 @@ class CGPDE {
       const std::pair< std::vector< std::size_t >,
                        std::vector< std::size_t > >& esup,
       const std::vector< int >& symbctri,
+      const std::vector< int >& slipwallbctri,
       const std::vector< real >& vol,
       const std::vector< std::size_t >& edgenode,
       const std::vector< std::size_t >& edgeid,
@@ -173,18 +174,18 @@ class CGPDE {
       real V,
       tk::Fields& R ) const
     { self->rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup,
-        esup, symbctri, vol, edgenode, edgeid,
+        esup, symbctri, slipwallbctri, vol, edgenode, edgeid,
         boxnodes, G, U, W, tp, V, R ); }
 
     //! Public interface to compute boundary surface integrals of pressure
     void bndPressureInt(
       const std::array< std::vector< real >, 3 >& coord,
       const std::vector< std::size_t >& triinpoel,
-      const std::vector< int >& symbctri,
+      const std::vector< int >& slipwallbctri,
       const tk::Fields& U,
       const std::array< tk::real, 3 >& CM,
       std::vector< real >& F ) const
-    { self->bndPressureInt( coord, triinpoel, symbctri, U, CM, F ); }
+    { self->bndPressureInt( coord, triinpoel, slipwallbctri, U, CM, F ); }
 
     //! Public interface for computing the minimum time step size
     real dt( const std::array< std::vector< real >, 3 >& coord,
@@ -358,6 +359,7 @@ class CGPDE {
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >&,
         const std::vector< int >&,
+        const std::vector< int >&,
         const std::vector< real >&,
         const std::vector< std::size_t >&,
         const std::vector< std::size_t >&,
@@ -493,6 +495,7 @@ class CGPDE {
         const std::pair< std::vector< std::size_t >,
                          std::vector< std::size_t > >& esup,
         const std::vector< int >& symbctri,
+        const std::vector< int >& slipwallbctri,
         const std::vector< real >& vol,
         const std::vector< std::size_t >& edgenode,
         const std::vector< std::size_t >& edgeid,
@@ -504,16 +507,16 @@ class CGPDE {
         real V,
         tk::Fields& R ) const override
       { data.rhs( t, coord, inpoel, triinpoel, gid, bid, lid, dfn, psup,
-                  esup, symbctri, vol, edgenode,
+                  esup, symbctri, slipwallbctri, vol, edgenode,
                   edgeid, boxnodes, G, U, W, tp, V, R ); }
       void bndPressureInt(
         const std::array< std::vector< real >, 3 >& coord,
         const std::vector< std::size_t >& triinpoel,
-        const std::vector< int >& symbctri,
+        const std::vector< int >& slipwallbctri,
         const tk::Fields& U,
         const std::array< tk::real, 3 >& CM,
         std::vector< real >& F ) const override
-      { data.bndPressureInt( coord, triinpoel, symbctri, U, CM, F ); }
+      { data.bndPressureInt( coord, triinpoel, slipwallbctri, U, CM, F ); }
       real dt( const std::array< std::vector< real >, 3 >& coord,
                const std::vector< std::size_t >& inpoel,
                tk::real t,

--- a/src/PDE/CGPDE.hpp
+++ b/src/PDE/CGPDE.hpp
@@ -218,7 +218,7 @@ class CGPDE {
     //! Public interface to set symmetry boundary conditions at nodes
     void
     symbc( tk::Fields& U,
-           tk::Fields& W,
+           const tk::Fields& W,
            const std::array< std::vector< real >, 3 >& coord,
            const std::unordered_map< int,
                    std::unordered_map< std::size_t,
@@ -386,7 +386,7 @@ class CGPDE {
              bool ) const = 0;
       virtual void symbc(
         tk::Fields& U,
-        tk::Fields& W,
+        const tk::Fields& W,
         const std::array< std::vector< real >, 3 >&,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,
@@ -522,7 +522,7 @@ class CGPDE {
                                       increment ); }
       void symbc(
         tk::Fields& U,
-        tk::Fields& W,
+        const tk::Fields& W,
         const std::array< std::vector< real >, 3 >& coord,
         const std::unordered_map< int,
                 std::unordered_map< std::size_t,

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -750,13 +750,11 @@ class CompFlow {
 
     //! Set symmetry boundary conditions at nodes
     //! \param[in] U Solution vector at recent time step
-    //! \param[in] W Mesh velocity
     //! \param[in] bnorm Face normals in boundary points, key local node id,
     //!   first 3 reals of value: unit normal, outer key: side set id
     //! \param[in] nodes Unique set of node ids at which to set symmetry BCs
     void
     symbc( tk::Fields& U,
-           const tk::Fields& W,
            const std::array< std::vector< real >, 3 >&,
            const std::unordered_map< int,
              std::unordered_map< std::size_t, std::array< real, 4 > > >& bnorm,
@@ -780,12 +778,12 @@ class CompFlow {
               if (i != end(j->second)) {
                 std::array< real, 3 >
                   n{ i->second[0], i->second[1], i->second[2] },
-                  rel_v{ U(p,1) - W(p,0), U(p,2) - W(p,1), U(p,3) - W(p,2) };
-                auto rel_v_dot_n = tk::dot( rel_v, n );
-                // symbc: remove normal component of relative velocity
-                U(p,1) -= rel_v_dot_n * n[0];
-                U(p,2) -= rel_v_dot_n * n[1];
-                U(p,3) -= rel_v_dot_n * n[2];
+                  v{ U(p,1), U(p,2), U(p,3) };
+                auto v_dot_n = tk::dot( v, n );
+                // symbc: remove normal component of velocity
+                U(p,1) -= v_dot_n * n[0];
+                U(p,2) -= v_dot_n * n[1];
+                U(p,3) -= v_dot_n * n[2];
               }
             }
           }

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <unordered_set>
 #include <unordered_map>
-#include <iostream>
 
 #include "DerivedData.hpp"
 #include "Exception.hpp"

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -483,14 +483,14 @@ class CompFlow {
     //! Compute boundary pressure integrals (force) for rigid body motion
     //! \param[in] coord Mesh node coordinates
     //! \param[in] triinpoel Boundary triangle face connecitivity with local ids
-    //! \param[in] symbctri Vector with 1 at symmetry BC boundary triangles
+    //! \param[in] slipwallbctri Vector with 1 at symmetry BC boundary triangles
     //! \param[in] U Solution vector at recent time step
     //! \param[in] CM Center of mass
     //! \param[in,out] F Force vector (appended with torque vector) computed
     void bndPressureInt(
       const std::array< std::vector< real >, 3 >& coord,
       const std::vector< std::size_t >& triinpoel,
-      const std::vector< int >& symbctri,
+      const std::vector< int >& slipwallbctri,
       const tk::Fields& U,
       const std::array< tk::real, 3 >& CM,
       std::vector< real >& F ) const
@@ -503,7 +503,7 @@ class CompFlow {
 
       // boundary integrals: compute surface integral of pressure (=force)
       for (std::size_t e=0; e<triinpoel.size()/3; ++e) {
-        if (symbctri[e]) {
+        if (slipwallbctri[e]) {
         // access node IDs
         std::size_t N[3] =
           { triinpoel[e*3+0], triinpoel[e*3+1], triinpoel[e*3+2] };

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <unordered_set>
 #include <unordered_map>
+#include <iostream>
 
 #include "DerivedData.hpp"
 #include "Exception.hpp"
@@ -780,12 +781,12 @@ class CompFlow {
               if (i != end(j->second)) {
                 std::array< real, 3 >
                   n{ i->second[0], i->second[1], i->second[2] },
-                  v{ U(p,1), U(p,2), U(p,3) };
-                auto v_dot_n = tk::dot( v, n );
-                // symbc: remove normal component of velocity
-                U(p,1) -= v_dot_n * n[0];
-                U(p,2) -= v_dot_n * n[1];
-                U(p,3) -= v_dot_n * n[2];
+                  rel_v{ U(p,1) - W(p,0), U(p,2) - W(p,1), U(p,3) - W(p,2) };
+                auto rel_v_dot_n = tk::dot( rel_v, n );
+                // symbc: remove normal component of relative velocity
+                U(p,1) -= rel_v_dot_n * n[0];
+                U(p,2) -= rel_v_dot_n * n[1];
+                U(p,3) -= rel_v_dot_n * n[2];
               }
             }
           }

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -757,7 +757,7 @@ class CompFlow {
     //! \param[in] nodes Unique set of node ids at which to set symmetry BCs
     void
     symbc( tk::Fields& U,
-           tk::Fields& W,
+           const tk::Fields& W,
            const std::array< std::vector< real >, 3 >&,
            const std::unordered_map< int,
              std::unordered_map< std::size_t, std::array< real, 4 > > >& bnorm,

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -402,6 +402,7 @@ class CompFlow {
     //! \param[in] psup Points surrounding points
     //! \param[in] esup Elements surrounding points
     //! \param[in] symbctri Vector with 1 at symmetry BC boundary triangles
+    //! \param[in] slipwallbctri Vector with 1 at slip BC boundary triangles
     //! \param[in] vol Nodal volumes
     //! \param[in] edgenode Local node IDs of edges
     //! \param[in] edgeid Edge ids in the order of access
@@ -425,6 +426,7 @@ class CompFlow {
               const std::pair< std::vector< std::size_t >,
                                std::vector< std::size_t > >& esup,
               const std::vector< int >& symbctri,
+              const std::vector< int >& slipwallbctri,
               const std::vector< real >& vol,
               const std::vector< std::size_t >& edgenode,
               const std::vector< std::size_t >& edgeid,
@@ -455,7 +457,7 @@ class CompFlow {
       domainint( coord, gid, edgenode, edgeid, psup, dfn, U, W, Grad, R );
 
       // compute boundary integrals
-      bndint( coord, triinpoel, symbctri, U, W, R );
+      bndint( coord, triinpoel, symbctri, slipwallbctri, U, W, R );
 
       // compute external (energy) sources
       const auto& icbox = g_inputdeck.get< tag::ic, tag::box >();
@@ -1311,12 +1313,14 @@ class CompFlow {
     //! \param[in] coord Mesh node coordinates
     //! \param[in] triinpoel Boundary triangle face connecitivity with local ids
     //! \param[in] symbctri Vector with 1 at symmetry BC boundary triangles
+    //! \param[in] slipwallbctri Vector with 1 at slip wall BC boundary triangles
     //! \param[in] U Solution vector at recent time step
     //! \param[in] W Mesh velocity
     //! \param[in,out] R Right-hand side vector computed
     void bndint( const std::array< std::vector< real >, 3 >& coord,
                  const std::vector< std::size_t >& triinpoel,
                  const std::vector< int >& symbctri,
+                 const std::vector< int >& slipwallbctri,
                  const tk::Fields& U,
                  const tk::Fields& W,
                  tk::Fields& R ) const
@@ -1370,30 +1374,34 @@ class CompFlow {
         real f[m_ncomp][3];
         real p, vn;
         int sym = symbctri[e];
+        int slip = slipwallbctri[e];
         p = m_mat_blk[0].compute< EOS::pressure >( rA, ruA/rA, rvA/rA, rwA/rA,
           reA );
-        vn = sym ? 0.0 : (nx*(ruA/rA-w1A) + ny*(rvA/rA-w2A) + nz*(rwA/rA-w3A));
+        vn = (sym || slip) ? 0.0 : (nx*(ruA/rA-w1A) + ny*(rvA/rA-w2A) + nz*(rwA/rA-w3A));
         f[0][0] = rA*vn;
         f[1][0] = ruA*vn + p*nx;
         f[2][0] = rvA*vn + p*ny;
         f[3][0] = rwA*vn + p*nz;
-        f[4][0] = reA*vn + p*(sym ? 0.0 : (nx*ruA + ny*rvA + nz*rwA)/rA);
+        f[4][0] = reA*vn + p*((sym || slip)
+                ? 0.0 : (nx*ruA + ny*rvA + nz*rwA)/rA);
         p = m_mat_blk[0].compute< EOS::pressure >( rB, ruB/rB, rvB/rB, rwB/rB,
           reB );
-        vn = sym ? 0.0 : (nx*(ruB/rB-w1B) + ny*(rvB/rB-w2B) + nz*(rwB/rB-w3B));
+        vn = (sym || slip) ? 0.0 : (nx*(ruB/rB-w1B) + ny*(rvB/rB-w2B) + nz*(rwB/rB-w3B));
         f[0][1] = rB*vn;
         f[1][1] = ruB*vn + p*nx;
         f[2][1] = rvB*vn + p*ny;
         f[3][1] = rwB*vn + p*nz;
-        f[4][1] = reB*vn + p*(sym ? 0.0 : (nx*ruB + ny*rvB + nz*rwB)/rB);
+        f[4][1] = reB*vn + p*((sym || slip)
+                ? 0.0 : (nx*ruB + ny*rvB + nz*rwB)/rB);
         p = m_mat_blk[0].compute< EOS::pressure >( rC, ruC/rC, rvC/rC, rwC/rC,
           reC );
-        vn = sym ? 0.0 : (nx*(ruC/rC-w1C) + ny*(rvC/rC-w2C) + nz*(rwC/rC-w3C));
+        vn = (sym || slip) ? 0.0 : (nx*(ruC/rC-w1C) + ny*(rvC/rC-w2C) + nz*(rwC/rC-w3C));
         f[0][2] = rC*vn;
         f[1][2] = ruC*vn + p*nx;
         f[2][2] = rvC*vn + p*ny;
         f[3][2] = rwC*vn + p*nz;
-        f[4][2] = reC*vn + p*(sym ? 0.0 : (nx*ruC + ny*rvC + nz*rwC)/rC);
+        f[4][2] = reC*vn + p*((sym || slip)
+                ? 0.0 : (nx*ruC + ny*rvC + nz*rwC)/rC);
         // compute face area
         auto A6 = tk::area( x[N[0]], x[N[1]], x[N[2]],
                             y[N[0]], y[N[1]], y[N[2]],

--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -750,11 +750,13 @@ class CompFlow {
 
     //! Set symmetry boundary conditions at nodes
     //! \param[in] U Solution vector at recent time step
+    //! \param[in] W Mesh velocity
     //! \param[in] bnorm Face normals in boundary points, key local node id,
     //!   first 3 reals of value: unit normal, outer key: side set id
     //! \param[in] nodes Unique set of node ids at which to set symmetry BCs
     void
     symbc( tk::Fields& U,
+           tk::Fields& W,
            const std::array< std::vector< real >, 3 >&,
            const std::unordered_map< int,
              std::unordered_map< std::size_t, std::array< real, 4 > > >& bnorm,

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -79,7 +79,7 @@ class CompFlow {
       , farfield
       , extrapolate
       , invalidBC         // No slip wall BC not implemented
-      , invalidBC },      // Slip wall BC not implemented
+      , symmetry },       // Slip equivalent to symmetry without mesh motion
       // BC Gradient functions
       { noOpGrad
       , noOpGrad

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -78,9 +78,11 @@ class CompFlow {
       , invalidBC         // Outlet BC not implemented
       , farfield
       , extrapolate
-      , invalidBC },      // No slip wall BC not implemented
+      , invalidBC         // No slip wall BC not implemented
+      , invalidBC },      // Slip wall BC not implemented
       // BC Gradient functions
       { noOpGrad
+      , noOpGrad
       , noOpGrad
       , noOpGrad
       , noOpGrad

--- a/src/PDE/ConfigureCompFlow.cpp
+++ b/src/PDE/ConfigureCompFlow.cpp
@@ -142,6 +142,10 @@ infoCompFlow( std::map< ctr::PDEType, tk::ncomp_t >& cnt )
     if (!sym.empty())
       nfo.emplace_back( "Symmetry BC sideset(s)", parameters( sym ) );
 
+    const auto& slip = ib.get< tag::slipwall >();
+    if (!slip.empty())
+      nfo.emplace_back( "Slip wall BC sideset(s)", parameters( slip ) );
+
     const auto& dir = ib.get< tag::dirichlet >();
     if (!dir.empty())
       nfo.emplace_back( "Dirichlet BC sideset(s)", parameters( dir ) );

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -83,7 +83,7 @@ class MultiMat {
       , farfield
       , extrapolate
       , noslipwall 
-      , invalidBC },      // Slip wall BC not implemented
+      , symmetry },       // Slip equivalent to symmetry without mesh motion
       // BC Gradient functions
       { noOpGrad
       , symmetryGrad
@@ -91,7 +91,7 @@ class MultiMat {
       , noOpGrad
       , noOpGrad
       , noOpGrad
-      , noOpGrad }
+      , symmetryGrad }
       ) );
 
       // Inlet BC has a different structure than above BCs, so it must be 

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -82,10 +82,12 @@ class MultiMat {
       , invalidBC         // Outlet BC not implemented
       , farfield
       , extrapolate
-      , noslipwall },
+      , noslipwall 
+      , invalidBC },      // Slip wall BC not implemented
       // BC Gradient functions
       { noOpGrad
       , symmetryGrad
+      , noOpGrad
       , noOpGrad
       , noOpGrad
       , noOpGrad

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -79,7 +79,7 @@ class MultiMat {
         , farfield
         , extrapolate
         , noslipwall 
-        , invalidBC },      // Slip wall BC not implemented
+        , symmetry },       // Slip equivalent to symmetry without mesh motion
         // BC Gradient functions
         { noOpGrad
         , symmetryGrad
@@ -87,7 +87,7 @@ class MultiMat {
         , noOpGrad
         , noOpGrad
         , noOpGrad
-        , noOpGrad }
+        , symmetryGrad }
         ) );
 
       // Inlet BC has a different structure than above BCs, so it must be 

--- a/src/PDE/MultiMat/FVMultiMat.hpp
+++ b/src/PDE/MultiMat/FVMultiMat.hpp
@@ -78,10 +78,12 @@ class MultiMat {
         , invalidBC         // Outlet BC not implemented
         , farfield
         , extrapolate
-        , noslipwall },
+        , noslipwall 
+        , invalidBC },      // Slip wall BC not implemented
         // BC Gradient functions
         { noOpGrad
         , symmetryGrad
+        , noOpGrad
         , noOpGrad
         , noOpGrad
         , noOpGrad

--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -81,10 +81,12 @@ class MultiSpecies {
         , invalidBC         // Outlet BC not implemented
         , farfield
         , extrapolate
-        , noslipwall },
+        , noslipwall 
+        , invalidBC },      // Slip wall BC not implemented
         // BC Gradient functions
         { noOpGrad
         , symmetryGrad
+        , noOpGrad
         , noOpGrad
         , noOpGrad
         , noOpGrad

--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -82,7 +82,7 @@ class MultiSpecies {
         , farfield
         , extrapolate
         , noslipwall 
-        , invalidBC },      // Slip wall BC not implemented
+        , symmetry },       // Slip equivalent to symmetry without mesh motion
         // BC Gradient functions
         { noOpGrad
         , symmetryGrad
@@ -90,7 +90,7 @@ class MultiSpecies {
         , noOpGrad
         , noOpGrad
         , noOpGrad
-        , noOpGrad }
+        , symmetryGrad }
         ) );
 
       // EoS initialization

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -227,6 +227,7 @@ class Transport {
       const std::pair< std::vector< std::size_t >,
                        std::vector< std::size_t > >& esup,
       const std::vector< int >& symbctri,
+      const std::vector< int >&,
       const std::vector< real >& vol,
       const std::vector< std::size_t >&,
       const std::vector< std::size_t >& edgeid,

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -398,7 +398,6 @@ class Transport {
     void
     symbc(
       tk::Fields&,
-      const tk::Fields&,
       const std::array< std::vector< real >, 3 >&,
       const std::unordered_map< int,
               std::unordered_map< std::size_t,

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -398,6 +398,7 @@ class Transport {
     void
     symbc(
       tk::Fields&,
+      tk::Fields&,
       const std::array< std::vector< real >, 3 >&,
       const std::unordered_map< int,
               std::unordered_map< std::size_t,

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -414,6 +414,17 @@ class Transport {
                 std::array< real, 4 > > >&,
       const std::unordered_set< std::size_t >& ) const {}
 
+    //! Set slip wall boundary conditions at nodes
+    void
+    slipwallbc(
+      tk::Fields&,
+      const tk::Fields&,
+      const std::array< std::vector< real >, 3 >&,
+      const std::unordered_map< int,
+              std::unordered_map< std::size_t,
+                std::array< real, 4 > > >&,
+      const std::unordered_set< std::size_t >& ) const {}
+
     //! Apply user defined time dependent BCs (no-op for transport)
     void
     timedepbc( tk::real,

--- a/src/PDE/Transport/CGTransport.hpp
+++ b/src/PDE/Transport/CGTransport.hpp
@@ -398,7 +398,7 @@ class Transport {
     void
     symbc(
       tk::Fields&,
-      tk::Fields&,
+      const tk::Fields&,
       const std::array< std::vector< real >, 3 >&,
       const std::unordered_map< int,
               std::unordered_map< std::size_t,

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -74,9 +74,11 @@ class Transport {
         , outlet
         , invalidBC  // Characteristic BC not implemented
         , extrapolate
+        , invalidBC        // Slip wall BC not implemented
         , invalidBC },      // No slip wall BC not implemented
         // BC Gradient functions
         { noOpGrad
+        , noOpGrad
         , noOpGrad
         , noOpGrad
         , noOpGrad


### PR DESCRIPTION
Closes #652. To copy/paste from that issue:

> The overset implementation (and presumably the ALE implementation as far as I can tell?) does not properly account for the motion of the background mesh when calculating symmetry boundary conditions. As a result, the normal velocity on these boundaries of the moving mesh will set the normal velocity equal to zero, instead of the normal component of the mesh velocity. The proper way to handle this seems to be to pass the mesh velocity into the `symbc()` function, in a similar way to how the it is passed into, e.g., `CompFlow::rhs()`.

The implementation is as described above: the mesh velocities are read directly into the `symbc()` method. The changes pushed at the time of writing do indeed affect ALECG implementation, and as a result these tests fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/653)
<!-- Reviewable:end -->
