### PR TITLE
make eos::totalenergy consistent with other eos functions so that it returns volume-fraction times the total energy density.

### DIFF
--- a/src/PDE/EoS/GodunovRomenski.cpp
+++ b/src/PDE/EoS/GodunovRomenski.cpp
@@ -284,20 +284,24 @@ GodunovRomenski::shearspeed(
 
 tk::real
 GodunovRomenski::totalenergy(
-  tk::real rho,
+  tk::real arho,
   tk::real u,
   tk::real v,
   tk::real w,
-  tk::real pr,
+  tk::real apr,
+  tk::real alpha,
   const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho Material density
+//! \param[in] arho Material partial density
 //! \param[in] u X-velocity
 //! \param[in] v Y-velocity
 //! \param[in] w Z-velocity
-//! \param[in] pr Material pressure
+//! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
 //! \param[in] defgrad Material inverse deformation gradient tensor
 //!   g_k. Default is 0, so that for the single-material system,
 //!   this argument can be left unspecified by the calling code
@@ -305,16 +309,16 @@ GodunovRomenski::totalenergy(
 // *************************************************************************
 {
   // obtain thermal and kinetic energy
-  auto pt = pr - pressure_coldcompr(rho);
+  auto apt = apr - pressure_coldcompr(arho, alpha);
   // in the above expression, shear pressure is not included in pr in the first
   // place, so should not subtract it
-  auto rhoEh = pt/m_gamma + 0.5*rho*(u*u + v*v + w*w);
+  auto arhoEh = apt/m_gamma + 0.5*arho*(u*u + v*v + w*w);
   // obtain elastic contribution to energy
   std::array< std::array< tk::real, 3 >, 3 > devH;
-  auto rhoEe = elasticEnergy(defgrad, devH);
-  auto rhoEc = coldcomprEnergy(rho);
+  auto arhoEe = alpha*elasticEnergy(defgrad, devH);
+  auto arhoEc = alpha*coldcomprEnergy(arho/alpha);
 
-  return (rhoEh + rhoEe + rhoEc);
+  return (arhoEh + arhoEe + arhoEc);
 }
 
 tk::real

--- a/src/PDE/EoS/GodunovRomenski.hpp
+++ b/src/PDE/EoS/GodunovRomenski.hpp
@@ -105,11 +105,12 @@ class GodunovRomenski {
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
     tk::real totalenergy(
-      tk::real rho,
+      tk::real arho,
       tk::real u,
       tk::real v,
       tk::real w,
-      tk::real pr,
+      tk::real apr,
+      tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/EoS/JWL.cpp
+++ b/src/PDE/EoS/JWL.cpp
@@ -218,30 +218,34 @@ JWL::soundspeed(
 
 tk::real
 JWL::totalenergy(
-  tk::real rho,
+  tk::real arho,
   tk::real u,
   tk::real v,
   tk::real w,
-  tk::real pr,
+  tk::real apr,
+  tk::real alpha,
   const std::array< std::array< tk::real, 3 >, 3 >& ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho Material density
+//! \param[in] arho Material partial density
 //! \param[in] u X-velocity
 //! \param[in] v Y-velocity
 //! \param[in] w Z-velocity
-//! \param[in] pr Material pressure
+//! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
 //! \return Material specific total energy using the stiffened-gas EoS
 // *************************************************************************
 {
   //// reference energy (input quantity, might need for calculation)
   //tk::real e0 = a/r1*exp(-r1*rho0/rho) + b/r2*exp(-r2*rho0/rho);
 
-  tk::real rhoE = rho*intEnergy( rho, pr )
-                + 0.5*rho*(u*u + v*v + w*w);
+  tk::real arhoE = arho*intEnergy( arho/alpha, apr/alpha )
+                + 0.5*arho*(u*u + v*v + w*w);
 
-  return rhoE;
+  return arhoE;
 }
 
 tk::real

--- a/src/PDE/EoS/JWL.hpp
+++ b/src/PDE/EoS/JWL.hpp
@@ -94,11 +94,12 @@ class JWL {
 
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
-    tk::real totalenergy( tk::real rho,
+    tk::real totalenergy( tk::real arho,
                           tk::real u,
                           tk::real v,
                           tk::real w,
-                          tk::real pr,
+                          tk::real apr,
+                          tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/EoS/SmallShearSolid.cpp
+++ b/src/PDE/EoS/SmallShearSolid.cpp
@@ -122,8 +122,8 @@ SmallShearSolid::pressure(
   auto arhoEh = arhoE - arhoEe;
 
   // use stiffened gas eos to get pressure
-  tk::real partpressure = (arhoEh - 0.5 * arho * (u*u + v*v + w*w) -
-    alpha*m_pstiff) * (m_gamma-1.0) - alpha*m_pstiff;
+  tk::real partpressure = (arhoEh - 0.5 * arho * (u*u + v*v + w*w))
+    * (m_gamma-1.0) - alpha*m_gamma*m_pstiff;
 
   // check partial pressure divergence
   if (!std::isfinite(partpressure)) {
@@ -603,20 +603,24 @@ SmallShearSolid::shearspeed(
 
 tk::real
 SmallShearSolid::totalenergy(
-  tk::real rho,
+  tk::real arho,
   tk::real u,
   tk::real v,
   tk::real w,
-  tk::real pr,
+  tk::real apr,
+  tk::real alpha,
   const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho Material density
+//! \param[in] arho Material partial density
 //! \param[in] u X-velocity
 //! \param[in] v Y-velocity
 //! \param[in] w Z-velocity
-//! \param[in] pr Material pressure
+//! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
 //! \param[in] defgrad Material inverse deformation gradient tensor
 //!   g_k. Default is 0, so that for the single-material system,
 //!   this argument can be left unspecified by the calling code
@@ -624,13 +628,13 @@ SmallShearSolid::totalenergy(
 // *************************************************************************
 {
   // obtain hydro contribution to energy
-  tk::real rhoEh = (pr + m_pstiff) / (m_gamma-1.0) + 0.5 * rho *
-    (u*u + v*v + w*w) + m_pstiff;
+  tk::real arhoEh = (apr + alpha*m_gamma*m_pstiff) / (m_gamma-1.0) + 0.5 * arho *
+    (u*u + v*v + w*w);
   // obtain elastic contribution to energy
   tk::real eps2;
-  tk::real rhoEe = elasticEnergy(defgrad, eps2);
+  tk::real arhoEe = alpha*elasticEnergy(defgrad, eps2);
 
-  return (rhoEh + rhoEe);
+  return (arhoEh + arhoEe);
 }
 
 tk::real

--- a/src/PDE/EoS/SmallShearSolid.hpp
+++ b/src/PDE/EoS/SmallShearSolid.hpp
@@ -95,11 +95,12 @@ class SmallShearSolid {
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
     tk::real totalenergy(
-      tk::real rho,
+      tk::real arho,
       tk::real u,
       tk::real v,
       tk::real w,
-      tk::real pr,
+      tk::real apr,
+      tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/EoS/StiffenedGas.cpp
+++ b/src/PDE/EoS/StiffenedGas.cpp
@@ -83,8 +83,8 @@ StiffenedGas::pressure(
   tk::real g = m_gamma;
   tk::real p_c = m_pstiff;
 
-  tk::real partpressure = (arhoE - 0.5 * arho * (u*u + v*v + w*w) -
-    alpha*p_c) * (g-1.0) - alpha*p_c;
+  tk::real partpressure = (arhoE - 0.5 * arho * (u*u + v*v + w*w)) * (g-1.0) -
+    alpha*g*p_c;
 
   // check partial pressure divergence
   if (!std::isfinite(partpressure)) {
@@ -168,28 +168,32 @@ StiffenedGas::soundspeed(
 
 tk::real
 StiffenedGas::totalenergy(
-  tk::real rho,
+  tk::real arho,
   tk::real u,
   tk::real v,
   tk::real w,
-  tk::real pr,
+  tk::real apr,
+  tk::real alpha,
   const std::array< std::array< tk::real, 3 >, 3 >& ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho Material density
+//! \param[in] arho Material partial density
 //! \param[in] u X-velocity
 //! \param[in] v Y-velocity
 //! \param[in] w Z-velocity
-//! \param[in] pr Material pressure
+//! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
 //! \return Material specific total energy using the stiffened-gas EoS
 // *************************************************************************
 {
   auto g = m_gamma;
   auto p_c = m_pstiff;
 
-  tk::real rhoE = (pr + p_c) / (g-1.0) + 0.5 * rho * (u*u + v*v + w*w) + p_c;
-  return rhoE;
+  tk::real arhoE = (apr + alpha*g*p_c) / (g-1.0) + 0.5 * arho * (u*u + v*v + w*w);
+  return arhoE;
 }
 
 tk::real

--- a/src/PDE/EoS/StiffenedGas.hpp
+++ b/src/PDE/EoS/StiffenedGas.hpp
@@ -80,11 +80,12 @@ class StiffenedGas {
 
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
-    tk::real totalenergy( tk::real rho,
+    tk::real totalenergy( tk::real arho,
                           tk::real u,
                           tk::real v,
                           tk::real w,
-                          tk::real pr,
+                          tk::real apr,
+                          tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/EoS/ThermallyPerfectGas.cpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.cpp
@@ -122,15 +122,17 @@ ThermallyPerfectGas::totalenergy(
   tk::real ,
   tk::real ,
   tk::real ,
+  tk::real ,
   const std::array< std::array< tk::real, 3 >, 3 >& ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho density
-//! \param[in] u X-velocity
-//! \param[in] v Y-velocity
-//! \param[in] w Z-velocity
-//! \param[in] pr pressure
+// //! \param[in] rho density
+// //! \param[in] u X-velocity
+// //! \param[in] v Y-velocity
+// //! \param[in] w Z-velocity
+// //! \param[in] pr pressure
+// //! \param[in] alpha volume fraction
 //! \return specific total energy using the thermally perfect gas EoS
 // *************************************************************************
 {

--- a/src/PDE/EoS/ThermallyPerfectGas.hpp
+++ b/src/PDE/EoS/ThermallyPerfectGas.hpp
@@ -171,11 +171,12 @@ class ThermallyPerfectGas {
 
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
-    [[noreturn]] tk::real totalenergy( tk::real rho,
+    [[noreturn]] tk::real totalenergy( tk::real arho,
                           tk::real u,
                           tk::real v,
                           tk::real w,
-                          tk::real pr,
+                          tk::real apr,
+                          tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/EoS/WilkinsAluminum.cpp
+++ b/src/PDE/EoS/WilkinsAluminum.cpp
@@ -291,20 +291,24 @@ WilkinsAluminum::shearspeed(
 
 tk::real
 WilkinsAluminum::totalenergy(
-  tk::real rho,
+  tk::real arho,
   tk::real u,
   tk::real v,
   tk::real w,
   tk::real,
+  tk::real alpha,
   const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
 // *************************************************************************
 //! \brief Calculate material specific total energy from the material
 //!   density, momentum and material pressure
-//! \param[in] rho Material density
+//! \param[in] arho Material partial density
 //! \param[in] u X-velocity
 //! \param[in] v Y-velocity
 //! \param[in] w Z-velocity
-// //! \param[in] pr Material pressure
+// //! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
 //! \param[in] defgrad Material inverse deformation gradient tensor
 //!   g_k. Default is 0, so that for the single-material system,
 //!   this argument can be left unspecified by the calling code
@@ -313,6 +317,7 @@ WilkinsAluminum::totalenergy(
 {
   // obtain hydro contribution to energy
   tk::real rho0 = m_rho0;
+  tk::real rho = arho/alpha;
   tk::real rhoEh = (e1+e2*std::pow(rho/rho0,2.0)+e3*(rho/rho0)
                     +e4*std::pow(rho/rho0,-1.0)-e5*std::log(rho/rho0))/rho0
                    + 0.5*rho*(u*u + v*v + w*w);
@@ -320,7 +325,7 @@ WilkinsAluminum::totalenergy(
   std::array< std::array< tk::real, 3 >, 3 > devH;
   tk::real rhoEe = elasticEnergy(defgrad, devH);
 
-  return (rhoEh + rhoEe);
+  return alpha*(rhoEh + rhoEe);
 }
 
 tk::real

--- a/src/PDE/EoS/WilkinsAluminum.hpp
+++ b/src/PDE/EoS/WilkinsAluminum.hpp
@@ -93,11 +93,12 @@ class WilkinsAluminum {
     //! \brief Calculate material specific total energy from the material
     //!   density, momentum and material pressure
     tk::real totalenergy(
-      tk::real rho,
+      tk::real arho,
       tk::real u,
       tk::real v,
       tk::real w,
-      tk::real pr,
+      tk::real apr,
+      tk::real alpha=1.0,
       const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
 
     //! \brief Calculate material temperature from the material density, and

--- a/src/PDE/Limiter.cpp
+++ b/src/PDE/Limiter.cpp
@@ -2864,12 +2864,12 @@ correctLimConservMultiMat(
       // Compute and store material energy at quadrature point
       for(std::size_t imat = 0; imat < nmat; imat++) {
         auto alphamat = state[volfracIdx(nmat, imat)];
-        auto rhomat = state[densityIdx(nmat, imat)]/alphamat;
-        auto premat = state[ncomp+pressureIdx(nmat, imat)]/alphamat;
+        auto arhomat = state[densityIdx(nmat, imat)];
+        auto apremat = state[ncomp+pressureIdx(nmat, imat)];
         auto gmat = getDeformGrad(nmat, imat, state);
-        s[pressureIdx(nmat,imat)] = alphamat *
-          mat_blk[imat].compute< EOS::totalenergy >( rhomat, vel[0], vel[1],
-          vel[2], premat, gmat );
+        s[pressureIdx(nmat,imat)] =
+          mat_blk[imat].compute< EOS::totalenergy >( arhomat, vel[0], vel[1],
+          vel[2], apremat, alphamat, gmat );
       }
 
       // Evaluate the righ-hand-side vector

--- a/src/PDE/MultiMat/BCFunctions.hpp
+++ b/src/PDE/MultiMat/BCFunctions.hpp
@@ -189,8 +189,9 @@ namespace inciter {
 
       ur[ncomp+pressureIdx(nmat, k)] = ur[volfracIdx(nmat,k)] * pk;
       ur[densityIdx(nmat,k)] = ur[volfracIdx(nmat,k)] * rhok;
-      ur[energyIdx(nmat,k)] = ur[volfracIdx(nmat,k)] *
-        mat_blk[k].compute< EOS::totalenergy >(rhok, v1r, v2r, v3r, pk);
+      ur[energyIdx(nmat,k)] =
+        mat_blk[k].compute< EOS::totalenergy >(ur[volfracIdx(nmat,k)]*rhok,
+        v1r, v2r, v3r, ur[volfracIdx(nmat,k)]*pk, ur[volfracIdx(nmat,k)]);
 
       // bulk density
       rho += ur[densityIdx(nmat,k)];
@@ -282,8 +283,9 @@ namespace inciter {
           ur[volfracIdx(nmat,k)] = alphamin;
         auto rhok = mat_blk[k].compute< EOS::density >(fp, ft);
         ur[densityIdx(nmat,k)] = ur[volfracIdx(nmat,k)] * rhok;
-        ur[energyIdx(nmat,k)] = ur[volfracIdx(nmat,k)] *
-          mat_blk[k].compute< EOS::totalenergy >(rhok, fu[0], fu[1], fu[2], fp);
+        ur[energyIdx(nmat,k)] =
+          mat_blk[k].compute< EOS::totalenergy >(ur[volfracIdx(nmat,k)]*rhok,
+          fu[0], fu[1], fu[2], ur[volfracIdx(nmat,k)]*fp, ur[volfracIdx(nmat,k)]);
 
         // material pressures
         ur[ncomp+pressureIdx(nmat, k)] = ur[volfracIdx(nmat, k)] * fp;
@@ -310,8 +312,9 @@ namespace inciter {
         auto p = ul[ncomp+pressureIdx(nmat,k)] / ul[volfracIdx(nmat,k)];
         auto rhok = mat_blk[k].compute< EOS::density >(p, ft);
         ur[densityIdx(nmat,k)] = ur[volfracIdx(nmat,k)] * rhok;
-        ur[energyIdx(nmat,k)] = ur[volfracIdx(nmat,k)] *
-          mat_blk[k].compute< EOS::totalenergy >(rhok, fu[0], fu[1], fu[2], p);
+        ur[energyIdx(nmat,k)] =
+          mat_blk[k].compute< EOS::totalenergy >(ur[volfracIdx(nmat,k)]*rhok,
+          fu[0], fu[1], fu[2], ur[volfracIdx(nmat,k)]*p, ur[volfracIdx(nmat,k)]);
 
         // material pressures
         ur[ncomp+pressureIdx(nmat, k)] = ur[volfracIdx(nmat, k)] * p;
@@ -329,9 +332,10 @@ namespace inciter {
       // by taking pressure from the outside and other quantities from the
       // internal cell.
       for (std::size_t k=0; k<nmat; ++k) {
-        ur[energyIdx(nmat, k)] = ul[volfracIdx(nmat, k)] *
+        ur[energyIdx(nmat, k)] =
         mat_blk[k].compute< EOS::totalenergy >(
-          ur[densityIdx(nmat, k)]/ul[volfracIdx(nmat, k)], v1l, v2l, v3l, fp );
+          ur[densityIdx(nmat, k)], v1l, v2l, v3l, ul[volfracIdx(nmat, k)]*fp,
+          ul[volfracIdx(nmat, k)] );
 
         // material pressures
         ur[ncomp+pressureIdx(nmat, k)] = ul[volfracIdx(nmat, k)] * fp;
@@ -504,9 +508,10 @@ namespace inciter {
         ul[volfracIdx(nmat, k)] );
       auto rhor_k = mat_blk[k].compute< inciter::EOS::density >( fbp, T_k );
       ur[densityIdx(nmat, k)] = ul[volfracIdx(nmat, k)] * rhor_k;
-      ur[energyIdx(nmat, k)] = ul[volfracIdx(nmat, k)] *
+      ur[energyIdx(nmat, k)] =
       mat_blk[k].compute< EOS::totalenergy >(
-        rhor_k, vl[0], vl[1], vl[2], fbp );
+        ul[volfracIdx(nmat, k)]*rhor_k, vl[0], vl[1], vl[2],
+        ul[volfracIdx(nmat, k)]*fbp, ul[volfracIdx(nmat, k)] );
       rhor_b += ur[densityIdx(nmat, k)];
 
       // material pressures

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -200,19 +200,18 @@ cleanTraceMultiMat(
           prelax = std::max(prelax, p_target);
 
           // energy change
-          auto rhomat = U(e, densityDofIdx(nmat, k, rdof, 0))
-            / alk;
+          auto arhomat = U(e, densityDofIdx(nmat, k, rdof, 0));
           auto gmat = getDeformGrad(nmat, k, ugp);
-          auto rhoEmat = mat_blk[k].compute< EOS::totalenergy >(rhomat, u, v, w,
-            prelax, gmat);
+          auto arhoEmat = mat_blk[k].compute< EOS::totalenergy >(arhomat, u, v, w,
+            alk*prelax, alk, gmat);
 
           // total energy flux into majority material
           d_arE += (U(e, energyDofIdx(nmat, k, rdof, 0))
-            - alk * rhoEmat);
+            - arhoEmat);
 
           // update state of trace material
           U(e, volfracDofIdx(nmat, k, rdof, 0)) = alk;
-          U(e, energyDofIdx(nmat, k, rdof, 0)) = alk*rhoEmat;
+          U(e, energyDofIdx(nmat, k, rdof, 0)) = arhoEmat;
           P(e, pressureDofIdx(nmat, k, rdof, 0)) = alk*prelax;
         }
       }
@@ -229,9 +228,9 @@ cleanTraceMultiMat(
           {{ {{1, 0, 0}},
              {{0, 1, 0}},
              {{0, 0, 1}} }};
-        U(e, energyDofIdx(nmat, k, rdof, 0)) = 1e-14
-          * mat_blk[k].compute< EOS::totalenergy >(rhok, u, v, w, p_target,
-          gk);
+        U(e, energyDofIdx(nmat, k, rdof, 0)) =
+          mat_blk[k].compute< EOS::totalenergy >(1e-14*rhok, u, v, w,
+          1e-14*p_target, 1e-14, gk);
         P(e, pressureDofIdx(nmat, k, rdof, 0)) = 1e-14 *
           p_target;
         resetSolidTensors(nmat, k, e, U, P);
@@ -247,14 +246,15 @@ cleanTraceMultiMat(
         auto prelax = mat_blk[k].compute< EOS::min_eff_pressure >(1e-10,
           U(e, densityDofIdx(nmat, k, rdof, 0)), alk);
         prelax = std::max(prelax, p_target);
-        auto rhok = U(e, densityDofIdx(nmat, k, rdof, 0)) / alk;
+        auto arhok = U(e, densityDofIdx(nmat, k, rdof, 0));
         auto gk = std::array< std::array< tk::real, 3 >, 3 >
           {{ {{1, 0, 0}},
              {{0, 1, 0}},
              {{0, 0, 1}} }};
         // update state of trace material
-        U(e, energyDofIdx(nmat, k, rdof, 0)) = alk
-          * mat_blk[k].compute< EOS::totalenergy >( rhok, u, v, w, prelax, gk );
+        U(e, energyDofIdx(nmat, k, rdof, 0)) =
+          mat_blk[k].compute< EOS::totalenergy >( arhok, u, v, w, alk*prelax,
+          alk, gk );
         P(e, pressureDofIdx(nmat, k, rdof, 0)) = alk *
           prelax;
         resetSolidTensors(nmat, k, e, U, P);

--- a/src/PDE/MultiMat/Problem/BoxInitialization.hpp
+++ b/src/PDE/MultiMat/Problem/BoxInitialization.hpp
@@ -106,9 +106,9 @@ void initializeBox( const std::vector< EOS >& mat_blk,
 
       pr = bgpreic;
       auto te = mat_blk[boxmatid].compute< EOS::totalenergy >(
-        rhok[boxmatid], u, v, w, pr);
+        boxmat_vf*rhok[boxmatid], u, v, w, boxmat_vf*pr, boxmat_vf );
       tmp = mat_blk[boxmatid].compute< EOS::temperature >(
-        boxmat_vf*rhok[boxmatid], u, v, w, boxmat_vf*te, boxmat_vf );
+        boxmat_vf*rhok[boxmatid], u, v, w, te, boxmat_vf );
 
       // if the above density and pressure lead to an invalid thermodynamic
       // state (negative temperature/energy), change temperature to background
@@ -182,8 +182,9 @@ void initializeBox( const std::vector< EOS >& mat_blk,
       else {
         gk = {{}};
       }
-      s[energyIdx(nmat,k)] = s[volfracIdx(nmat,k)] *
-        mat_blk[k].compute< EOS::totalenergy >( rhok[k], u, v, w, pr, gk );
+      s[energyIdx(nmat,k)] =
+        mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat,k)]*rhok[k],
+        u, v, w, s[volfracIdx(nmat,k)]*pr, s[volfracIdx(nmat,k)], gk );
     }
   }
   // bulk momentum

--- a/src/PDE/MultiMat/Problem/EquilInterfaceAdvect.cpp
+++ b/src/PDE/MultiMat/Problem/EquilInterfaceAdvect.cpp
@@ -74,10 +74,12 @@ MultiMatProblemEquilInterfaceAdvect::initialize(
   s[densityIdx(nmat, 0)] = s[volfracIdx(nmat, 0)]*r;
   s[densityIdx(nmat, 1)] = s[volfracIdx(nmat, 1)]*r;
   // total specific energy
-  s[energyIdx(nmat, 0)] = s[volfracIdx(nmat, 0)]*
-    mat_blk[0].compute< EOS::totalenergy >( r, u, v, w, p );
-  s[energyIdx(nmat, 1)] = s[volfracIdx(nmat, 1)]*
-    mat_blk[1].compute< EOS::totalenergy >( r, u, v, w, p );
+  s[energyIdx(nmat, 0)] =
+    mat_blk[0].compute< EOS::totalenergy >( s[volfracIdx(nmat, 0)]*r, u, v, w,
+    s[volfracIdx(nmat, 0)]*p, s[volfracIdx(nmat, 0)] );
+  s[energyIdx(nmat, 1)] =
+    mat_blk[1].compute< EOS::totalenergy >( s[volfracIdx(nmat, 1)]*r, u, v, w,
+    s[volfracIdx(nmat, 1)]*p, s[volfracIdx(nmat, 1)] );
   // momentum
   s[momentumIdx(nmat, 0)] = r*u;
   s[momentumIdx(nmat, 1)] = r*v;

--- a/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
+++ b/src/PDE/MultiMat/Problem/InterfaceAdvection.cpp
@@ -92,8 +92,9 @@ MultiMatProblemInterfaceAdvection::initialize(
   {
     auto rhok = mat_blk[k].compute< EOS::density >( 1.0e5, 300.0 );
     s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)] * rhok;
-    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]
-      * mat_blk[k].compute< EOS::totalenergy >( rhok, u, v, w, 1.0e5 );
+    s[energyIdx(nmat, k)] =
+      mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat, k)]*rhok,
+      u, v, w, s[volfracIdx(nmat, k)]*1.0e5, s[volfracIdx(nmat, k)] );
     rhob += s[densityIdx(nmat, k)];
   }
   s[momentumIdx(nmat, 0)] = rhob * u;

--- a/src/PDE/MultiMat/Problem/RichtmyerMeshkov.cpp
+++ b/src/PDE/MultiMat/Problem/RichtmyerMeshkov.cpp
@@ -83,8 +83,9 @@ MultiMatProblemRichtmyerMeshkov::initialize( ncomp_t ncomp,
     s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)]*r;
     rb += s[densityIdx(nmat, k)];
     // total specific energy
-    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]*
-      mat_blk[k].compute< EOS::totalenergy >( r, u, v, w, p );
+    s[energyIdx(nmat, k)] =
+      mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat, k)]*r, u, v, w,
+      s[volfracIdx(nmat, k)]*p, s[volfracIdx(nmat, k)] );
   }
   // momentum
   s[momentumIdx(nmat, 0)] = rb*u;

--- a/src/PDE/MultiMat/Problem/ShockDensityWave.cpp
+++ b/src/PDE/MultiMat/Problem/ShockDensityWave.cpp
@@ -95,8 +95,9 @@ MultiMatProblemShockDensityWave::initialize( ncomp_t ncomp,
     s[densityIdx(nmat, imat)] = s[volfracIdx(nmat, imat)]*r;
 
     // total specific energy
-    s[energyIdx(nmat, imat)] = s[volfracIdx(nmat, imat)]*
-      mat_blk[imat].compute< EOS::totalenergy >( r, u, v, w, p );
+    s[energyIdx(nmat, imat)] =
+      mat_blk[imat].compute< EOS::totalenergy >( s[volfracIdx(nmat, imat)]*r,
+      u, v, w, s[volfracIdx(nmat, imat)]*p, s[volfracIdx(nmat, imat)] );
 
     rb += s[densityIdx(nmat, imat)];
   }

--- a/src/PDE/MultiMat/Problem/ShockHeBubble.cpp
+++ b/src/PDE/MultiMat/Problem/ShockHeBubble.cpp
@@ -92,8 +92,9 @@ MultiMatProblemShockHeBubble::initialize( ncomp_t ncomp,
     // partial density
     s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)]*r[k];
     // total specific energy
-    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]*
-      mat_blk[k].compute< EOS::totalenergy >( r[k], u, v, w, p );
+    s[energyIdx(nmat, k)] =
+      mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat, k)]*r[k],
+      u, v, w, s[volfracIdx(nmat, k)]*p, s[volfracIdx(nmat, k)] );
     rb += s[densityIdx(nmat, k)];
   }
 

--- a/src/PDE/MultiMat/Problem/SinewavePacket.cpp
+++ b/src/PDE/MultiMat/Problem/SinewavePacket.cpp
@@ -64,8 +64,9 @@ MultiMatProblemSinewavePacket::initialize( ncomp_t ncomp,
   auto rhob = std::exp(-a*(xi-0.5)*(xi-0.5)) * std::sin(c*pi*xi) + 2.0;
   s[volfracIdx(nmat, 0)] = 1.0;
   s[densityIdx(nmat, 0)] = s[volfracIdx(nmat, 0)] * rhob;
-  s[energyIdx(nmat, 0)] = s[volfracIdx(nmat, 0)]
-    * mat_blk[0].compute< EOS::totalenergy >( rhob, u, v, w, 1.0 );
+  s[energyIdx(nmat, 0)] =
+    mat_blk[0].compute< EOS::totalenergy >( s[volfracIdx(nmat, 0)]*rhob, u, v, w,
+    s[volfracIdx(nmat, 0)]*1.0,  s[volfracIdx(nmat, 0)] );
   s[momentumIdx(nmat, 0)] = rhob * u;
   s[momentumIdx(nmat, 1)] = rhob * v;
   s[momentumIdx(nmat, 2)] = rhob * w;

--- a/src/PDE/MultiMat/Problem/SodShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/SodShocktube.cpp
@@ -82,10 +82,12 @@ MultiMatProblemSodShocktube::initialize( ncomp_t ncomp,
   s[densityIdx(nmat, 0)] = s[volfracIdx(nmat, 0)]*r;
   s[densityIdx(nmat, 1)] = s[volfracIdx(nmat, 1)]*r;
   // total specific energy
-  s[energyIdx(nmat, 0)] = s[volfracIdx(nmat, 0)]*
-    mat_blk[0].compute< EOS::totalenergy >( r, u, v, w, p );
-  s[energyIdx(nmat, 1)] = s[volfracIdx(nmat, 1)]*
-    mat_blk[1].compute< EOS::totalenergy >( r, u, v, w, p );
+  s[energyIdx(nmat, 0)] =
+    mat_blk[0].compute< EOS::totalenergy >( s[volfracIdx(nmat, 0)]*r, u, v, w,
+    s[volfracIdx(nmat, 0)]*p, s[volfracIdx(nmat, 0)] );
+  s[energyIdx(nmat, 1)] =
+    mat_blk[1].compute< EOS::totalenergy >( s[volfracIdx(nmat, 1)]*r, u, v, w,
+    s[volfracIdx(nmat, 1)]*p, s[volfracIdx(nmat, 1)] );
 
   return s;
 }

--- a/src/PDE/MultiMat/Problem/UnderwaterEx.cpp
+++ b/src/PDE/MultiMat/Problem/UnderwaterEx.cpp
@@ -99,8 +99,9 @@ MultiMatProblemUnderwaterEx::initialize( ncomp_t ncomp,
     // partial density
     s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)]*r[k];
     // total specific energy
-    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]*
-      mat_blk[k].compute< EOS::totalenergy >( r[k], u, v, w, p );
+    s[energyIdx(nmat, k)] =
+      mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat, k)]*r[k],
+      u, v, w, s[volfracIdx(nmat, k)]*p, s[volfracIdx(nmat, k)] );
     rb += s[densityIdx(nmat, k)];
   }
 

--- a/src/PDE/MultiMat/Problem/UserDefined.cpp
+++ b/src/PDE/MultiMat/Problem/UserDefined.cpp
@@ -93,9 +93,9 @@ MultiMatProblemUserDefined::initialize( ncomp_t ncomp,
       g = {{}};
     }
     // total specific energy
-    s[energyIdx(nmat,k)] = s[volfracIdx(nmat,k)] *
-      mat_blk[k].compute< EOS::totalenergy >(rhok, u, v, w, bgpreic,
-      g);
+    s[energyIdx(nmat,k)] =
+      mat_blk[k].compute< EOS::totalenergy >(s[volfracIdx(nmat,k)]*rhok, u, v,
+      w, s[volfracIdx(nmat,k)]*bgpreic, s[volfracIdx(nmat,k)], g);
     // bulk density
     rb += s[densityIdx(nmat,k)];
   }

--- a/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
+++ b/src/PDE/MultiMat/Problem/WaterAirShocktube.cpp
@@ -86,8 +86,9 @@ MultiMatProblemWaterAirShocktube::initialize( ncomp_t ncomp,
     // partial density
     s[densityIdx(nmat, k)] = s[volfracIdx(nmat, k)]*r[k];
     // total specific energy
-    s[energyIdx(nmat, k)] = s[volfracIdx(nmat, k)]*
-      mat_blk[k].compute< EOS::totalenergy >( r[k], u, v, w, p );
+    s[energyIdx(nmat, k)] =
+      mat_blk[k].compute< EOS::totalenergy >( s[volfracIdx(nmat, k)]*r[k],
+      u, v, w, s[volfracIdx(nmat, k)]*p, s[volfracIdx(nmat, k)] );
   }
 
   return s;

--- a/src/PDE/Reconstruction.cpp
+++ b/src/PDE/Reconstruction.cpp
@@ -965,11 +965,11 @@ evalFVSol( const std::vector< inciter::EOS >& mat_blk,
       alk = std::max(std::min(alk, 1.0-static_cast<tk::real>(nmat-1)*1e-12),
         1e-12);
     }
-    state[energyIdx(nmat,k)] = alk *
+    state[energyIdx(nmat,k)] =
       mat_blk[k].compute< inciter::EOS::totalenergy >(
-      state[densityIdx(nmat,k)]/alk, sprim[velocityIdx(nmat,0)],
+      state[densityIdx(nmat,k)], sprim[velocityIdx(nmat,0)],
       sprim[velocityIdx(nmat,1)], sprim[velocityIdx(nmat,2)],
-      sprim[pressureIdx(nmat,k)]/alk);
+      sprim[pressureIdx(nmat,k)], alk);
     rhob += state[densityIdx(nmat,k)];
   }
   // get momentum from reconstructed velocity and bulk density


### PR DESCRIPTION
EOS::totalenergy now returns \alpha_k \rho_k E_k