### PR TITLE
turn off rho0constraint by default since apparently we should not use it

### DIFF
--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -329,7 +329,7 @@ LuaParser::storeInputDeck(
       gideck.get< tag::multimat, tag::intsharp_param >(), 1.8);
     storeIfSpecd< uint64_t >(
       lua_ideck["multimat"], "rho0constraint",
-      gideck.get< tag::multimat, tag::rho0constraint >(), 1);
+      gideck.get< tag::multimat, tag::rho0constraint >(), 0);
     storeIfSpecd< int >(
       lua_ideck["multimat"], "dt_sos_massavg",
       gideck.get< tag::multimat, tag::dt_sos_massavg >(), 0);


### PR DESCRIPTION
Quick change to avoid potential problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/669)
<!-- Reviewable:end -->
