### PR TITLE
use 'orientation' keyword in control files to rotate overset mesh

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -1885,7 +1885,10 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
 
       keywords.insert({"orientation", "Configure orientation",
         R"(Configure orientation of an IC box for rotation about centroid of
-        box; or configure orientation of a mesh relative to another.)",
+        box (when specified within an IC 'box' block); or configure orientation
+        of a mesh (when specified within a 'mesh' block). Requires specification
+        of three angles about which the entity (box or mesh) is to be rotated.
+        The entity is rotated about the cartesian coordinate axes.)",
         "vector of 3 reals"});
 
       keywords.insert({"initiate", "Initiation type",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -1948,9 +1948,10 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
       keywords.insert({"filename", "Set filename",
         R"(Set filename, e.g., mesh filename for solver coupling.)", "string"});
 
-      keywords.insert({"location", "Configure location",
-        R"(Configure location of a mesh relative to another.)",
-        "vector of 3 reals"});
+      keywords.insert({"location", "Configure location of mesh",
+        R"(Configure location of a mesh relative to its local coordinate
+        system. Requires specification of three distances which are used to
+        relocate the mesh.)", "vector of 3 reals"});
 
       keywords.insert({"moment_of_inertia", "Moment of inertia of rigid body",
         R"(Moment of inertia of rigid body for rotational motion)", "real"});

--- a/src/Inciter/Partitioner.cpp
+++ b/src/Inciter/Partitioner.cpp
@@ -119,14 +119,44 @@ Partitioner::Partitioner(
 
   // Rotate mesh if specified
   if (rotate_mesh) {
+    auto mesh_cm =
+      g_inputdeck.get< tag::mesh >()[meshid].get< tag::center_of_mass >();
+    auto& x = m_coord[0];
+    auto& y = m_coord[1];
+    auto& z = m_coord[2];
+    for (std::size_t i=0; i<x.size(); ++i) {
+      std::array< tk::real, 3 >
+        point{{ x[i]-mesh_cm[0], y[i]-mesh_cm[1], z[i]-mesh_cm[2] }};
+      tk::rotatePoint(
+        {{ mesh_orientation[0], mesh_orientation[1], mesh_orientation[2] }},
+        point );
+      x[i] = point[0]+mesh_cm[0];
+      y[i] = point[1]+mesh_cm[1];
+      z[i] = point[2]+mesh_cm[2];
+    }
+  }
+
+  // Check if mesh location specified
+  auto mesh_location =
+    g_inputdeck.get< tag::mesh >()[meshid].get< tag::location >();
+  bool relocate_mesh(false);
+  for (std::size_t i=0; i<3; ++i) {
+    if (std::abs(mesh_location[i]) > 1e-8) {
+      relocate_mesh = true;
+      break;
+    }
+  }
+
+  // Relocate mesh if specified
+  if (relocate_mesh) {
     auto& x = m_coord[0];
     auto& y = m_coord[1];
     auto& z = m_coord[2];
     for (std::size_t i=0; i<x.size(); ++i) {
       std::array< tk::real, 3 > point{{ x[i], y[i], z[i] }};
-      tk::rotatePoint(
-        {{ mesh_orientation[0], mesh_orientation[1], mesh_orientation[2] }},
-        point );
+      // negative values due to how tk::movePoint() is interpreted
+      tk::movePoint(
+        {{ -mesh_location[0], -mesh_location[1], -mesh_location[2] }}, point );
       x[i] = point[0];
       y[i] = point[1];
       z[i] = point[2];

--- a/src/Inciter/Partitioner.cpp
+++ b/src/Inciter/Partitioner.cpp
@@ -24,6 +24,7 @@
 #include "DGPDE.hpp"
 #include "Inciter/Options/Scheme.hpp"
 #include "UnsMesh.hpp"
+#include "Vector.hpp"
 #include "ContainerUtil.hpp"
 #include "Callback.hpp"
 
@@ -104,6 +105,33 @@ Partitioner::Partitioner(
   std::vector< std::size_t > triinpoel;
   mr.readMeshPart( m_ginpoel, m_inpoel, triinpoel, m_lid, m_coord,
                    m_elemBlockId, CkNumNodes(), CkMyNode() );
+
+  // Check if mesh rotation specified
+  auto mesh_orientation =
+    g_inputdeck.get< tag::mesh >()[meshid].get< tag::orientation >();
+  bool rotate_mesh(false);
+  for (std::size_t i=0; i<3; ++i) {
+    if (std::abs(mesh_orientation[i]) > 1e-8) {
+      rotate_mesh = true;
+      break;
+    }
+  }
+
+  // Rotate mesh if specified
+  if (rotate_mesh) {
+    auto& x = m_coord[0];
+    auto& y = m_coord[1];
+    auto& z = m_coord[2];
+    for (std::size_t i=0; i<x.size(); ++i) {
+      std::array< tk::real, 3 > point{{ x[i], y[i], z[i] }};
+      tk::rotatePoint(
+        {{ mesh_orientation[0], mesh_orientation[1], mesh_orientation[2] }},
+        point );
+      x[i] = point[0];
+      y[i] = point[1];
+      z[i] = point[2];
+    }
+  }
 
   // Compute triangle connectivity for side sets, reduce boundary face for side
   // sets to this compute node only and to compute-node-local face ids


### PR DESCRIPTION
The orientation keyword inside the mesh block in the control file is used to rotate meshes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/670)
<!-- Reviewable:end -->
