### PR TITLE
Fixing some minor overset bugs

### DIFF
--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -1276,9 +1276,11 @@ OversetFE::solve()
       }
     }
 
-    // Mark if mesh moved
+    // Mark if mesh moved or is moving
     if (std::sqrt(tk::dot(m_surfForce, m_surfForce)) > 1e-12 ||
-      std::sqrt(tk::dot(m_surfTorque, m_surfTorque)) > 1e-12)
+      std::sqrt(tk::dot(m_surfTorque, m_surfTorque)) > 1e-12 ||
+      std::sqrt(tk::dot(m_centMassVeln, m_centMassVeln)) > 1e-12 ||
+      std::sqrt(m_angVelMeshn * m_angVelMeshn) > 1e-12 )
       m_movedmesh = 1;
     else
       m_movedmesh = 0;
@@ -1317,6 +1319,7 @@ OversetFE::solve()
         }
         r_mag = std::sqrt(r_mag);
         auto a_tgt = alpha_mesh*r_mag;
+        auto v_tgt = m_angVelMeshn*r_mag;
 
         // get the other two directions
         auto i1 = (sym_dir+1)%3;
@@ -1326,6 +1329,8 @@ OversetFE::solve()
         auto theta = std::atan2(rCM[i2],rCM[i1]);
         auto a1 = a_tgt*std::cos((pi/2.0)+theta);
         auto a2 = a_tgt*std::sin((pi/2.0)+theta);
+        auto v1 = v_tgt*std::cos((pi/2.0)+theta);
+        auto v2 = v_tgt*std::sin((pi/2.0)+theta);
 
         // angle of rotation
         auto dtheta = m_angVelMesh*dtp + 0.5*alpha_mesh*dtp*dtp;
@@ -1344,16 +1349,16 @@ OversetFE::solve()
           // mesh displacement from translation
           dsT = m_centMassVel[i]*dtp + 0.5*a_mesh[i]*dtp*dtp;
           // mesh displacement from rotation
-          dsR = rCM[i] + m_centMass[i] - d->Coordn()[i][p];
+          dsR = rCM[i] + m_centMassn[i] - d->Coordn()[i][p];
           // add both contributions
           d->Coord()[i][p] = d->Coordn()[i][p] + dsT + dsR;
           // mesh velocity change from translation
-          u_mesh(p,i) += a_mesh[i]*dtp;
+          u_mesh(p,i) = m_centMassVeln[i] + a_mesh[i]*dtp;
         }
 
         // add contribution of rotation to mesh velocity
-        u_mesh(p,i1) += a1*dtp;
-        u_mesh(p,i2) += a2*dtp;
+        u_mesh(p,i1) += v1 + a1*dtp;
+        u_mesh(p,i2) += v2 + a2*dtp;
       }
 
       // update angular velocity


### PR DESCRIPTION
This commit fixes three things:
1. The criteria for the mesh moving is that there is some force on it. Technically, the mesh could be moving even if it has no force applied to it if it has some velocity from a previous time step. This is a pretty unlikely, edge case scenario that I don't imagine would really ever happen, but maybe it could if there is some body moving at the exact speed as a background flow.
2. The displacement from the rotation used the center of mass location at the end of the previous RK stage, not the previous time step.
3. `u_mesh` does something similar as the rotation displacement. It also doesn't seem to properly take into account the angular velocity the mesh might already have.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/672)
<!-- Reviewable:end -->
