### PR TITLE
reintroduce check for negative/non-finite volume fractions in cleanTr…

### DIFF
--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -200,7 +200,34 @@ cleanTraceMultiMat(
       )
         ctm_element = true;
 
-      if (ctm_element) {
+      // check for unbounded volume fractions
+      if (alk < 0.0 || !std::isfinite(alk))
+      {
+        auto rhok = mat_blk[k].compute< EOS::density >(p_target,
+          std::max(1e-8,tmax));
+        if (std::isfinite(alk)) d_al += (alk - 1e-14);
+        // update state of trace material
+        U(e, volfracDofIdx(nmat, k, rdof, 0)) = 1e-14;
+        U(e, densityDofIdx(nmat, k, rdof, 0)) = 1e-14 * rhok;
+        auto gk = std::array< std::array< tk::real, 3 >, 3 >
+          {{ {{1, 0, 0}},
+             {{0, 1, 0}},
+             {{0, 0, 1}} }};
+        U(e, energyDofIdx(nmat, k, rdof, 0)) =
+          mat_blk[k].compute< EOS::totalenergy >(1e-14*rhok, u, v, w,
+          1e-14*p_target, 1e-14, gk);
+        P(e, pressureDofIdx(nmat, k, rdof, 0)) = 1e-14 *
+          p_target;
+        resetSolidTensors(nmat, k, e, U, P);
+        for (std::size_t i=1; i<rdof; ++i) {
+          U(e, volfracDofIdx(nmat, k, rdof, i)) = 0.0;
+          U(e, densityDofIdx(nmat, k, rdof, i)) = 0.0;
+          U(e, energyDofIdx(nmat, k, rdof, i)) = 0.0;
+          P(e, pressureDofIdx(nmat, k, rdof, i)) = 0.0;
+        }
+      }
+
+      else if (ctm_element) {
         tk::real prelax(0.0);
         std::array< std::array< tk::real, 3 >, 3 > gmat {{}};
         if (solidx[k] > 0) {

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -200,33 +200,6 @@ cleanTraceMultiMat(
       )
         ctm_element = true;
 
-      // check for unbounded volume fractions
-      if (alk < 0.0 || !std::isfinite(alk))
-      {
-        auto rhok = mat_blk[k].compute< EOS::density >(p_target,
-          std::max(1e-8,tmax));
-        if (std::isfinite(alk)) d_al += (alk - 1e-14);
-        // update state of trace material
-        U(e, volfracDofIdx(nmat, k, rdof, 0)) = 1e-14;
-        U(e, densityDofIdx(nmat, k, rdof, 0)) = 1e-14 * rhok;
-        auto gk = std::array< std::array< tk::real, 3 >, 3 >
-          {{ {{1, 0, 0}},
-             {{0, 1, 0}},
-             {{0, 0, 1}} }};
-        U(e, energyDofIdx(nmat, k, rdof, 0)) =
-          mat_blk[k].compute< EOS::totalenergy >(1e-14*rhok, u, v, w,
-          1e-14*p_target, 1e-14, gk);
-        P(e, pressureDofIdx(nmat, k, rdof, 0)) = 1e-14 *
-          p_target;
-        resetSolidTensors(nmat, k, e, U, P);
-        for (std::size_t i=1; i<rdof; ++i) {
-          U(e, volfracDofIdx(nmat, k, rdof, i)) = 0.0;
-          U(e, densityDofIdx(nmat, k, rdof, i)) = 0.0;
-          U(e, energyDofIdx(nmat, k, rdof, i)) = 0.0;
-          P(e, pressureDofIdx(nmat, k, rdof, i)) = 0.0;
-        }
-      }
-
       else if (ctm_element) {
         tk::real prelax(0.0);
         std::array< std::array< tk::real, 3 >, 3 > gmat {{}};
@@ -237,6 +210,13 @@ cleanTraceMultiMat(
             for (std::size_t j=0; j<3; ++j)
               gmat[i][j] = U(e, deformDofIdx(nmat, solidx[k], i, j, rdof, 0));
         }
+
+        // check for unbounded volume fractions
+        if (alk < 0.0 || !std::isfinite(alk)) {
+          if (std::isfinite(alk)) d_al += (alk - 1e-14);
+          alk = 1e-14;
+        }
+
         // determine target relaxation pressure
         prelax = mat_blk[k].compute< EOS::min_eff_pressure >(1e-10,
           U(e, densityDofIdx(nmat, k, rdof, 0)), alk);

--- a/src/PDE/MultiMat/MiscMultiMatFns.cpp
+++ b/src/PDE/MultiMat/MiscMultiMatFns.cpp
@@ -200,7 +200,7 @@ cleanTraceMultiMat(
       )
         ctm_element = true;
 
-      else if (ctm_element) {
+      if (ctm_element) {
         tk::real prelax(0.0);
         std::array< std::array< tk::real, 3 >, 3 > gmat {{}};
         if (solidx[k] > 0) {
@@ -213,8 +213,11 @@ cleanTraceMultiMat(
 
         // check for unbounded volume fractions
         if (alk < 0.0 || !std::isfinite(alk)) {
+          auto rhok = mat_blk[k].compute< EOS::density >(p_target,
+            std::max(1e-8,tmax));
           if (std::isfinite(alk)) d_al += (alk - 1e-14);
           alk = 1e-14;
+          U(e, densityDofIdx(nmat, k, rdof, 0)) = alk * rhok;
         }
 
         // determine target relaxation pressure


### PR DESCRIPTION
Reintroduces a check for negative volume fractions in `MiscMultiMatFns::cleanTraceMultiMat()`. In some cases, these types of volume fractions could pop up and cause crashes, and seem to need some special treatment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/682)
<!-- Reviewable:end -->
