### PR TITLE
Reorder integrations in IMEX

### DIFF
--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -2350,8 +2350,7 @@ std::vector< tk::real > DG::nonlinear_func(std::size_t e,
 
   // Compute stiff_rhs
   g_dgpde[d->MeshId()].stiff_rhs( e, myGhosts()->m_geoElem,
-    myGhosts()->m_inpoel, myGhosts()->m_coord,
-    m_u, m_p, m_ndof, m_stiffrhs );
+    m_u, m_ndof, m_stiffrhs );
 
   // Store f
   std::vector< tk::real > f(n, 0.0);

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -2173,21 +2173,33 @@ DG::imex_integrate()
     m_stiffrhsprev = m_stiffrhs;
 
     // Compute the imex update
+    const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
+    const auto neq = m_u.nprop()/rdof;
 
-    // Integrate explicitly on the imex equations
-    // (To use as initial values)
-    for (std::size_t e=0; e<myGhosts()->m_nunk; ++e) {
+    for (std::size_t e=0; e<nelem; ++e) {
       auto vole = myGhosts()->m_geoElem(e,0);
+      // Integrate explicitly on all equations
+      for (std::size_t c=0; c<neq; ++c)
+      {
+        for (std::size_t k=0; k<m_numEqDof[c]; ++k)
+        {
+          auto rmark = c*rdof+k;
+          auto mark = c*ndof+k;
+          m_u(e, rmark) = m_un(e, rmark) + d->Dt() * (
+            expl_rkcoef[0][m_stage] * m_rhsprev(e, mark)/(vole*mass_dubiner[k])
+            + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/(vole*mass_dubiner[k]));
+          if(fabs(m_u(e, rmark)) < 1e-16)
+            m_u(e, rmark) = 0;
+        }
+      }
+      // Integrate previous implicit step, which is now explicit
       for (std::size_t c=0; c<m_nstiffeq; ++c)
       {
         for (std::size_t k=0; k<m_numEqDof[c]; ++k)
         {
           auto rmark = m_stiffEqIdx[c]*rdof+k;
-          auto mark = m_stiffEqIdx[c]*ndof+k;
-          m_u(e, rmark) =  m_un(e, rmark) + d->Dt() * (
-            expl_rkcoef[0][m_stage] * m_rhsprev(e, mark)/(vole*mass_dubiner[k])
-            + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/(vole*mass_dubiner[k])
-            + impl_rkcoef[0][m_stage]
+          m_u(e, rmark) += d->Dt() *
+            ( impl_rkcoef[0][m_stage]
             * m_stiffrhsprev(e,c*ndof+k)/(vole*mass_dubiner[k]) );
           if(fabs(m_u(e, rmark)) < 1e-16)
             m_u(e, rmark) = 0;
@@ -2196,7 +2208,6 @@ DG::imex_integrate()
     }
 
     // Solve for implicit-explicit equations
-    const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
     for (std::size_t e=0; e<nelem; ++e)
     {
 
@@ -2243,37 +2254,21 @@ DG::imex_integrate()
 
     }
 
-    // Then, integrate explicitly on the remaining equations
-    for (std::size_t e=0; e<nelem; ++e) {
-      auto vole = myGhosts()->m_geoElem(e,0);
-      for (std::size_t c=0; c<m_nnonstiffeq; ++c)
-      {
-        for (std::size_t k=0; k<m_numEqDof[c]; ++k)
-        {
-          auto rmark = m_nonStiffEqIdx[c]*rdof+k;
-          auto mark = m_nonStiffEqIdx[c]*ndof+k;
-          m_u(e, rmark) =  m_un(e, rmark) + d->Dt() * (
-            expl_rkcoef[0][m_stage] * m_rhsprev(e, mark)/(vole*mass_dubiner[k])
-            + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/(vole*mass_dubiner[k]));
-          if(fabs(m_u(e, rmark)) < 1e-16)
-            m_u(e, rmark) = 0;
-        }
-      }
-    }
   }
   else {
     // For last stage just use all previously computed stages
     const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
+    const auto neq = m_u.nprop()/rdof;
     for (std::size_t e=0; e<nelem; ++e)
     {
       auto vole = myGhosts()->m_geoElem(e,0);
-      // First integrate explicitly on nonstiff equations
-      for (std::size_t c=0; c<m_nnonstiffeq; ++c)
+      // First integrate explicitly on all equations
+      for (std::size_t c=0; c<neq; ++c)
       {
         for (std::size_t k=0; k<m_numEqDof[c]; ++k)
         {
-          auto rmark = m_nonStiffEqIdx[c]*rdof+k;
-          auto mark = m_nonStiffEqIdx[c]*ndof+k;
+          auto rmark = c*rdof+k;
+          auto mark = c*ndof+k;
           m_u(e, rmark) =  m_un(e, rmark) + d->Dt() * (
             expl_rkcoef[0][m_stage] * m_rhsprev(e, mark)/(vole*mass_dubiner[k])
             + expl_rkcoef[1][m_stage] * m_rhs(e, mark)/(vole*mass_dubiner[k]));
@@ -2281,21 +2276,16 @@ DG::imex_integrate()
             m_u(e, rmark) = 0;
         }
       }
-      // Then, integrate the imex-equations
+      // Then, integrate the implicit part
       for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
         for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
         {
           auto rmark = m_stiffEqIdx[ieq]*rdof+idof;
-          auto mark = m_stiffEqIdx[ieq]*ndof+idof;
-          m_u(e, rmark) = m_un(e, rmark)
-            + d->Dt() * (expl_rkcoef[0][m_stage]
-                         * m_rhsprev(e,mark)/(vole*mass_dubiner[idof])
-                         + expl_rkcoef[1][m_stage]
-                         * m_rhs(e,mark)/(vole*mass_dubiner[idof])
-                         + impl_rkcoef[0][m_stage]
-                         * m_stiffrhsprev(e,ieq*ndof+idof)/(vole*mass_dubiner[idof])
-                         + impl_rkcoef[1][m_stage]
-                         * m_stiffrhs(e,ieq*ndof+idof)/(vole*mass_dubiner[idof]) );
+          m_u(e, rmark) +=
+            d->Dt() * ( impl_rkcoef[0][m_stage]
+                      * m_stiffrhsprev(e,ieq*ndof+idof)/(vole*mass_dubiner[idof])
+                      + impl_rkcoef[1][m_stage]
+                      * m_stiffrhs(e,ieq*ndof+idof)/(vole*mass_dubiner[idof]) );
           if(fabs(m_u(e, rmark)) < 1e-16)
             m_u(e, rmark) = 0;
         }

--- a/src/PDE/CompFlow/DGCompFlow.hpp
+++ b/src/PDE/CompFlow/DGCompFlow.hpp
@@ -782,18 +782,12 @@ class CompFlow {
     //! Compute stiff terms for a single element, not implemented here
     // //! \param[in] e Element number
     // //! \param[in] geoElem Element geometry array
-    // //! \param[in] inpoel Element-node connectivity
-    // //! \param[in] coord Array of nodal coordinates
     // //! \param[in] U Solution vector at recent time step
-    // //! \param[in] P Primitive vector at recent time step
     // //! \param[in] ndofel Vector of local number of degrees of freedom
     // //! \param[in,out] R Right-hand side vector computed
     void stiff_rhs( std::size_t /*e*/,
                     const tk::Fields& /*geoElem*/,
-                    const std::vector< std::size_t >& /*inpoel*/,
-                    const tk::UnsMesh::Coords& /*coord*/,
                     const tk::Fields& /*U*/,
-                    const tk::Fields& /*P*/,
                     const std::vector< std::size_t >& /*ndofel*/,
                     tk::Fields& /*R*/ ) const
     {}

--- a/src/PDE/DGPDE.hpp
+++ b/src/PDE/DGPDE.hpp
@@ -342,13 +342,10 @@ class DGPDE {
     //! Public interface for computing stiff terms for an element
     void stiff_rhs( std::size_t e,
                     const tk::Fields& geoElem,
-                    const std::vector< std::size_t >& inpoel,
-                    const tk::UnsMesh::Coords& coord,
                     const tk::Fields& U,
-                    const tk::Fields& P,
                     const std::vector< std::size_t >& ndofel,
                     tk::Fields& R ) const
-    { return self->stiff_rhs( e, geoElem, inpoel, coord, U, P, ndofel, R); }
+    { return self->stiff_rhs( e, geoElem, U, ndofel, R); }
 
     //! Public interface to returning maps of output var functions
     std::map< std::string, tk::GetVarFn > OutVarFn() const
@@ -535,9 +532,6 @@ class DGPDE {
                                            std::vector< tk::real >,
                                            tk::Fields& ) const = 0;
       virtual void stiff_rhs( std::size_t,
-                              const tk::Fields&,
-                              const std::vector< std::size_t >&,
-                              const tk::UnsMesh::Coords&,
                               const tk::Fields&,
                               const tk::Fields&,
                               const std::vector< std::size_t >&,
@@ -734,13 +728,10 @@ class DGPDE {
       { return data.balance_plastic_energy( e, x_star, x, U); }
       void stiff_rhs( std::size_t e,
                       const tk::Fields& geoElem,
-                      const std::vector< std::size_t >& inpoel,
-                      const tk::UnsMesh::Coords& coord,
                       const tk::Fields& U,
-                      const tk::Fields& P,
                       const std::vector< std::size_t >& ndofel,
                       tk::Fields& R ) const override
-      { return data.stiff_rhs( e, geoElem, inpoel, coord, U, P, ndofel, R ); }
+      { return data.stiff_rhs( e, geoElem, U, ndofel, R ); }
       std::map< std::string, tk::GetVarFn > OutVarFn() const override
       { return data.OutVarFn(); }
       std::vector< std::string > analyticFieldNames() const override

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1170,40 +1170,31 @@ class MultiMat {
     //! \param[in,out] R Right-hand side vector computed
     void stiff_rhs( std::size_t e,
                     const tk::Fields& geoElem,
-                    const std::vector< std::size_t >& inpoel,
-                    const tk::UnsMesh::Coords& coord,
+                    const std::vector< std::size_t >& /*inpoel*/,
+                    const tk::UnsMesh::Coords& /*coord*/,
                     const tk::Fields& U,
-                    const tk::Fields& P,
+                    const tk::Fields& /*P*/,
                     const std::vector< std::size_t >& ndofel,
                     tk::Fields& R ) const
     {
       const auto ndof = g_inputdeck.get< tag::ndof >();
       const auto rdof = g_inputdeck.get< tag::rdof >();
       auto nmat = g_inputdeck.get< tag::multimat, tag::nmat >();
-      const auto intsharp =
-        g_inputdeck.get< tag::multimat, tag::intsharp >();
       const auto& solidx = inciter::g_inputdeck.get<
         tag::matidxmap, tag::solidx >();
 
-      Assert( U.nunk() == P.nunk(), "Number of unknowns in solution "
-              "vector and primitive vector at recent time step incorrect" );
+      // Assert( U.nunk() == P.nunk(), "Number of unknowns in solution "
+      //         "vector and primitive vector at recent time step incorrect" );
       Assert( U.nprop() == rdof*m_ncomp, "Number of components in solution "
               "vector must equal "+ std::to_string(rdof*m_ncomp) );
-      Assert( P.nprop() == rdof*m_nprim, "Number of components in primitive "
-              "vector must equal "+ std::to_string(rdof*m_nprim) );
+      // Assert( P.nprop() == rdof*m_nprim, "Number of components in primitive "
+      //         "vector must equal "+ std::to_string(rdof*m_nprim) );
       Assert( R.nprop() == ndof*nstiffeq(), "Number of components in "
               "right-hand side must equal "+ std::to_string(ndof*nstiffeq()) );
 
       // set rhs to zero for element e
       for (std::size_t i=0; i<ndof*nstiffeq(); ++i)
         R(e, i) = 0.0;
-
-      const auto& cx = coord[0];
-      const auto& cy = coord[1];
-      const auto& cz = coord[2];
-
-      auto ncomp = U.nprop()/rdof;
-      auto nprim = P.nprop()/rdof;
 
       auto ng = tk::NGvol(ndofel[e]);
 
@@ -1218,26 +1209,14 @@ class MultiMat {
 
       tk::GaussQuadratureTet( ng, coordgp, wgp );
 
-      // Extract the element coordinates
-      std::array< std::array< tk::real, 3>, 4 > coordel {{
-        {{ cx[ inpoel[4*e  ] ], cy[ inpoel[4*e  ] ], cz[ inpoel[4*e  ] ] }},
-        {{ cx[ inpoel[4*e+1] ], cy[ inpoel[4*e+1] ], cz[ inpoel[4*e+1] ] }},
-        {{ cx[ inpoel[4*e+2] ], cy[ inpoel[4*e+2] ], cz[ inpoel[4*e+2] ] }},
-        {{ cx[ inpoel[4*e+3] ], cy[ inpoel[4*e+3] ], cz[ inpoel[4*e+3] ] }}
-      }};
-
       // Gaussian quadrature
       for (std::size_t igp=0; igp<ng; ++igp)
       {
-        // Compute the coordinates of quadrature point at physical domain
-        auto gp = tk::eval_gp( igp, coordel, coordgp );
-
         // Compute the basis function
         auto B = tk::eval_basis( ndofel[e], coordgp[0][igp], coordgp[1][igp],
                              coordgp[2][igp] );
 
-        auto state = tk::evalPolynomialSol(m_mat_blk, intsharp, ncomp, nprim,
-          rdof, nmat, e, ndofel[e], inpoel, coord, geoElem, gp, B, U, P);
+        auto state = tk::eval_state( m_ncomp, rdof, ndofel[e], e, U, B );
 
         // compute source
         // Loop through materials

--- a/src/PDE/MultiMat/DGMultiMat.hpp
+++ b/src/PDE/MultiMat/DGMultiMat.hpp
@@ -1162,18 +1162,12 @@ class MultiMat {
     //! Compute stiff terms for a single element
     //! \param[in] e Element number
     //! \param[in] geoElem Element geometry array
-    //! \param[in] inpoel Element-node connectivity
-    //! \param[in] coord Array of nodal coordinates
     //! \param[in] U Solution vector at recent time step
-    //! \param[in] P Primitive vector at recent time step
     //! \param[in] ndofel Vector of local number of degrees of freedom
     //! \param[in,out] R Right-hand side vector computed
     void stiff_rhs( std::size_t e,
                     const tk::Fields& geoElem,
-                    const std::vector< std::size_t >& /*inpoel*/,
-                    const tk::UnsMesh::Coords& /*coord*/,
                     const tk::Fields& U,
-                    const tk::Fields& /*P*/,
                     const std::vector< std::size_t >& ndofel,
                     tk::Fields& R ) const
     {

--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -794,18 +794,12 @@ class MultiSpecies {
     //! Compute stiff terms for a single element. No-op until chem sources added
     // //! \param[in] e Element number
     // //! \param[in] geoElem Element geometry array
-    // //! \param[in] inpoel Element-node connectivity
-    // //! \param[in] coord Array of nodal coordinates
     // //! \param[in] U Solution vector at recent time step
-    // //! \param[in] P Primitive vector at recent time step
     // //! \param[in] ndofel Vector of local number of degrees of freedom
     // //! \param[in,out] R Right-hand side vector computed
     void stiff_rhs( std::size_t /*e*/,
                     const tk::Fields& /*geoElem*/,
-                    const std::vector< std::size_t >& /*inpoel*/,
-                    const tk::UnsMesh::Coords& /*coord*/,
                     const tk::Fields& /*U*/,
-                    const tk::Fields& /*P*/,
                     const std::vector< std::size_t >& /*ndofel*/,
                     tk::Fields& /*R*/ ) const {}
 

--- a/src/PDE/Transport/DGTransport.hpp
+++ b/src/PDE/Transport/DGTransport.hpp
@@ -446,18 +446,12 @@ class Transport {
     //! Compute stiff terms for a single element, not implemented here
     // //! \param[in] e Element number
     // //! \param[in] geoElem Element geometry array
-    // //! \param[in] inpoel Element-node connectivity
-    // //! \param[in] coord Array of nodal coordinates
     // //! \param[in] U Solution vector at recent time step
-    // //! \param[in] P Primitive vector at recent time step
     // //! \param[in] ndofel Vector of local number of degrees of freedom
     // //! \param[in,out] R Right-hand side vector computed
     void stiff_rhs( std::size_t /*e*/,
                     const tk::Fields& /*geoElem*/,
-                    const std::vector< std::size_t >& /*inpoel*/,
-                    const tk::UnsMesh::Coords& /*coord*/,
                     const tk::Fields& /*U*/,
-                    const tk::Fields& /*P*/,
                     const std::vector< std::size_t >& /*ndofel*/,
                     tk::Fields& /*R*/ ) const
     {}


### PR DESCRIPTION
IMEX was incorrectly integrating the explicit equations after performing the implicit integrations, making it so the implicit variables used older versions of explicit variables.

Here we fix that by integrating the explicit part of all equations first, and performing the implicit operations afterwards.

In addition, due to the call to EvalPolynomialSol in stiff_rhs generating issues, we replaced it with a call to eval_state, which does the same thing minus the THINC reconstruction. A few argument were removed from stiff_rhs as a result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/685)
<!-- Reviewable:end -->
