### PR TITLE
Fix to star states of g-matrix in HLLC and HLLD solvers

### DIFF
--- a/src/Base/Vector.hpp
+++ b/src/Base/Vector.hpp
@@ -463,6 +463,18 @@ rotatePoint( const std::array< tk::real, 3 >& angles,
   point = x;
 }
 
+//! Check if 3x3 matrix is empty to avoid unnecesary calculations
+//! \param[in] mat 3x3 matrix.
+//! \return Boolean which will be true if matrix contains all zeros.
+inline bool is_matrix_empty(const std::array< std::array< tk::real, 3>, 3> mat)
+{
+  for (const auto& row : mat)
+    for (double v : row)
+      if (std::abs(v) < 1.0e-16)
+        return false;
+  return true;
+}
+
 //! \brief Get the Right Cauchy-Green strain tensor from the inverse deformation
 //! gradient tensor.
 //! \param[in] g Inverse deformation gradient tensor
@@ -681,6 +693,10 @@ inline std::array< std::array< tk::real, 3 >, 3 >
 rotateTensor(const std::array< std::array< tk::real, 3 >, 3 >& mat,
              const std::array< tk::real, 3 >& r )
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(mat))
+    return {{}};
+
   // define rotation matrix
   std::array< std::array< tk::real, 3 >, 3 > rotMatrix = getRotationMatrix(r);
   double rotMat[9];
@@ -728,6 +744,10 @@ inline std::array< std::array< tk::real, 3 >, 3 >
 unrotateTensor(const std::array< std::array< tk::real, 3 >, 3 >& mat,
                const std::array< tk::real, 3 >& r )
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(mat))
+    return {{}};
+
   // define rotation matrix
   std::array< std::array< tk::real, 3 >, 3 > rotMatrix = getRotationMatrix(r);
   double rotMat[9];
@@ -806,6 +826,10 @@ inline std::array< std::array< tk::real, 3 >, 3 >
 reflectTensor(const std::array< std::array< tk::real, 3 >, 3 >& mat,
               const std::array< std::array< tk::real, 3 >, 3 >& reflectMat)
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(mat))
+    return {{}};
+
   // define reflection matrix
   double refMat[9];
   for (std::size_t i=0; i<3; ++i)

--- a/src/Base/Vector.hpp
+++ b/src/Base/Vector.hpp
@@ -468,9 +468,9 @@ rotatePoint( const std::array< tk::real, 3 >& angles,
 //! \return Boolean which will be true if matrix contains all zeros.
 inline bool is_matrix_empty(const std::array< std::array< tk::real, 3>, 3> mat)
 {
-  for (const auto& row : mat)
-    for (double v : row)
-      if (std::abs(v) < 1.0e-16)
+  for (std::size_t i=0; i<3; ++i)
+    for (std::size_t j=0; j<3; ++j)
+      if (std::abs(mat[i][j]) > 1.0e-16)
         return false;
   return true;
 }
@@ -482,6 +482,10 @@ inline bool is_matrix_empty(const std::array< std::array< tk::real, 3>, 3> mat)
 inline std::array< std::array< real, 3 >, 3 >
 getRightCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(g))
+    return {{}};
+
   // allocate matrices
   double G[9], C[9];
 
@@ -523,6 +527,10 @@ getRightCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
 inline std::array< std::array< real, 3 >, 3 >
 getLeftCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(g))
+    return {{}};
+
   // allocate matrices
   double G[9], b[9];
 
@@ -581,6 +589,10 @@ getIsochorRightCauchyGreen(const std::array< std::array< real, 3 >, 3 >& g)
 inline std::array< std::array< real, 3 >, 3 >
 getDevHencky(const std::array< std::array< real, 3 >, 3 >& g)
 {
+  // Return empty if input matrix is empty
+  if (is_matrix_empty(g))
+    return {{}};
+
   // Get right volm-preserving part of Cauchy-Green strain tensor
   auto C = getIsochorRightCauchyGreen(g);
 

--- a/src/PDE/Riemann/HLLCMultiMat.hpp
+++ b/src/PDE/Riemann/HLLCMultiMat.hpp
@@ -255,11 +255,13 @@ struct HLLCMultiMat {
     auto uStar = u;
 
     tk::real rholStar(0.0), rhorStar(0.0);
-    std::vector< std::array< std::array< tk::real, 3 >, 3 > > gnlStar, gnrStar;
-    std::vector< std::array< std::array< tk::real, 3 >, 3 > > glStar, grStar;
+    std::array< std::array< tk::real, 3 >, 3 > tempArray {{ {0,0,0}, {0,0,0}, {0,0,0} }};
+    std::vector< std::array< std::array< tk::real, 3 >, 3 > >
+      gnlStar(nmat, tempArray), gnrStar(nmat, tempArray),
+      glStar(nmat, tempArray), grStar(nmat, tempArray);
     for (std::size_t k=0; k<nmat; ++k) {
       // Left
-      gnlStar.push_back(gnl[k]);
+      gnlStar[k] = gnl[k];
       if (solidx[k] > 0)
       {
         gnlStar[k][0][0] = w_l * gnl[k][0][0]
@@ -273,7 +275,7 @@ struct HLLCMultiMat {
           + gnl[k][2][2]*(vnl[2]-vnlStar[2])/(Sm-Sl);
       }
       // rotate g back to original frame of reference
-      glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
+      glStar[k] = tk::unrotateTensor(gnlStar[k], fn);
       uStar[0][volfracIdx(nmat, k)] = u[0][volfracIdx(nmat, k)];
       uStar[0][densityIdx(nmat, k)] = w_l * u[0][densityIdx(nmat, k)];
       uStar[0][energyIdx(nmat, k)] = w_l * u[0][energyIdx(nmat, k)]
@@ -287,7 +289,7 @@ struct HLLCMultiMat {
       rholStar += uStar[0][densityIdx(nmat, k)];
 
       // Right
-      gnrStar.push_back(gnr[k]);
+      gnrStar[k] = gnr[k];
       if (solidx[k] > 0)
       {
         gnrStar[k][0][0] = w_r * gnr[k][0][0]
@@ -301,7 +303,7 @@ struct HLLCMultiMat {
           + gnr[k][2][2]*(vnr[2]-vnrStar[2])/(Sm-Sr);
       }
       // rotate g back to original frame of reference
-      grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
+      grStar[k] = tk::unrotateTensor(gnrStar[k], fn);
       uStar[1][volfracIdx(nmat, k)] = u[1][volfracIdx(nmat, k)];
       uStar[1][densityIdx(nmat, k)] = w_r * u[1][densityIdx(nmat, k)];
       uStar[1][energyIdx(nmat, k)] = w_r * u[1][energyIdx(nmat, k)]

--- a/src/PDE/Riemann/HLLCMultiMat.hpp
+++ b/src/PDE/Riemann/HLLCMultiMat.hpp
@@ -259,9 +259,9 @@ struct HLLCMultiMat {
     std::vector< std::array< std::array< tk::real, 3 >, 3 > > glStar, grStar;
     for (std::size_t k=0; k<nmat; ++k) {
       // Left
+      gnlStar.push_back(gnl[k]);
       if (solidx[k] > 0)
       {
-        gnlStar.push_back(gnl[k]);
         gnlStar[k][0][0] = w_l * gnl[k][0][0]
           + gnl[k][0][1]*(vnl[1]-vnlStar[1])/(Sm-Sl)
           + gnl[k][0][2]*(vnl[2]-vnlStar[2])/(Sm-Sl);
@@ -271,9 +271,9 @@ struct HLLCMultiMat {
         gnlStar[k][2][0] = w_l * gnl[k][2][0]
           + gnl[k][2][1]*(vnl[1]-vnlStar[1])/(Sm-Sl)
           + gnl[k][2][2]*(vnl[2]-vnlStar[2])/(Sm-Sl);
-        // rotate g back to original frame of reference
-        glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
       }
+      // rotate g back to original frame of reference
+      glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
       uStar[0][volfracIdx(nmat, k)] = u[0][volfracIdx(nmat, k)];
       uStar[0][densityIdx(nmat, k)] = w_l * u[0][densityIdx(nmat, k)];
       uStar[0][energyIdx(nmat, k)] = w_l * u[0][energyIdx(nmat, k)]
@@ -287,9 +287,9 @@ struct HLLCMultiMat {
       rholStar += uStar[0][densityIdx(nmat, k)];
 
       // Right
+      gnrStar.push_back(gnr[k]);
       if (solidx[k] > 0)
       {
-        gnrStar.push_back(gnr[k]);
         gnrStar[k][0][0] = w_r * gnr[k][0][0]
           + gnr[k][0][1]*(vnr[1]-vnrStar[1])/(Sm-Sr)
           + gnr[k][0][2]*(vnr[2]-vnrStar[2])/(Sm-Sr);
@@ -299,9 +299,9 @@ struct HLLCMultiMat {
         gnrStar[k][2][0] = w_r * gnr[k][2][0]
           + gnr[k][2][1]*(vnr[1]-vnrStar[1])/(Sm-Sr)
           + gnr[k][2][2]*(vnr[2]-vnrStar[2])/(Sm-Sr);
-        // rotate g back to original frame of reference
-        grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
       }
+      // rotate g back to original frame of reference
+      grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
       uStar[1][volfracIdx(nmat, k)] = u[1][volfracIdx(nmat, k)];
       uStar[1][densityIdx(nmat, k)] = w_r * u[1][densityIdx(nmat, k)];
       uStar[1][energyIdx(nmat, k)] = w_r * u[1][energyIdx(nmat, k)]

--- a/src/PDE/Riemann/HLLDMultiMat.hpp
+++ b/src/PDE/Riemann/HLLDMultiMat.hpp
@@ -223,11 +223,13 @@ struct HLLDMultiMat {
     auto uStar = u;
 
     tk::real rholStar(0.0), rhorStar(0.0);
-    std::vector< std::array< std::array< tk::real, 3 >, 3 > > gnlStar, gnrStar;
-    std::vector< std::array< std::array< tk::real, 3 >, 3 > > glStar, grStar;
+    std::array< std::array< tk::real, 3 >, 3 > tempArray {{ {0,0,0}, {0,0,0}, {0,0,0} }};
+    std::vector< std::array< std::array< tk::real, 3 >, 3 > >
+      gnlStar(nmat, tempArray), gnrStar(nmat, tempArray),
+      glStar(nmat, tempArray), grStar(nmat, tempArray);
     for (std::size_t k=0; k<nmat; ++k) {
       // Left
-      gnlStar.push_back(gnl[k]);
+      gnlStar[k] = gnl[k];
       if (solidx[k] > 0)
       {
         gnlStar[k][0][0] *= w_l;
@@ -235,7 +237,7 @@ struct HLLDMultiMat {
         gnlStar[k][2][0] *= w_l;
       }
       // rotate g back to original frame of reference
-      glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
+      glStar[k] = tk::unrotateTensor(gnlStar[k], fn);
       uStar[0][volfracIdx(nmat, k)] = u[0][volfracIdx(nmat, k)];
       uStar[0][densityIdx(nmat, k)] = w_l * u[0][densityIdx(nmat, k)];
       uStar[0][energyIdx(nmat, k)] = w_l * u[0][energyIdx(nmat, k)]
@@ -246,7 +248,7 @@ struct HLLDMultiMat {
         uStar[0][densityIdx(nmat, k)], uStar[0][volfracIdx(nmat, k)], k );
 
       // Right
-      gnrStar.push_back(gnr[k]);
+      gnrStar[k] = gnr[k];
       if (solidx[k] > 0)
       {
         gnrStar[k][0][0] *= w_r;
@@ -254,7 +256,7 @@ struct HLLDMultiMat {
         gnrStar[k][2][0] *= w_r;
       }
       // rotate g back to original frame of reference
-      grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
+      grStar[k] = tk::unrotateTensor(gnrStar[k], fn);
       uStar[1][volfracIdx(nmat, k)] = u[1][volfracIdx(nmat, k)];
       uStar[1][densityIdx(nmat, k)] = w_r * u[1][densityIdx(nmat, k)];
       uStar[1][energyIdx(nmat, k)] = w_r * u[1][energyIdx(nmat, k)]
@@ -297,7 +299,7 @@ struct HLLDMultiMat {
     std::array< std::array< tk::real, 3 >, 3 >
       gnrStarStar{{{0,0,0},{0,0,0},{0,0,0}}};
     std::vector< std::array< std::array< tk::real, 3 >, 3 > >
-      glStarStar, grStarStar;
+      glStarStar(nmat, tempArray), grStarStar(nmat, tempArray);
     auto uStarStar = uStar;
     if (nsld > 0) {
       for (std::size_t k=0; k<nmat; ++k) {
@@ -389,7 +391,7 @@ struct HLLDMultiMat {
                              + gnlStar[k][2][2]*(vnl[2]-vnlStarStar[2])/(Sm-Ssl);
         }
         // rotate g back to original frame of reference
-        glStarStar.push_back(tk::unrotateTensor(gnlStarStar, fn));
+        glStarStar[k] = tk::unrotateTensor(gnlStarStar, fn);
         uStarStar[0][volfracIdx(nmat, k)] = uStar[0][volfracIdx(nmat, k)];
         uStarStar[0][densityIdx(nmat, k)] = uStar[0][densityIdx(nmat, k)];
         uStarStar[0][energyIdx(nmat, k)] = uStar[0][energyIdx(nmat, k)]
@@ -412,7 +414,7 @@ struct HLLDMultiMat {
                              + gnrStar[k][2][2]*(vnr[2]-vnrStarStar[2])/(Sm-Ssr);
         }
         // rotate g back to original frame of reference
-        grStarStar.push_back(tk::unrotateTensor(gnrStarStar, fn));
+        grStarStar[k] = tk::unrotateTensor(gnrStarStar, fn);
         uStarStar[1][volfracIdx(nmat, k)] = uStar[1][volfracIdx(nmat, k)];
         uStarStar[1][densityIdx(nmat, k)] = uStar[1][densityIdx(nmat, k)];
         uStarStar[1][energyIdx(nmat, k)] = uStar[1][energyIdx(nmat, k)]

--- a/src/PDE/Riemann/HLLDMultiMat.hpp
+++ b/src/PDE/Riemann/HLLDMultiMat.hpp
@@ -227,15 +227,15 @@ struct HLLDMultiMat {
     std::vector< std::array< std::array< tk::real, 3 >, 3 > > glStar, grStar;
     for (std::size_t k=0; k<nmat; ++k) {
       // Left
+      gnlStar.push_back(gnl[k]);
       if (solidx[k] > 0)
       {
-        gnlStar.push_back(gnl[k]);
         gnlStar[k][0][0] *= w_l;
         gnlStar[k][1][0] *= w_l;
         gnlStar[k][2][0] *= w_l;
-        // rotate g back to original frame of reference
-        glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
       }
+      // rotate g back to original frame of reference
+      glStar.push_back(tk::unrotateTensor(gnlStar[k], fn));
       uStar[0][volfracIdx(nmat, k)] = u[0][volfracIdx(nmat, k)];
       uStar[0][densityIdx(nmat, k)] = w_l * u[0][densityIdx(nmat, k)];
       uStar[0][energyIdx(nmat, k)] = w_l * u[0][energyIdx(nmat, k)]
@@ -246,15 +246,15 @@ struct HLLDMultiMat {
         uStar[0][densityIdx(nmat, k)], uStar[0][volfracIdx(nmat, k)], k );
 
       // Right
+      gnrStar.push_back(gnr[k]);
       if (solidx[k] > 0)
       {
-        gnrStar.push_back(gnr[k]);
         gnrStar[k][0][0] *= w_r;
         gnrStar[k][1][0] *= w_r;
         gnrStar[k][2][0] *= w_r;
-        // rotate g back to original frame of reference
-        grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
       }
+      // rotate g back to original frame of reference
+      grStar.push_back(tk::unrotateTensor(gnrStar[k], fn));
       uStar[1][volfracIdx(nmat, k)] = u[1][volfracIdx(nmat, k)];
       uStar[1][densityIdx(nmat, k)] = w_r * u[1][densityIdx(nmat, k)];
       uStar[1][energyIdx(nmat, k)] = w_r * u[1][energyIdx(nmat, k)]
@@ -387,9 +387,9 @@ struct HLLDMultiMat {
                              + gnlStar[k][1][2]*(vnl[2]-vnlStarStar[2])/(Sm-Ssl);
           gnlStarStar[2][0] += gnlStar[k][2][1]*(vnl[1]-vnlStarStar[1])/(Sm-Ssl)
                              + gnlStar[k][2][2]*(vnl[2]-vnlStarStar[2])/(Sm-Ssl);
-          // rotate g back to original frame of reference
-          glStarStar.push_back(tk::unrotateTensor(gnlStarStar, fn));
         }
+        // rotate g back to original frame of reference
+        glStarStar.push_back(tk::unrotateTensor(gnlStarStar, fn));
         uStarStar[0][volfracIdx(nmat, k)] = uStar[0][volfracIdx(nmat, k)];
         uStarStar[0][densityIdx(nmat, k)] = uStar[0][densityIdx(nmat, k)];
         uStarStar[0][energyIdx(nmat, k)] = uStar[0][energyIdx(nmat, k)]
@@ -410,9 +410,9 @@ struct HLLDMultiMat {
                              + gnrStar[k][1][2]*(vnr[2]-vnrStarStar[2])/(Sm-Ssr);
           gnrStarStar[2][0] += gnrStar[k][2][1]*(vnr[1]-vnrStarStar[1])/(Sm-Ssr)
                              + gnrStar[k][2][2]*(vnr[2]-vnrStarStar[2])/(Sm-Ssr);
-          // rotate g back to original frame of reference
-          grStarStar.push_back(tk::unrotateTensor(gnrStarStar, fn));
         }
+        // rotate g back to original frame of reference
+        grStarStar.push_back(tk::unrotateTensor(gnrStarStar, fn));
         uStarStar[1][volfracIdx(nmat, k)] = uStar[1][volfracIdx(nmat, k)];
         uStarStar[1][densityIdx(nmat, k)] = uStar[1][densityIdx(nmat, k)];
         uStarStar[1][energyIdx(nmat, k)] = uStar[1][energyIdx(nmat, k)]


### PR DESCRIPTION
Fixed a bug where inner states the g-matrix were being allocated only for solids, which led to incorrect memory allocations if solids' indexes came after fluids'.

Additionally, Implemented a function in Base/Vector.hpp to more safely and cheaply deal with empty inputs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/688)
<!-- Reviewable:end -->
