### PR TITLE
Option to provide NASA9 database file and input species by their name to simplify control files in MultiSpecies

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -131,12 +131,13 @@ using materialList = tk::TaggedTuple< brigand::list<
 
 // Species/EOS object
 using speciesList = tk::TaggedTuple< brigand::list<
-  tag::id,       std::vector< uint64_t >,
-  tag::gamma,    std::vector< tk::real >,
-  tag::R,        std::vector< tk::real >,
-  tag::cp_coeff, std::vector< std::vector< std::vector< tk::real > > >,
-  tag::t_range,  std::vector< std::vector< tk::real > >,
-  tag::dH_ref,   std::vector< tk::real >
+  tag::id,        std::vector< uint64_t >,
+  tag::gamma,     std::vector< tk::real >,
+  tag::R,         std::vector< tk::real >,
+  tag::cp_coeff,  std::vector< std::vector< std::vector< tk::real > > >,
+  tag::t_range,   std::vector< std::vector< tk::real > >,
+  tag::dH_ref,    std::vector< tk::real >,
+  tag::spec_name, std::vector< std::string >
 > >;
 
 // Boundary conditions block
@@ -301,6 +302,9 @@ using ConfigMembers = brigand::list<
   tag::imex_maxiter,     uint32_t,
   tag::imex_reltol,      tk::real,
   tag::imex_abstol,      tk::real,
+
+  // NASA9 database location for MultiSpecies
+  tag::nasa9_filepath, std::string,
 
   // steady-state solver options
   tag::implicit_timestepping, bool,
@@ -564,6 +568,17 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keywords is used to specify the absolute tolerance that
         the non-linear solver uses to obtain the implicit unknowns within the
         Implicit-Explicit Runge-Kutta scheme.)", "real"});
+
+      // -----------------------------------------------------------------------
+      // MultiSpecies option to provide NASA9 DB filepath
+      // -----------------------------------------------------------------------
+
+      keywords.insert({"nasa9_filepath",
+        "Provide the path to the NASA9 data file",
+        R"(This keywords is used to specify the filepath of the NASA9 database
+        file. By providing this file, the user is able to initialize species by
+        providing their names (variable spec_name) and the rest of the parameters
+        will be read from the file)", "real"});
 
       // -----------------------------------------------------------------------
       // steady-state solver options
@@ -1135,6 +1150,11 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         the reference temperature in the enthalpy calculations is 0 K. This number
         is taken from the NASA Glenn 2002 report, and is the heat of formation
         divided by the species molar mass.)", "vector of reals"});
+
+      keywords.insert({"spec_name", "List of species names, e.g. CO2, Ar.",
+        R"(This keyword is used to specify a list of chemical species which will serve
+        as reference for the program to retrieve its TPG coefficients from the NASA9
+        database)", "vector of strings"});
 
       keywords.insert({"R", "Specific gas constant",
         R"(This keyword is used to specify the species property, specific gas

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -578,7 +578,9 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keywords is used to specify the filepath of the NASA9 database
         file. By providing this file, the user is able to initialize species by
         providing their names (variable spec_name) and the rest of the parameters
-        will be read from the file)", "real"});
+        will be read from the file. Default assumes file is called nasa9.dat and
+        is located the working directory where inciter is being executed from)",
+        "string"});
 
       // -----------------------------------------------------------------------
       // steady-state solver options
@@ -1154,7 +1156,8 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
       keywords.insert({"spec_name", "List of species names, e.g. CO2, Ar.",
         R"(This keyword is used to specify a list of chemical species which will serve
         as reference for the program to retrieve its TPG coefficients from the NASA9
-        database)", "vector of strings"});
+        database. if species names are specified, the nasa9_filepath must be specified
+        or the nasa9 database must be present at the default location.)", "strings"});
 
       keywords.insert({"R", "Specific gas constant",
         R"(This keyword is used to specify the species property, specific gas

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -668,7 +668,7 @@ LuaParser::storeInputDeck(
           for (std::size_t ispec=0; ispec<nspec; ++ispec){
             std::string spec_name =
               spci_deck.get< tag::spec_name >()[ispec];
-            nasa9_cache[spci_deck.get< tag::spec_name >()[ispec]] =
+            nasa9_cache[spec_name] =
               read_nasa9_species(nasa9_path, spec_name);
 
             const N9Species& spec = nasa9_cache.at(spec_name);
@@ -685,13 +685,13 @@ LuaParser::storeInputDeck(
                 t_range[ispec][interv+1] = I.Thigh;
             }
           }
-            // Store unknowns (manually for the high-dimension ones)
-            storeVecIfSpecd< tk::real >(
-              sol_spc[i+1], "R", spci_deck.get< tag::R >(), R);
-            storeVecIfSpecd< tk::real >(
-              sol_spc[i+1], "dH_ref", spci_deck.get< tag::dH_ref >(), dH_ref);
-            spci_deck.get< tag::cp_coeff >() = cp_coeff;
-            spci_deck.get< tag::t_range >() = t_range;
+          // Store unknowns (manually for the high-dimension ones)
+          storeVecIfSpecd< tk::real >(
+            sol_spc[i+1], "R", spci_deck.get< tag::R >(), R);
+          storeVecIfSpecd< tk::real >(
+            sol_spc[i+1], "dH_ref", spci_deck.get< tag::dH_ref >(), dH_ref);
+          spci_deck.get< tag::cp_coeff >() = cp_coeff;
+          spci_deck.get< tag::t_range >() = t_range;
         }
         else {
           // R

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -23,6 +23,8 @@
 #include "PDE/MultiMat/MultiMatIndexing.hpp"
 #include "PDE/MultiSpecies/MultiSpeciesIndexing.hpp"
 
+#include "Nasa9DB.hpp"
+
 namespace tk {
 namespace grm {
 
@@ -157,6 +159,11 @@ LuaParser::storeInputDeck(
     Throw("No time step calculation policy has been selected in the "
       "preceeding block. Use keyword 'dt' to set a constant or 'cfl' to set an "
       "adaptive time step size calculation policy.");
+
+  // Option to provide NASA9 file directory to read species for MultiSpecies
+  // ---------------------------------------------------------------------------
+  storeIfSpecd< std::string >(
+    lua_ideck, "nasa9_filepath", gideck.get< tag::nasa9_filepath >(), "nasa9.dat");
 
   // partitioning/reordering options
   // ---------------------------------------------------------------------------
@@ -643,18 +650,63 @@ LuaParser::storeInputDeck(
         Assert(nspec == spci_deck.get< tag::id >().size(),
           "Number of ids in species-block not equal to number of species");
 
-        // R
-        checkStoreMatProp(sol_spc[i+1], "R", nspec,
-          spci_deck.get< tag::R >());
-        // cp_coeff
-        checkStoreMatPropVecVec(sol_spc[i+1], "cp_coeff", nspec, 3, 8,
-          spci_deck.get< tag::cp_coeff >());
-        // t_range
-        checkStoreMatPropVec(sol_spc[i+1], "t_range", nspec, 4,
-          spci_deck.get< tag::t_range >());
-        // dH_ref
-        checkStoreMatProp(sol_spc[i+1], "dH_ref", nspec,
-          spci_deck.get< tag::dH_ref >());
+        // If names are given, ready data from Nasa9 file, otherwise read all
+        // from control file
+        storeVecIfSpecd< std::string >(
+          sol_spc[i+1], "spec_name", spci_deck.get< tag::spec_name >(),
+          std::vector< std::string >(nspec, ""));
+        if (sol_spc[i+1]["spec_name"].valid()) {
+          std::string nasa9_path = gideck.get< tag::nasa9_filepath >();
+          std::unordered_map<std::string,N9Species> nasa9_cache;
+
+          std::vector<tk::real> R(nspec);
+          std::vector<std::vector<std::vector<tk::real>>> cp_coeff(nspec,
+            std::vector<std::vector<tk::real>>( 3, std::vector<tk::real>(8)));
+          std::vector<std::vector<tk::real>> t_range(nspec,
+            std::vector<tk::real>(4));
+          std::vector<tk::real> dH_ref(nspec);
+          for (std::size_t ispec=0; ispec<nspec; ++ispec){
+            std::string spec_name =
+              spci_deck.get< tag::spec_name >()[ispec];
+            nasa9_cache[spci_deck.get< tag::spec_name >()[ispec]] =
+              read_nasa9_species(nasa9_path, spec_name);
+
+            const N9Species& spec = nasa9_cache.at(spec_name);
+            dH_ref[ispec] = spec.Hf298_mass;
+            R[ispec] = spec.R();
+
+            // Loop over intervals and retrieve coefficients
+            for (std::size_t interv = 0; interv < spec.nIntervals(); ++interv) {
+              const N9Interval& I = spec.intervalByIndex(interv);
+              for (std::size_t k = 0; k < 9; ++k)
+                cp_coeff[ispec][interv][k] = I.a[k];
+              t_range[ispec][interv] = I.Tlow;
+              if (interv == spec.nIntervals()-1)
+                t_range[ispec][interv+1] = I.Thigh;
+            }
+          }
+            // Store unknowns (manually for the high-dimension ones)
+            storeVecIfSpecd< tk::real >(
+              sol_spc[i+1], "R", spci_deck.get< tag::R >(), R);
+            storeVecIfSpecd< tk::real >(
+              sol_spc[i+1], "dH_ref", spci_deck.get< tag::dH_ref >(), dH_ref);
+            spci_deck.get< tag::cp_coeff >() = cp_coeff;
+            spci_deck.get< tag::t_range >() = t_range;
+        }
+        else {
+          // R
+          checkStoreMatProp(sol_spc[i+1], "R", nspec,
+            spci_deck.get< tag::R >());
+          // cp_coeff
+          checkStoreMatPropVecVec(sol_spc[i+1], "cp_coeff", nspec, 3, 8,
+            spci_deck.get< tag::cp_coeff >());
+          // t_range
+          checkStoreMatPropVec(sol_spc[i+1], "t_range", nspec, 4,
+            spci_deck.get< tag::t_range >());
+          // dH_ref
+          checkStoreMatProp(sol_spc[i+1], "dH_ref", nspec,
+            spci_deck.get< tag::dH_ref >());
+        }
       }
 
       // Generate mapping between material index and eos parameter index

--- a/src/Control/Inciter/InputDeck/Nasa9DB.hpp
+++ b/src/Control/Inciter/InputDeck/Nasa9DB.hpp
@@ -203,5 +203,5 @@ inline N9Species read_nasa9_species(const std::string& file,
     return sp;
   }
 
-  throw std::runtime_error("Species " + targetName + " not found in " + file);
+  Throw("Species " + targetName + " not found in " + file);
 }

--- a/src/Control/Inciter/InputDeck/Nasa9DB.hpp
+++ b/src/Control/Inciter/InputDeck/Nasa9DB.hpp
@@ -88,10 +88,10 @@ struct N9Species {
 
 // Fixed-width 5×16 field reader (NASA style)
 inline void n9_collect_fw(const std::string& line, std::vector<double>& out) {
-  for (int f = 0; f < 5; ++f) {
-    int start = f * 16;
-    if (start >= (int)line.size()) break;
-    int end = std::min(start + 16, (int)line.size());
+  for (std::size_t f = 0; f < 5; ++f) {
+    std::size_t start = f * 16;
+    if (start >= line.size()) break;
+    std::size_t end = std::min(start + 16, line.size());
     std::string chunk = line.substr(start, end - start);
     if (chunk.find_first_not_of(" \t\r\n") == std::string::npos) continue;
     for (char& c : chunk) if (c=='D' || c=='d') c = 'E';
@@ -158,7 +158,7 @@ inline N9Species read_nasa9_species(const std::string& file,
     sp.Hf298_mass  = Hf298 / Mw;
 
     // 3 intervals: header + 2 coeff lines each
-    for (int iv = 0; iv < 3; ++iv) {
+    for (std::size_t iv = 0; iv < 3; ++iv) {
       std::string hdr;
       // skip comments/blank lines between blocks
       while (true) {
@@ -194,7 +194,7 @@ inline N9Species read_nasa9_species(const std::string& file,
       N9Interval I;
       I.Tlow  = Tmin;
       I.Thigh = Tmax;
-      for (int k = 0; k < 9; ++k)
+      for (std::size_t k = 0; k < 9; ++k)
         I.a[k] = coeffs[k];
 
       sp.intervals.push_back(I);

--- a/src/Control/Inciter/InputDeck/Nasa9DB.hpp
+++ b/src/Control/Inciter/InputDeck/Nasa9DB.hpp
@@ -1,0 +1,207 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <array>
+#include <fstream>
+#include <sstream>
+#include <cctype>
+#include <cmath>
+#include <stdexcept>
+
+constexpr double NASA9_RU = 8.31446261815324; // J/(mol·K)
+
+struct N9Interval {
+  double Tlow  = 0.0;
+  double Thigh = 0.0;
+  std::array<double,9> a{};
+};
+
+struct N9Species {
+  std::string name;
+  double Mw         = 0.0;  // kg/mol
+  double Hf298_mol  = 0.0;  // J/mol (formation)
+  double Hf298_mass = 0.0;  // J/kg (formation)
+  std::vector<N9Interval> intervals; // should be 3
+
+  double R() const { return NASA9_RU / Mw; }   // J/(kg·K)
+
+  const std::vector<N9Interval>& getIntervals() const { return intervals; }
+
+  std::size_t nIntervals() const { return intervals.size(); }
+
+  const N9Interval& intervalByIndex(std::size_t i) const {
+    return intervals.at(i);
+  }
+
+  const N9Interval& interval(double T) const {
+    if (intervals.empty())
+      throw std::runtime_error("No intervals for " + name);
+    if (T <= intervals.front().Thigh) return intervals.front();
+    if (T >= intervals.back().Tlow)   return intervals.back();
+    for (const auto& I : intervals)
+      if (T >= I.Tlow && T <= I.Thigh) return I;
+    return intervals.back();
+  }
+
+  // Dimensionless NASA-9 forms
+  static double Cp_over_R(double T, const N9Interval& I) {
+    const double invT  = 1.0/T;
+    const double invT2 = invT*invT;
+    const double T2 = T*T, T3 = T2*T, T4 = T3*T;
+    const auto& a = I.a;
+    return a[0]*invT2 + a[1]*invT + a[2] + a[3]*T + a[4]*T2 + a[5]*T3 + a[6]*T4;
+  }
+  static double h_over_RT(double T, const N9Interval& I) {
+    const double invT  = 1.0/T;
+    const double invT2 = invT*invT;
+    const double T2 = T*T, T3 = T2*T, T4 = T3*T;
+    const auto& a = I.a;
+    return -a[0]*invT2 + a[1]*std::log(T) + a[2]
+         + 0.5*a[3]*T + (a[4]*T2)/3.0 + (a[5]*T3)/4.0 + (a[6]*T4)/5.0
+         + a[7]*invT;
+  }
+  static double s_over_R(double T, const N9Interval& I) {
+    const double invT  = 1.0/T;
+    const double invT2 = invT*invT;
+    const double T2 = T*T, T3 = T2*T, T4 = T3*T;
+    const auto& a = I.a;
+    return -0.5*a[0]*invT2 - a[1]*invT + a[2]*std::log(T)
+         + a[3]*T + 0.5*a[4]*T2 + (a[5]*T3)/3.0 + (a[6]*T4)/4.0
+         + a[8];
+  }
+
+  // Mass-based properties
+  double Cp(double T) const { // J/(kg·K)
+    const auto& I = interval(T);
+    return Cp_over_R(T,I) * NASA9_RU / Mw;
+  }
+  double h(double T) const {  // J/kg (sensible)
+    const auto& I = interval(T);
+    return h_over_RT(T,I) * NASA9_RU * T / Mw;
+  }
+  double s(double T) const {  // J/(kg·K)
+    const auto& I = interval(T);
+    return s_over_R(T,I) * NASA9_RU / Mw;
+  }
+  double h_ref_298() const { return h(298.15); } // J/kg
+};
+
+// Fixed-width 5×16 field reader (NASA style)
+inline void n9_collect_fw(const std::string& line, std::vector<double>& out) {
+  for (int f = 0; f < 5; ++f) {
+    int start = f * 16;
+    if (start >= (int)line.size()) break;
+    int end = std::min(start + 16, (int)line.size());
+    std::string chunk = line.substr(start, end - start);
+    if (chunk.find_first_not_of(" \t\r\n") == std::string::npos) continue;
+    for (char& c : chunk) if (c=='D' || c=='d') c = 'E';
+    char* e = nullptr;
+    double v = std::strtod(chunk.c_str(), &e);
+    if (e != chunk.c_str())
+      out.push_back(v);
+  }
+}
+
+// Whitespace float reader (for comp/header lines)
+inline void n9_collect_ws(const std::string& s, std::vector<double>& out) {
+  std::istringstream ss(s);
+  std::string tok;
+  while (ss >> tok) {
+    for (char& c : tok) if (c=='D' || c=='d') c='E';
+    char* e = nullptr;
+    double v = std::strtod(tok.c_str(), &e);
+    if (e != tok.c_str())
+      out.push_back(v);
+  }
+}
+
+// Read ONLY ONE SPECIES block from nasa9.dat
+inline N9Species read_nasa9_species(const std::string& file,
+                                    const std::string& targetName)
+{
+  std::ifstream in(file);
+  if (!in)
+    throw std::runtime_error("Cannot open nasa9 file: " + file);
+
+  std::string line;
+  while (std::getline(in, line)) {
+    // strip leading spaces
+    std::string nameLine = line;
+    auto p1 = nameLine.find_first_not_of(" \t\r\n");
+    if (p1 == std::string::npos) continue;
+    // species name is first token
+    std::istringstream ns(nameLine.substr(p1));
+    std::string spName;
+    ns >> spName;
+    if (spName != targetName) continue; // not the one we want
+
+    // ---- Found the species header ----
+
+    // comp/meta line
+    std::string comp;
+    if (!std::getline(in, comp))
+      throw std::runtime_error("EOF after header for " + targetName);
+
+    std::vector<double> nums;
+    n9_collect_ws(comp, nums);
+    if (nums.size() < 2)
+      throw std::runtime_error("Cannot parse Mw/Hf line for " + targetName);
+
+    double Hf298   = nums.back();            // J/mol
+    double Mw_gmol = nums[nums.size()-2];    // g/mol
+    double Mw      = Mw_gmol * 1e-3;         // kg/mol
+
+    N9Species sp;
+    sp.name        = targetName;
+    sp.Mw          = Mw;
+    sp.Hf298_mol   = Hf298;
+    sp.Hf298_mass  = Hf298 / Mw;
+
+    // 3 intervals: header + 2 coeff lines each
+    for (int iv = 0; iv < 3; ++iv) {
+      std::string hdr;
+      // skip comments/blank lines between blocks
+      while (true) {
+        if (!std::getline(in, hdr))
+          throw std::runtime_error("EOF in header for " + targetName);
+        std::string tmp = hdr;
+        auto q1 = tmp.find_first_not_of(" \t\r\n");
+        if (q1 == std::string::npos || tmp[q1]=='!') continue;
+        break;
+      }
+
+      std::string thdr = hdr;
+      // parse Tmin Tmax from header
+      std::vector<double> hnums;
+      n9_collect_ws(thdr, hnums);
+      if (hnums.size() < 2)
+        throw std::runtime_error("Bad interval header for " + targetName);
+      double Tmin = hnums[0];
+      double Tmax = hnums[1];
+
+      // coeff lines
+      std::string c1, c2;
+      if (!std::getline(in, c1) || !std::getline(in, c2))
+        throw std::runtime_error("EOF reading coeffs for " + targetName);
+
+      std::vector<double> coeffs;
+      coeffs.reserve(10);
+      n9_collect_fw(c1, coeffs);
+      n9_collect_fw(c2, coeffs);
+      if (coeffs.size() < 9)
+        throw std::runtime_error("Fewer than 9 coeffs for " + targetName);
+
+      N9Interval I;
+      I.Tlow  = Tmin;
+      I.Thigh = Tmax;
+      for (int k = 0; k < 9; ++k)
+        I.a[k] = coeffs[k];
+
+      sp.intervals.push_back(I);
+    }
+
+    return sp;
+  }
+
+  throw std::runtime_error("Species " + targetName + " not found in " + file);
+}

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -166,6 +166,8 @@ DEFTAG(imex_maxiter);
 DEFTAG(imex_reltol);
 DEFTAG(imex_abstol);
 
+DEFTAG(nasa9_filepath);
+
 DEFTAG(ncomp);
 DEFTAG(pde);
 DEFTAG(problem);
@@ -224,6 +226,7 @@ DEFTAG(matidx);
 DEFTAG(solidx);
 DEFTAG(yield_stress);
 DEFTAG(K0);
+DEFTAG(spec_name);
 DEFTAG(R);
 DEFTAG(cp_coeff);
 DEFTAG(t_range);


### PR DESCRIPTION
Implemented two new control variables:

- nasa9_filepath <- general (the path start from the working directory)
- spec_name <- in the species block (size of nspec)

Allows the user to provide a NASA9 database file and only filling the species block with spec_id and spec_name. The rest of the necessary parameters will be automatically read from the database.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/690)
<!-- Reviewable:end -->
