### PR TITLE
Migrate to Charm v8

### DIFF
--- a/src/Inciter/ALE.cpp
+++ b/src/Inciter/ALE.cpp
@@ -83,6 +83,9 @@ ALE::ALE( const tk::CProxy_ConjugateGradients& conjugategradientsproxy,
   thisProxy[ thisIndex ].wait4vel();
   thisProxy[ thisIndex ].wait4pot();
   thisProxy[ thisIndex ].wait4for();
+
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 std::tuple< tk::CSR, std::vector< tk::real >, std::vector< tk::real > >

--- a/src/Inciter/ALE.hpp
+++ b/src/Inciter/ALE.hpp
@@ -72,7 +72,7 @@ class ALE : public CBase_ALE {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit ALE( CkMigrateMessage* ) {}
+    explicit ALE( CkMigrateMessage* msg ) : CBase_ALE( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -147,6 +147,9 @@ ALECG::ALECG( const CProxy_Discretization& disc,
 
   d->comfinal();
 
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
+
 }
 //! [Constructor]
 

--- a/src/Inciter/ALECG.hpp
+++ b/src/Inciter/ALECG.hpp
@@ -84,7 +84,7 @@ class ALECG : public CBase_ALECG {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit ALECG( CkMigrateMessage* msg ) : CBase_ALECG( msg ) {}
+    explicit ALECG( CkMigrateMessage* msg ) : CBase_ALECG( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -223,6 +223,9 @@ DG::DG( const CProxy_Discretization& disc,
   contribute( sizeof(std::size_t), &meshid, CkReduction::nop,
     CkCallback(CkReductionTarget(Transporter,doneInsertingGhosts),
     Disc()->Tr()) );
+
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 void

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -78,7 +78,7 @@ class DG : public CBase_DG {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit DG( CkMigrateMessage* msg ) : CBase_DG( msg ) {}
+    explicit DG( CkMigrateMessage* msg ) : CBase_DG( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/Discretization.cpp
+++ b/src/Inciter/Discretization.cpp
@@ -178,6 +178,8 @@ Discretization::Discretization(
       //std::cout << "Disc: " << m_meshid << " m2m::addMesh()\n";
     }
   }
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 std::unordered_map< std::size_t, std::size_t >

--- a/src/Inciter/Discretization.hpp
+++ b/src/Inciter/Discretization.hpp
@@ -85,7 +85,7 @@ class Discretization : public CBase_Discretization {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit Discretization( CkMigrateMessage* ) {}
+    explicit Discretization( CkMigrateMessage* msg ) : CBase_Discretization( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/FV.cpp
+++ b/src/Inciter/FV.cpp
@@ -122,6 +122,9 @@ FV::FV( const CProxy_Discretization& disc,
   contribute( sizeof(std::size_t), &meshid, CkReduction::nop,
     CkCallback(CkReductionTarget(Transporter,doneInsertingGhosts),
     Disc()->Tr()) );
+
+    // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 void

--- a/src/Inciter/FV.hpp
+++ b/src/Inciter/FV.hpp
@@ -77,7 +77,7 @@ class FV : public CBase_FV {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit FV( CkMigrateMessage* msg ) : CBase_FV( msg ) {}
+    explicit FV( CkMigrateMessage* msg ) : CBase_FV( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/Ghosts.cpp
+++ b/src/Inciter/Ghosts.cpp
@@ -64,6 +64,9 @@ Ghosts::Ghosts( const CProxy_Discretization& disc,
       g_inputdeck.get< tag::cmd, tag::quiescence >())
     stateProxy.ckLocalBranch()->insert( "Ghosts", thisIndex, CkMyPe(), Disc()->It(),
                                         "Ghosts" );
+
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 void

--- a/src/Inciter/Ghosts.hpp
+++ b/src/Inciter/Ghosts.hpp
@@ -69,7 +69,7 @@ class Ghosts : public CBase_Ghosts {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit Ghosts( CkMigrateMessage* ) {}
+    explicit Ghosts( CkMigrateMessage* msg ) : CBase_Ghosts( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -168,6 +168,9 @@ OversetFE::OversetFE( const CProxy_Discretization& disc,
 
   d->comfinal();
 
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
+
 }
 //! [Constructor]
 

--- a/src/Inciter/OversetFE.hpp
+++ b/src/Inciter/OversetFE.hpp
@@ -77,7 +77,7 @@ class OversetFE : public CBase_OversetFE {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit OversetFE( CkMigrateMessage* msg ) : CBase_OversetFE( msg ) {}
+    explicit OversetFE( CkMigrateMessage* msg ) : CBase_OversetFE( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/Inciter/Refiner.cpp
+++ b/src/Inciter/Refiner.cpp
@@ -157,6 +157,9 @@ Refiner::Refiner( std::size_t meshid,
 
   // Generate boundary data structures for coarse mesh
   coarseMesh();
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
+
 
   // If initial mesh refinement is configured, start initial mesh refinement.
   // See also tk::grm::check_amr_errors in Control/Inciter/InputDeck/Ggrammar.h.

--- a/src/Inciter/Refiner.cpp
+++ b/src/Inciter/Refiner.cpp
@@ -157,7 +157,12 @@ Refiner::Refiner( std::size_t meshid,
 
   // Generate boundary data structures for coarse mesh
   coarseMesh();
-  // Array elements must not use the chare_objs table
+  // Array elements must not use the chare_objs table from charm v8.0.1.
+  // Done by setting the chareIdx to -1. When a chare’s destructor is called,
+  // there is special logic intended for destroying singleton chares that needs
+  // to be avoided for chares in chare arrays. This is done with an if statement
+  // that checks the chareIdx, which is -1 for non-singleton chares. If chareIdx
+  // is wrong, it will throw an error.
   chareIdx = -1;
 
 

--- a/src/Inciter/Refiner.hpp
+++ b/src/Inciter/Refiner.hpp
@@ -160,7 +160,6 @@ class Refiner : public CBase_Refiner {
     //! \brief Pack/Unpack serialize member function
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
     void pup( PUP::er &p ) override {
-        ArrayElement::pup(p);
       p | m_meshid;
       p | m_ncit;
       p | m_host;
@@ -209,9 +208,6 @@ class Refiner : public CBase_Refiner {
       p | m_rid;
       //p | m_oldrid;
       p | m_lref;
-            if (p.isUnpacking()) {
-              chareIdx = -1;
-            }
       //p | m_oldlref;
       //p | m_oldparent;
       p | m_writeCallback;

--- a/src/Inciter/Refiner.hpp
+++ b/src/Inciter/Refiner.hpp
@@ -90,7 +90,7 @@ class Refiner : public CBase_Refiner {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVar
-    explicit Refiner( CkMigrateMessage* ) {}
+    explicit Refiner( CkMigrateMessage* msg ) : CBase_Refiner( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif
@@ -160,6 +160,7 @@ class Refiner : public CBase_Refiner {
     //! \brief Pack/Unpack serialize member function
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
     void pup( PUP::er &p ) override {
+        ArrayElement::pup(p);
       p | m_meshid;
       p | m_ncit;
       p | m_host;
@@ -208,6 +209,9 @@ class Refiner : public CBase_Refiner {
       p | m_rid;
       //p | m_oldrid;
       p | m_lref;
+            if (p.isUnpacking()) {
+              chareIdx = -1;
+            }
       //p | m_oldlref;
       //p | m_oldparent;
       p | m_writeCallback;

--- a/src/Inciter/Sorter.cpp
+++ b/src/Inciter/Sorter.cpp
@@ -93,7 +93,7 @@ Sorter::Sorter( std::size_t meshid,
             { return std::all_of( begin(s.second), end(s.second),
                        [&](auto f){ return f*3+2 < m_triinpoel.size(); } ); } ),
           "Boundary face data structures inconsistent" );
-  
+
   // Array elements must not use the chare_objs table
   chareIdx = -1;
 }

--- a/src/Inciter/Sorter.cpp
+++ b/src/Inciter/Sorter.cpp
@@ -93,6 +93,9 @@ Sorter::Sorter( std::size_t meshid,
             { return std::all_of( begin(s.second), end(s.second),
                        [&](auto f){ return f*3+2 < m_triinpoel.size(); } ); } ),
           "Boundary face data structures inconsistent" );
+  
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 void

--- a/src/Inciter/Sorter.hpp
+++ b/src/Inciter/Sorter.hpp
@@ -82,7 +82,7 @@ class Sorter : public CBase_Sorter {
     #endif
     //! Migrate constructor
     // cppcheck-suppress uninitMemberVarPrivate
-    explicit Sorter( CkMigrateMessage* ) {}
+    explicit Sorter( CkMigrateMessage* msg ) : CBase_Sorter( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif

--- a/src/LinearSolver/ConjugateGradients.cpp
+++ b/src/LinearSolver/ConjugateGradients.cpp
@@ -88,6 +88,9 @@ ConjugateGradients::ConjugateGradients(
   Assert( m_A.rsize() == m_gid.size()*A.Ncomp(), "Size mismatch" );
   Assert( m_x.size() == m_gid.size()*A.Ncomp(), "Size mismatch" );
   Assert( m_b.size() == m_gid.size()*A.Ncomp(), "Size mismatch" );
+
+  // Array elements must not use the chare_objs table
+  chareIdx = -1;
 }
 
 void

--- a/src/LinearSolver/ConjugateGradients.hpp
+++ b/src/LinearSolver/ConjugateGradients.hpp
@@ -76,7 +76,7 @@ class ConjugateGradients : public CBase_ConjugateGradients {
                           gid, lid, nodecommmap ) {}
 
     //! Migrate constructor
-    explicit ConjugateGradients( CkMigrateMessage* ) {}
+    explicit ConjugateGradients( CkMigrateMessage* msg ) : CBase_ConjugateGradients( msg ) { chareIdx = -1; }
     #if defined(__clang__)
       #pragma clang diagnostic pop
     #endif


### PR DESCRIPTION
Makes changes to allow Quinoa to run with Charm++ version 8. This requires setting chareIdx to -1 in various chare arrays to fix a bug during the migration of those chares.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/692)
<!-- Reviewable:end -->
