### PR TITLE
Bug fix on boxnodes.empty(), now linear detonate will run in overset

### DIFF
--- a/src/PDE/CompFlow/CGCompFlow.hpp
+++ b/src/PDE/CompFlow/CGCompFlow.hpp
@@ -1499,7 +1499,8 @@ class CompFlow {
         // for all boxes
         for (const auto& b : icbox) {
           // if linear initialize is set up (energy-pill)
-          if (b.template get< tag::initiate >() == ctr::InitiateType::LINEAR) {
+          if (b.template get< tag::initiate >() == ctr::InitiateType::LINEAR && 
+                      !boxnodes[bcnt].empty()) {
 
           std::vector< tk::real > box
            { b.template get< tag::xmin >(), b.template get< tag::xmax >(),


### PR DESCRIPTION
Added better check for boxnodes to make sure we don't operate on empty containers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/697)
<!-- Reviewable:end -->
