### PR TITLE
Bug fix on multispec box init

### DIFF
--- a/src/PDE/MultiSpecies/Problem/BoxInitialization.hpp
+++ b/src/PDE/MultiSpecies/Problem/BoxInitialization.hpp
@@ -106,7 +106,7 @@ void initializeBox( const std::vector< EOS >& mat_blk,
   // [II] Finally initialize the solution vector
   // partial density
   for (std::size_t k=0; k<nspec; ++k) {
-    s[multispecies::densityIdx(nspec,k)] = Ys[k] * rhok[k];
+    s[multispecies::densityIdx(nspec,k)] = rhok[k];
   }
   // total specific energy
   s[multispecies::energyIdx(nspec,0)] = rbulk * spi;


### PR DESCRIPTION
Error when setting partial density after box init. Incorrectly premultiplied species density with mass fraction. Led to bad initialization of problems. 

This was missed in the regression because Sod problem uses mass fraction of either 0 or 1. Bug revealed on initialization with more complex mass fractions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/698)
<!-- Reviewable:end -->
