### PR TITLE
Fixed bug where some triangles were excluded from proper sideset marking, causing spurious forces in the rigid body motion solver

### DIFF
--- a/src/Inciter/ALECG.cpp
+++ b/src/Inciter/ALECG.cpp
@@ -206,8 +206,11 @@ ALECG::queryBnd()
   // to obtain force on overset walls
   m_slipwallbctri.resize( m_triinpoel.size()/3, 0 );
   for (std::size_t e=0; e<m_triinpoel.size()/3; ++e)
-    if (m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes))
+    if (m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes) ||
+        m_slipwallbcnodes.find(m_triinpoel[e*3+1]) != end(m_slipwallbcnodes) ||
+        m_slipwallbcnodes.find(m_triinpoel[e*3+2]) != end(m_slipwallbcnodes)){
       m_slipwallbctri[e] = 1;
+    }
 
   // Prepare unique set of time dependent BC nodes
   m_timedepbcnodes.clear();

--- a/src/Inciter/OversetFE.cpp
+++ b/src/Inciter/OversetFE.cpp
@@ -220,8 +220,11 @@ OversetFE::getBCNodes()
   // to obtain force on overset walls
   m_slipwallbctri.resize( m_triinpoel.size()/3, 0 );
   for (std::size_t e=0; e<m_triinpoel.size()/3; ++e)
-    if (m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes))
+    if (m_slipwallbcnodes.find(m_triinpoel[e*3+0]) != end(m_slipwallbcnodes) ||
+        m_slipwallbcnodes.find(m_triinpoel[e*3+1]) != end(m_slipwallbcnodes) ||
+        m_slipwallbcnodes.find(m_triinpoel[e*3+2]) != end(m_slipwallbcnodes)){
       m_slipwallbctri[e] = 1;
+    }
 
   // Prepare unique set of time dependent BC nodes
   m_timedepbcnodes.clear();


### PR DESCRIPTION
Confirmed that moving the block creates triangles marked as slipwall that should not be.  Instead of moving the block, we now check all the corners of the triangle and if any are a slipwall, the triangle gets marked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/701)
<!-- Reviewable:end -->
