### PR TITLE
Linear Mie-Gruneisen EOS for solids

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -125,6 +125,9 @@ using materialList = tk::TaggedTuple< brigand::list<
   tag::yield_stress,       std::vector< tk::real >,
   tag::alpha,              std::vector< tk::real >,
   tag::K0,                 std::vector< tk::real >,
+  tag::b,                  std::vector< tk::real >,
+  tag::c0,                 std::vector< tk::real >,
+  tag::s1,                 std::vector< tk::real >,
   tag::cv,                 std::vector< tk::real >,
   tag::k,                  std::vector< tk::real >,
   tag::plasticity_reltime, std::vector< tk::real >
@@ -1056,7 +1059,9 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
 
       keywords.insert({"w_gru", "Grueneisen coefficient",
         R"(This keyword is used to specify the material property, Gruneisen
-        coefficient for the Jones-Wilkins-Lee equation of state.)",
+        coefficient for the Jones-Wilkins-Lee equation of state, and the
+        reference Gruneisen coefficient for the linear Mie-Gruneisen equation
+        of state.)",
         "vector of reals"});
 
       keywords.insert({"A_jwl", "JWL EoS A parameter",
@@ -1123,6 +1128,21 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keyword is used to specify the K0 parameter for
         Godunov-Romenski EOS for solids.)", "vector of reals"});
 
+      keywords.insert({"b", "b parameter for Linear Mie-Gruneisen EOS",
+        R"(This keyword is used to specify the b parameter in the
+        density-dependent Gruneisen coefficient for the linear Mie-Gruneisen
+        equation of state.)", "vector of reals"});
+
+      keywords.insert({"c0", "c0 parameter for Linear Mie-Gruneisen EOS",
+        R"(This keyword is used to specify the c0 parameter in the linear
+        Us-Up Hugoniot relation for the linear Mie-Gruneisen equation of
+        state. Units: m/s)", "vector of reals"});
+
+      keywords.insert({"s1", "s1 parameter for Linear Mie-Gruneisen EOS",
+        R"(This keyword is used to specify the s1 slope parameter in the linear
+        Us-Up Hugoniot relation for the linear Mie-Gruneisen equation of
+        state.)", "vector of reals"});
+
       keywords.insert({"cv", "specific heat at constant volume",
         R"(This keyword is used to specify the material property, specific heat at
         constant volume.)", "vector of reals"});
@@ -1186,6 +1206,14 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         the internal energy See Plohr, J. N., & Plohr, B. J. (2005). Linearized
         analysis of Richtmyer–Meshkov flow for elastic materials. Journal of Fluid
         Mechanics, 537, 55-89 for further details.)"});
+
+      keywords.insert({"linear_miegruneisen",
+        "Select the Linear Mie-Gruneisen equation of state",
+        R"(This keyword is used to select the linear Mie-Gruneisen equation of
+        state for solids. This EOS uses a linear Us-Up Hugoniot with a
+        density-dependent Gruneisen coefficient for the hydrodynamic
+        contribution, and a small-shear approximation for the
+        elastic contribution.)"});
 
       keywords.insert({"wilkins_aluminum",
         "Select Wilkins' equation of state for aluminum",

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -125,7 +125,6 @@ using materialList = tk::TaggedTuple< brigand::list<
   tag::yield_stress,       std::vector< tk::real >,
   tag::alpha,              std::vector< tk::real >,
   tag::K0,                 std::vector< tk::real >,
-  tag::b,                  std::vector< tk::real >,
   tag::c0,                 std::vector< tk::real >,
   tag::s1,                 std::vector< tk::real >,
   tag::cv,                 std::vector< tk::real >,
@@ -1120,18 +1119,15 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         which indicates the stress (units: Pa) after which the material begins
         plastic flow.)", "vector of reals"});
 
-      keywords.insert({"alpha", "alpha parameter for Godunov-Romenski EOS",
+      keywords.insert({"alpha", "alpha EOS parameter",
         R"(This keyword is used to specify the alpha parameter for
-        Godunov-Romenski EOS for solids.)", "vector of reals"});
+        Godunov-Romenski EOS for solids, and the density-dependence
+        exponent for the Gruneisen coefficient in the linear Mie-Gruneisen
+        equation of state.)", "vector of reals"});
 
       keywords.insert({"K0", "K0 parameter for Godunov-Romenski EOS",
         R"(This keyword is used to specify the K0 parameter for
         Godunov-Romenski EOS for solids.)", "vector of reals"});
-
-      keywords.insert({"b", "b parameter for Linear Mie-Gruneisen EOS",
-        R"(This keyword is used to specify the b parameter in the
-        density-dependent Gruneisen coefficient for the linear Mie-Gruneisen
-        equation of state.)", "vector of reals"});
 
       keywords.insert({"c0", "c0 parameter for Linear Mie-Gruneisen EOS",
         R"(This keyword is used to specify the c0 parameter in the linear

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -1208,12 +1208,13 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         Mechanics, 537, 55-89 for further details.)"});
 
       keywords.insert({"linear_miegruneisen",
-        "Select the Linear Mie-Gruneisen equation of state",
+        "Select the Linear Mie-Gruneisen equation of state (a.k.a. shock-wave EOS)",
         R"(This keyword is used to select the linear Mie-Gruneisen equation of
         state for solids. This EOS uses a linear Us-Up Hugoniot with a
         density-dependent Gruneisen coefficient for the hydrodynamic
         contribution, and a small-shear approximation for the
-        elastic contribution.)"});
+        elastic contribution. This EOS is described in Shyue, J Comp Phys (2001)
+        171(2), 678-707.)"});
 
       keywords.insert({"wilkins_aluminum",
         "Select Wilkins' equation of state for aluminum",

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -1484,6 +1484,50 @@ LuaParser::registerMaterials(
     // assign solid
     is_solid = true;
   }
+  // Linear Mie-Gruneisen materials
+  else if (mati_deck.get< tag::eos >() ==
+    inciter::ctr::MaterialType::LINEARMIEGRUNEISEN) {
+    // w_gru
+    checkStoreMatProp(sol_mat[imat+1], "w_gru", ntype,
+      mati_deck.get< tag::w_gru >());
+
+    // rho0_jwl
+    checkStoreMatProp(sol_mat[imat+1], "rho0_jwl", ntype,
+      mati_deck.get< tag::rho0_jwl >());
+
+    // b
+    checkStoreMatProp(sol_mat[imat+1], "b", ntype,
+      mati_deck.get< tag::b >());
+
+    // c0
+    checkStoreMatProp(sol_mat[imat+1], "c0", ntype,
+      mati_deck.get< tag::c0 >());
+
+    // s1
+    checkStoreMatProp(sol_mat[imat+1], "s1", ntype,
+      mati_deck.get< tag::s1 >());
+
+    // mu
+    checkStoreMatProp(sol_mat[imat+1], "mu", ntype,
+      mati_deck.get< tag::mu >());
+
+    // plasticity_reltime
+    if (!sol_mat[imat+1]["plasticity_reltime"].valid())
+      sol_mat[imat+1]["plasticity_reltime"] =
+        std::vector< tk::real >(ntype, 1.0e-05);
+    checkStoreMatProp(sol_mat[imat+1], "plasticity_reltime", ntype,
+      mati_deck.get< tag::plasticity_reltime >());
+
+    // yield_stress
+    if (!sol_mat[imat+1]["yield_stress"].valid())
+      sol_mat[imat+1]["yield_stress"] =
+        std::vector< tk::real >(ntype, 300.0e+06);
+    checkStoreMatProp(sol_mat[imat+1], "yield_stress", ntype,
+      mati_deck.get< tag::yield_stress >());
+
+    // assign solid
+    is_solid = true;
+  }
   // Wilkins aluminum materials
   else if (mati_deck.get< tag::eos >() ==
     inciter::ctr::MaterialType::WILKINSALUMINUM) {

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -1495,9 +1495,9 @@ LuaParser::registerMaterials(
     checkStoreMatProp(sol_mat[imat+1], "rho0_jwl", ntype,
       mati_deck.get< tag::rho0_jwl >());
 
-    // b
-    checkStoreMatProp(sol_mat[imat+1], "b", ntype,
-      mati_deck.get< tag::b >());
+    // alpha
+    checkStoreMatProp(sol_mat[imat+1], "alpha", ntype,
+      mati_deck.get< tag::alpha >());
 
     // c0
     checkStoreMatProp(sol_mat[imat+1], "c0", ntype,

--- a/src/Control/Inciter/Options/Material.hpp
+++ b/src/Control/Inciter/Options/Material.hpp
@@ -24,6 +24,7 @@ namespace ctr {
 enum class MaterialType : uint8_t { STIFFENEDGAS
                                   , JWL
                                   , SMALLSHEARSOLID
+                                  , LINEARMIEGRUNEISEN
                                   , WILKINSALUMINUM
                                   , GODUNOVROMENSKI
                                   , THERMALLYPERFECTGAS
@@ -47,6 +48,7 @@ class Material : public tk::Toggle< MaterialType > {
         { { MaterialType::STIFFENEDGAS, "stiffenedgas" }
         , { MaterialType::JWL, "jwl" }
         , { MaterialType::SMALLSHEARSOLID, "smallshearsolid" }
+        , { MaterialType::LINEARMIEGRUNEISEN, "linear_miegruneisen" }
         , { MaterialType::WILKINSALUMINUM, "wilkins_aluminum" }
         , { MaterialType::GODUNOVROMENSKI, "godunovromenski" }
         , { MaterialType::THERMALLYPERFECTGAS, "thermallyperfectgas" }
@@ -55,6 +57,7 @@ class Material : public tk::Toggle< MaterialType > {
         { { "stiffenedgas", MaterialType::STIFFENEDGAS }
         , { "jwl", MaterialType::JWL }
         , { "smallshearsolid", MaterialType::SMALLSHEARSOLID }
+        , { "linear_miegruneisen", MaterialType::LINEARMIEGRUNEISEN }
         , { "wilkins_aluminum", MaterialType::WILKINSALUMINUM }
         , { "godunovromenski", MaterialType::GODUNOVROMENSKI }
         , { "thermallyperfectgas", MaterialType::THERMALLYPERFECTGAS }

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -226,6 +226,7 @@ DEFTAG(matidx);
 DEFTAG(solidx);
 DEFTAG(yield_stress);
 DEFTAG(K0);
+DEFTAG(s1);
 DEFTAG(spec_name);
 DEFTAG(R);
 DEFTAG(cp_coeff);

--- a/src/PDE/EoS/CMakeLists.txt
+++ b/src/PDE/EoS/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(EOS
             StiffenedGas.cpp
             JWL.cpp
             SmallShearSolid.cpp
+            LinearMieGruneisen.cpp
             WilkinsAluminum.cpp
             GodunovRomenski.cpp
             ThermallyPerfectGas.cpp)

--- a/src/PDE/EoS/EOS.cpp
+++ b/src/PDE/EoS/EOS.cpp
@@ -61,13 +61,14 @@ EOS::EOS( ctr::MaterialType mattype, EqType eq, std::size_t k )
   else if (mattype == ctr::MaterialType::LINEARMIEGRUNEISEN) {
     // query input deck for LinearMieGruneisen parameters
     auto gamma0 = getmatprop< tag::w_gru >(k);
-    auto b = getmatprop< tag::b >(k);
+    auto alpha = getmatprop< tag::alpha >(k);
     auto c0 = getmatprop< tag::c0 >(k);
     auto s1 = getmatprop< tag::s1 >(k);
     auto c_v = getmatprop< tag::cv >(k);
     auto mu = getmatprop< tag::mu >(k);
     auto rho0_gr = getmatprop< tag::rho0_jwl >(k);
-    m_material = LinearMieGruneisen(gamma0, rho0_gr, b, c0, s1, c_v, mu);
+    m_material =
+      LinearMieGruneisen(gamma0, rho0_gr, alpha, c0, s1, c_v, mu);
   }
   else if (mattype == ctr::MaterialType::WILKINSALUMINUM) {
     // query input deck for Wilkins parameters

--- a/src/PDE/EoS/EOS.cpp
+++ b/src/PDE/EoS/EOS.cpp
@@ -58,6 +58,17 @@ EOS::EOS( ctr::MaterialType mattype, EqType eq, std::size_t k )
     auto mu = getmatprop< tag::mu >(k);
     m_material = SmallShearSolid(g, ps, c_v, mu);
   }
+  else if (mattype == ctr::MaterialType::LINEARMIEGRUNEISEN) {
+    // query input deck for LinearMieGruneisen parameters
+    auto gamma0 = getmatprop< tag::w_gru >(k);
+    auto b = getmatprop< tag::b >(k);
+    auto c0 = getmatprop< tag::c0 >(k);
+    auto s1 = getmatprop< tag::s1 >(k);
+    auto c_v = getmatprop< tag::cv >(k);
+    auto mu = getmatprop< tag::mu >(k);
+    auto rho0_gr = getmatprop< tag::rho0_jwl >(k);
+    m_material = LinearMieGruneisen(gamma0, rho0_gr, b, c0, s1, c_v, mu);
+  }
   else if (mattype == ctr::MaterialType::WILKINSALUMINUM) {
     // query input deck for Wilkins parameters
     auto g = getmatprop< tag::gamma >(k);

--- a/src/PDE/EoS/EOS.hpp
+++ b/src/PDE/EoS/EOS.hpp
@@ -19,6 +19,7 @@
 #include "EoS/StiffenedGas.hpp"
 #include "EoS/JWL.hpp"
 #include "EoS/SmallShearSolid.hpp"
+#include "EoS/LinearMieGruneisen.hpp"
 #include "EoS/WilkinsAluminum.hpp"
 #include "EoS/GodunovRomenski.hpp"
 #include "EoS/ThermallyPerfectGas.hpp"
@@ -39,6 +40,7 @@ class EOS {
     std::variant< StiffenedGas
                 , JWL
                 , SmallShearSolid
+                , LinearMieGruneisen
                 , WilkinsAluminum
                 , GodunovRomenski
                 , ThermallyPerfectGas

--- a/src/PDE/EoS/LinearMieGruneisen.cpp
+++ b/src/PDE/EoS/LinearMieGruneisen.cpp
@@ -5,12 +5,13 @@
              2016-2018 Los Alamos National Security, LLC.,
              2019-2021 Triad National Security, LLC.
              All rights reserved. See the LICENSE file for details.
-  \brief     Linear Mie-Gruneisen equation of state for solids
+  \brief     Linear Mie-Gruneisen equation of state (a.k.a. shock-wave EOS)
   \details   This file defines functions for the LinearMieGruneisen equation of
              state for solids. The elastic contribution follows SmallShearSolid.
              The hydrodynamic contribution uses a linear Us-Up Hugoniot and a
-             density-dependent Gruneisen coefficient,
-             Gamma = gamma0 + b*(1-rho0/rho).
+             density-dependent Gruneisen coefficient. Ref. Shyue, K. M. (2001).
+             A fluid-mixture type algorithm for compressible multicomponent flow
+             with Mie–Grüneisen equation of state. J Comp Phys, 171(2), 678-707.
 */
 // *****************************************************************************
 
@@ -430,7 +431,7 @@ LinearMieGruneisen::gruneisen( tk::real rho ) const
 //! \return Gruneisen coefficient
 // *************************************************************************
 {
-  return m_gamma0 + m_b*eta(rho);
+  return m_gamma0 * std::pow(m_rho0/rho, m_b);
 }
 
 tk::real

--- a/src/PDE/EoS/LinearMieGruneisen.cpp
+++ b/src/PDE/EoS/LinearMieGruneisen.cpp
@@ -442,7 +442,7 @@ LinearMieGruneisen::dGruneisenDrho( tk::real rho ) const
 //! \return Derivative of Gruneisen coefficient wrt density
 // *************************************************************************
 {
-  return m_b*dEtaDrho(rho);
+  return (- m_b * gruneisen(rho) / rho);
 }
 
 tk::real

--- a/src/PDE/EoS/LinearMieGruneisen.cpp
+++ b/src/PDE/EoS/LinearMieGruneisen.cpp
@@ -25,12 +25,14 @@ using inciter::LinearMieGruneisen;
 
 LinearMieGruneisen::LinearMieGruneisen(
   tk::real gamma0,
+  tk::real rho0,
   tk::real b,
   tk::real c0,
   tk::real s1,
   tk::real cv,
   tk::real mu ) :
   m_gamma0(gamma0),
+  m_rho0(rho0),
   m_b(b),
   m_c0(c0),
   m_s1(s1),
@@ -39,6 +41,7 @@ LinearMieGruneisen::LinearMieGruneisen(
 // *************************************************************************
 //  Constructor
 //! \param[in] gamma0 Reference Gruneisen coefficient
+//! \param[in] rho0 Initial density
 //! \param[in] b Density-dependence coefficient for Gruneisen coefficient
 //! \param[in] c0 Bulk sound speed coefficient in linear Us-Up relation
 //! \param[in] s1 Slope coefficient in linear Us-Up relation
@@ -46,16 +49,6 @@ LinearMieGruneisen::LinearMieGruneisen(
 //! \param[in] mu Constant shear modulus
 // *************************************************************************
 { }
-
-void
-LinearMieGruneisen::setRho0( tk::real rho0 )
-// *************************************************************************
-//  Set rho0 EOS parameter; i.e. the initial density
-//! \param[in] rho0 Initial material density that needs to be stored
-// *************************************************************************
-{
-  m_rho0 = rho0;
-}
 
 tk::real
 LinearMieGruneisen::density(

--- a/src/PDE/EoS/LinearMieGruneisen.cpp
+++ b/src/PDE/EoS/LinearMieGruneisen.cpp
@@ -27,14 +27,14 @@ using inciter::LinearMieGruneisen;
 LinearMieGruneisen::LinearMieGruneisen(
   tk::real gamma0,
   tk::real rho0,
-  tk::real b,
+  tk::real alpha,
   tk::real c0,
   tk::real s1,
   tk::real cv,
   tk::real mu ) :
   m_gamma0(gamma0),
   m_rho0(rho0),
-  m_b(b),
+  m_alpha(alpha),
   m_c0(c0),
   m_s1(s1),
   m_cv(cv),
@@ -43,7 +43,7 @@ LinearMieGruneisen::LinearMieGruneisen(
 //  Constructor
 //! \param[in] gamma0 Reference Gruneisen coefficient
 //! \param[in] rho0 Initial density
-//! \param[in] b Density-dependence coefficient for Gruneisen coefficient
+//! \param[in] alpha Density-dependence exponent for Gruneisen coefficient
 //! \param[in] c0 Bulk sound speed coefficient in linear Us-Up relation
 //! \param[in] s1 Slope coefficient in linear Us-Up relation
 //! \param[in] cv Specific heat at constant volume
@@ -431,7 +431,7 @@ LinearMieGruneisen::gruneisen( tk::real rho ) const
 //! \return Gruneisen coefficient
 // *************************************************************************
 {
-  return m_gamma0 * std::pow(m_rho0/rho, m_b);
+  return m_gamma0 * std::pow(m_rho0/rho, m_alpha);
 }
 
 tk::real
@@ -442,7 +442,7 @@ LinearMieGruneisen::dGruneisenDrho( tk::real rho ) const
 //! \return Derivative of Gruneisen coefficient wrt density
 // *************************************************************************
 {
-  return (- m_b * gruneisen(rho) / rho);
+  return (- m_alpha * gruneisen(rho) / rho);
 }
 
 tk::real

--- a/src/PDE/EoS/LinearMieGruneisen.cpp
+++ b/src/PDE/EoS/LinearMieGruneisen.cpp
@@ -1,0 +1,524 @@
+// *****************************************************************************
+/*!
+  \file      src/PDE/EoS/LinearMieGruneisen.cpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019-2021 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Linear Mie-Gruneisen equation of state for solids
+  \details   This file defines functions for the LinearMieGruneisen equation of
+             state for solids. The elastic contribution follows SmallShearSolid.
+             The hydrodynamic contribution uses a linear Us-Up Hugoniot and a
+             density-dependent Gruneisen coefficient,
+             Gamma = gamma0 + b*(1-rho0/rho).
+*/
+// *****************************************************************************
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+#include "Vector.hpp"
+#include "EoS/LinearMieGruneisen.hpp"
+
+using inciter::LinearMieGruneisen;
+
+LinearMieGruneisen::LinearMieGruneisen(
+  tk::real gamma0,
+  tk::real b,
+  tk::real c0,
+  tk::real s1,
+  tk::real cv,
+  tk::real mu ) :
+  m_gamma0(gamma0),
+  m_b(b),
+  m_c0(c0),
+  m_s1(s1),
+  m_cv(cv),
+  m_mu(mu)
+// *************************************************************************
+//  Constructor
+//! \param[in] gamma0 Reference Gruneisen coefficient
+//! \param[in] b Density-dependence coefficient for Gruneisen coefficient
+//! \param[in] c0 Bulk sound speed coefficient in linear Us-Up relation
+//! \param[in] s1 Slope coefficient in linear Us-Up relation
+//! \param[in] cv Specific heat at constant volume
+//! \param[in] mu Constant shear modulus
+// *************************************************************************
+{ }
+
+void
+LinearMieGruneisen::setRho0( tk::real rho0 )
+// *************************************************************************
+//  Set rho0 EOS parameter; i.e. the initial density
+//! \param[in] rho0 Initial material density that needs to be stored
+// *************************************************************************
+{
+  m_rho0 = rho0;
+}
+
+tk::real
+LinearMieGruneisen::density(
+  tk::real pr,
+  tk::real temp ) const
+// *************************************************************************
+//! \brief Calculate density from the material pressure and temperature
+//!   using the LinearMieGruneisen equation of state
+//! \param[in] pr Material pressure
+//! \param[in] temp Material temperature
+//! \return Material density calculated using the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  auto rho = m_rho0;
+  const std::size_t maxiter = 50;
+  const tk::real tol = 1.0e-10;
+
+  for (std::size_t iter=0; iter<maxiter; ++iter) {
+    const auto p = hugoniotPressure(rho) + gruneisen(rho)*rho*m_cv*temp;
+    const auto dpdrho = dHugoniotPressureDrho(rho) +
+      (gruneisen(rho) + rho*dGruneisenDrho(rho))*m_cv*temp;
+    const auto rhoold = rho;
+    const auto delta = (p - pr)/dpdrho;
+    rho -= delta;
+    if (rho <= 0.0) rho = 0.5*rhoold;
+    if (std::abs(delta) <= tol*std::max(1.0, std::abs(rho))) break;
+  }
+
+  return rho;
+}
+
+tk::real
+LinearMieGruneisen::pressure(
+  tk::real arho,
+  tk::real u,
+  tk::real v,
+  tk::real w,
+  tk::real arhoE,
+  tk::real alpha,
+  std::size_t /*imat*/,
+  const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
+// *************************************************************************
+//! \brief Calculate pressure from the material density, momentum, total energy
+//!   and the inverse deformation gradient tensor using the LinearMieGruneisen
+//!   equation of state
+//! \param[in] arho Material partial density (alpha_k * rho_k)
+//! \param[in] u X-velocity
+//! \param[in] v Y-velocity
+//! \param[in] w Z-velocity
+//! \param[in] arhoE Material total energy (alpha_k * rho_k * E_k)
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+// //! \param[in] imat Material-id who's EoS is required. Default is 0, so that
+// //!   for the single-material system, this argument can be left unspecified
+// //!   by the calling code
+//! \param[in] defgrad Material inverse deformation gradient tensor
+//!   (g_k). Default is 0, so that for the single-material system,
+//!   this argument can be left unspecified by the calling code
+//! \return Material partial pressure (alpha_k * p_k) calculated using the
+//!   LinearMieGruneisen EoS
+// *************************************************************************
+{
+  // obtain elastic contribution to energy
+  tk::real eps2;
+  const auto arhoEe = alpha*elasticEnergy(defgrad, eps2);
+  // obtain hydrodynamic internal energy
+  const auto arhoEi = arhoE - arhoEe - 0.5*arho*(u*u + v*v + w*w);
+
+  const auto rho = arho/alpha;
+  auto partpressure = alpha*hugoniotPressure(rho) +
+    gruneisen(rho)*(arhoEi - arho*hugoniotEnergy(rho));
+
+  partpressure = std::max(min_eff_pressure(1e-10, arho, alpha), partpressure);
+
+  return partpressure;
+}
+
+tk::real
+LinearMieGruneisen::pressure_coldcompr(
+  tk::real arho,
+  tk::real alpha ) const
+// *************************************************************************
+//! \brief Calculate cold-compression component of pressure
+//! \param[in] arho Material partial density
+//! \param[in] alpha Material volume fraction
+//! \return Material partial cold-compression pressure
+// *************************************************************************
+{
+  return alpha*hugoniotPressure(arho/alpha);
+}
+
+std::array< std::array< tk::real, 3 >, 3 >
+LinearMieGruneisen::CauchyStress(
+  tk::real alpha,
+  std::size_t /*imat*/,
+  const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
+// *************************************************************************
+//! \brief Calculate the elastic Cauchy stress tensor from the material
+//!   inverse deformation gradient tensor using the LinearMieGruneisen EOS
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+// //! \param[in] imat Material-id who's EoS is required. Default is 0, so that
+// //!   for the single-material system, this argument can be left unspecified
+// //!   by the calling code
+//! \param[in] defgrad Material inverse deformation gradient tensor (g_k).
+//! \return Material Cauchy stress tensor (alpha_k * sigma_k) calculated using
+//!   the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  std::array< std::array< tk::real, 3 >, 3 > asig{{{0,0,0}, {0,0,0}, {0,0,0}}};
+
+  // obtain elastic contribution to energy
+  tk::real eps2;
+  elasticEnergy(defgrad, eps2);
+
+  // p_mean
+  auto pmean = - alpha * m_mu * eps2;
+
+  // Volumetric component of Cauchy stress tensor
+  asig[0][0] = -pmean;
+  asig[1][1] = -pmean;
+  asig[2][2] = -pmean;
+
+  // Deviatoric (trace-free) part of volume-preserving left Cauchy-Green tensor
+  auto devbt = tk::getLeftCauchyGreen(defgrad);
+  auto detb = std::pow(tk::determinant(devbt), 1.0/3.0);
+  for (std::size_t i=0; i<3; ++i) {
+    for (std::size_t j=0; j<3; ++j)
+      devbt[i][j] /= detb;
+  }
+  auto trbt = (devbt[0][0]+devbt[1][1]+devbt[2][2])/3.0;
+  devbt[0][0] -= trbt;
+  devbt[1][1] -= trbt;
+  devbt[2][2] -= trbt;
+
+  // Add deviatoric component of Cauchy stress tensor
+  for (std::size_t i=0; i<3; ++i) {
+    for (std::size_t j=0; j<3; ++j)
+      asig[i][j] += m_mu*alpha*devbt[i][j];
+  }
+
+  return asig;
+}
+
+tk::real
+LinearMieGruneisen::soundspeed(
+  tk::real arho,
+  tk::real apr,
+  tk::real alpha,
+  std::size_t imat,
+  const std::array< std::array< tk::real, 3 >, 3 >& /*defgrad*/ ) const
+// *************************************************************************
+//! Calculate speed of sound from the material density and material pressure
+//! \param[in] arho Material partial density (alpha_k * rho_k)
+//! \param[in] apr Material partial pressure (alpha_k * p_k)
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+//! \param[in] imat Material-id who's EoS is required. Default is 0, so that
+//!   for the single-material system, this argument can be left unspecified
+//!   by the calling code
+//!   (alpha * sigma_ij * n_j) projected onto the normal vector. Default is 0,
+//!   so that for the single-material system, this argument can be left
+//!   unspecified by the calling code
+//  //! \param[in] defgrad Material inverse deformation gradient tensor
+//  //!   (g_k) with the first dimension aligned to direction in which
+//  //!   wave speeds are required. Default is 0, so that for the single-material
+//  //!   system, this argument can be left unspecified by the calling code
+//! \return Material speed of sound using the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  // Approximated elastic contribution, from Barton, P. T. (2019).
+  // An interface-capturing Godunov method for the simulation of compressible
+  // solid-fluid problems. Journal of Computational Physics, 390, 25-50
+  auto al_eff = std::max( 1.0e-14, alpha );
+  tk::real a = (4.0/3.0) * m_mu * al_eff / arho;
+
+  // Hydrodynamic contribution from the Mie-Gruneisen derivatives.
+  const auto rho = arho/al_eff;
+  const auto gamma = gruneisen(rho);
+  const auto e_thermal =
+    (apr - al_eff*hugoniotPressure(rho))/(gamma*arho);
+  a += dHugoniotPressureDrho(rho)
+     + (gamma + rho*dGruneisenDrho(rho))*e_thermal
+     - gamma*rho*dHugoniotEnergyDrho(rho)
+     + gamma*apr/arho;
+
+  // Compute square root
+  a = std::sqrt(std::max(1.0e-15, a));
+
+  // check sound speed divergence
+  if (!std::isfinite(a)) {
+    std::cout << "Material-id:      " << imat << std::endl;
+    std::cout << "Volume-fraction:  " << alpha << std::endl;
+    std::cout << "Partial density:  " << arho << std::endl;
+    std::cout << "Partial pressure: " << apr << std::endl;
+    Throw("Material-" + std::to_string(imat) + " has nan/inf sound speed: "
+      + std::to_string(a) + ", material volume fraction: " +
+      std::to_string(alpha));
+  }
+
+  return a;
+}
+
+tk::real
+LinearMieGruneisen::shearspeed(
+  tk::real arho,
+  tk::real alpha,
+  std::size_t imat ) const
+// *************************************************************************
+//! Calculate speed of sound from the material density and material pressure
+//! \param[in] arho Material partial density (alpha_k * rho_k)
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+//! \param[in] imat Material-id who's EoS is required. Default is 0, so that
+//!   for the single-material system, this argument can be left unspecified
+//!   by the calling code
+//! \return Material shear-wave speed speed using the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  // Approximate shear-wave speed. Ref. Barton, P. T. (2019).
+  // An interface-capturing Godunov method for the simulation of compressible
+  // solid-fluid problems. Journal of Computational Physics, 390, 25-50.
+  auto al_eff = std::max( 1e-14, alpha );
+  tk::real a = std::sqrt(al_eff*m_mu/arho);
+
+  // check shear-wave speed divergence
+  if (!std::isfinite(a)) {
+    std::cout << "Material-id:      " << imat << std::endl;
+    std::cout << "Volume-fraction:  " << alpha << std::endl;
+    std::cout << "Partial density:  " << arho << std::endl;
+    Throw("Material-" + std::to_string(imat) + " has nan/inf shear-wave speed: "
+      + std::to_string(a) + ", material volume fraction: " +
+      std::to_string(alpha));
+  }
+
+  return a;
+}
+
+tk::real
+LinearMieGruneisen::totalenergy(
+  tk::real arho,
+  tk::real u,
+  tk::real v,
+  tk::real w,
+  tk::real apr,
+  tk::real alpha,
+  const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
+// *************************************************************************
+//! \brief Calculate material specific total energy from the material
+//!   density, momentum and material pressure
+//! \param[in] arho Material partial density
+//! \param[in] u X-velocity
+//! \param[in] v Y-velocity
+//! \param[in] w Z-velocity
+//! \param[in] apr Material partial pressure
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+//! \param[in] defgrad Material inverse deformation gradient tensor
+//!   g_k. Default is 0, so that for the single-material system,
+//!   this argument can be left unspecified by the calling code
+//! \return Material specific total energy using the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  const auto rho = arho/alpha;
+
+  // obtain hydrodynamic and kinetic energy
+  tk::real arhoEh = arho*hugoniotEnergy(rho) +
+    (apr - alpha*hugoniotPressure(rho))/gruneisen(rho) +
+    0.5 * arho * (u*u + v*v + w*w);
+  // obtain elastic contribution to energy
+  tk::real eps2;
+  tk::real arhoEe = alpha*elasticEnergy(defgrad, eps2);
+
+  return (arhoEh + arhoEe);
+}
+
+tk::real
+LinearMieGruneisen::temperature(
+  tk::real arho,
+  tk::real u,
+  tk::real v,
+  tk::real w,
+  tk::real arhoE,
+  tk::real alpha,
+  const std::array< std::array< tk::real, 3 >, 3 >& defgrad ) const
+// *************************************************************************
+//! \brief Calculate material temperature from the material density, and
+//!   material specific total energy
+//! \param[in] arho Material partial density (alpha_k * rho_k)
+//! \param[in] u X-velocity
+//! \param[in] v Y-velocity
+//! \param[in] w Z-velocity
+//! \param[in] arhoE Material total energy (alpha_k * rho_k * E_k)
+//! \param[in] alpha Material volume fraction. Default is 1.0, so that for
+//!   the single-material system, this argument can be left unspecified by
+//!   the calling code
+//! \param[in] defgrad Material inverse deformation gradient tensor
+//!   (g_k). Default is 0, so that for the single-material system,
+//!   this argument can be left unspecified by the calling code
+//! \return Material temperature using the LinearMieGruneisen EoS
+// *************************************************************************
+{
+  // obtain elastic contribution to energy
+  tk::real eps2;
+  auto arhoEe = alpha*elasticEnergy(defgrad, eps2);
+  // obtain hydrodynamic internal energy
+  auto arhoEi = arhoE - arhoEe - 0.5*arho*(u*u + v*v + w*w);
+
+  const auto rho = arho/alpha;
+  const auto t = (arhoEi/arho - hugoniotEnergy(rho))/m_cv;
+  return t;
+}
+
+tk::real
+LinearMieGruneisen::min_eff_pressure(
+  tk::real min,
+  tk::real arho,
+  tk::real alpha ) const
+// *************************************************************************
+//! Compute the minimum allowed pressure
+//! \param[in] min Numerical threshold above which pressure needs to be limited
+//! \param[in] arho Material partial density (alpha_k * rho_k)
+//! \param[in] alpha Material volume fraction
+//! \return Minimum pressure allowed by physical constraints
+// *************************************************************************
+{
+  // minimum pressure is constrained by zero soundspeed.
+  auto al_eff = std::max( 1.0e-14, alpha );
+  auto rho = arho/al_eff;
+  auto gamma = gruneisen(rho);
+  auto dgamma = dGruneisenDrho(rho);
+  auto aph = al_eff*hugoniotPressure(rho);
+
+  auto co = (gamma + rho*dgamma)/(gamma*arho);
+  auto p_coeff = gamma/arho + co;
+  auto p_const = dHugoniotPressureDrho(rho)
+               - gamma*rho*dHugoniotEnergyDrho(rho)
+               - co*aph;
+
+  return -p_const/p_coeff + min;
+}
+
+tk::real
+LinearMieGruneisen::elasticEnergy(
+  const std::array< std::array< tk::real, 3 >, 3 >& defgrad,
+  tk::real& eps2 ) const
+// *************************************************************************
+//! \brief Calculate elastic contribution to material energy from the material
+//!   density, and deformation gradient tensor
+//! \param[in] defgrad Material inverse deformation gradient tensor
+//! \param[in/out] eps2 Elastic shear distortion
+//! \return Material elastic energy using the LinearMieGruneisen EoS
+//! \details This function returns the material elastic energy, and also stores
+//!   the elastic shear distortion for further use
+// *************************************************************************
+{
+  // compute volume-preserving part of Right Cauchy-Green strain tensor
+  auto Ct = tk::getIsochorRightCauchyGreen(defgrad);
+
+  // compute elastic shear distortion
+  eps2 = 0.5 * (Ct[0][0]+Ct[1][1]+Ct[2][2] - 3.0);
+
+  // compute elastic energy
+  auto rhoEe = m_mu * eps2;
+
+  return rhoEe;
+}
+
+tk::real
+LinearMieGruneisen::gruneisen( tk::real rho ) const
+// *************************************************************************
+//! Compute density-dependent Gruneisen coefficient
+//! \param[in] rho Material density
+//! \return Gruneisen coefficient
+// *************************************************************************
+{
+  return m_gamma0 + m_b*eta(rho);
+}
+
+tk::real
+LinearMieGruneisen::dGruneisenDrho( tk::real rho ) const
+// *************************************************************************
+//! Compute derivative of density-dependent Gruneisen coefficient wrt density
+//! \param[in] rho Material density
+//! \return Derivative of Gruneisen coefficient wrt density
+// *************************************************************************
+{
+  return m_b*dEtaDrho(rho);
+}
+
+tk::real
+LinearMieGruneisen::eta( tk::real rho ) const
+// *************************************************************************
+//! Compute compression measure
+//! \param[in] rho Material density
+//! \return Compression measure
+// *************************************************************************
+{
+  return 1.0 - m_rho0/rho;
+}
+
+tk::real
+LinearMieGruneisen::dEtaDrho( tk::real rho ) const
+// *************************************************************************
+//! Compute derivative of compression measure wrt density
+//! \param[in] rho Material density
+//! \return Derivative of compression measure wrt density
+// *************************************************************************
+{
+  return m_rho0/(rho*rho);
+}
+
+tk::real
+LinearMieGruneisen::hugoniotPressure( tk::real rho ) const
+// *************************************************************************
+//! Compute linear Us-Up Hugoniot pressure
+//! \param[in] rho Material density
+//! \return Hugoniot pressure
+// *************************************************************************
+{
+  const auto et = eta(rho);
+  const auto den = 1.0 - m_s1*et;
+  return m_rho0*m_c0*m_c0*et/(den*den);
+}
+
+tk::real
+LinearMieGruneisen::dHugoniotPressureDrho( tk::real rho ) const
+// *************************************************************************
+//! Compute derivative of Hugoniot pressure wrt density
+//! \param[in] rho Material density
+//! \return Derivative of Hugoniot pressure wrt density
+// *************************************************************************
+{
+  const auto et = eta(rho);
+  const auto den = 1.0 - m_s1*et;
+  return m_rho0*m_c0*m_c0*(1.0 + m_s1*et)/(den*den*den)*
+    dEtaDrho(rho);
+}
+
+tk::real
+LinearMieGruneisen::hugoniotEnergy( tk::real rho ) const
+// *************************************************************************
+//! Compute Hugoniot internal energy
+//! \param[in] rho Material density
+//! \return Hugoniot internal energy
+// *************************************************************************
+{
+  return 0.5*hugoniotPressure(rho)*eta(rho)/m_rho0;
+}
+
+tk::real
+LinearMieGruneisen::dHugoniotEnergyDrho( tk::real rho ) const
+// *************************************************************************
+//! Compute derivative of Hugoniot internal energy wrt density
+//! \param[in] rho Material density
+//! \return Derivative of Hugoniot internal energy wrt density
+// *************************************************************************
+{
+  return 0.5/m_rho0*( dHugoniotPressureDrho(rho)*eta(rho) +
+    hugoniotPressure(rho)*dEtaDrho(rho) );
+}

--- a/src/PDE/EoS/LinearMieGruneisen.hpp
+++ b/src/PDE/EoS/LinearMieGruneisen.hpp
@@ -23,7 +23,7 @@ namespace inciter {
 class LinearMieGruneisen {
 
   private:
-    tk::real m_gamma0, m_b, m_rho0, m_c0, m_s1, m_cv, m_mu;
+    tk::real m_gamma0, m_rho0, m_b, m_c0, m_s1, m_cv, m_mu;
 
     //! \brief Calculate elastic contribution to material energy from the
     //!   material density, and deformation gradient tensor
@@ -62,14 +62,15 @@ class LinearMieGruneisen {
     //! Constructor
     LinearMieGruneisen(
       tk::real gamma0,
+      tk::real rho0,
       tk::real b,
       tk::real c0,
       tk::real s1,
       tk::real cv,
       tk::real mu );
 
-    //! Set rho0 EOS parameter; i.e. the initial density
-    void setRho0(tk::real rho0);
+    //! Set rho0 EOS parameter; no-op since provided by user
+    void setRho0(tk::real) {}
 
     //! Calculate density from the material pressure and temperature
     tk::real density( tk::real pr,
@@ -165,8 +166,8 @@ class LinearMieGruneisen {
     //! \param[in,out] p Charm++'s PUP::er serializer object reference
     void pup( PUP::er &p ) /*override*/ {
       p | m_gamma0;
-      p | m_b;
       p | m_rho0;
+      p | m_b;
       p | m_c0;
       p | m_s1;
       p | m_cv;

--- a/src/PDE/EoS/LinearMieGruneisen.hpp
+++ b/src/PDE/EoS/LinearMieGruneisen.hpp
@@ -1,0 +1,184 @@
+// *****************************************************************************
+/*!
+  \file      src/PDE/EoS/LinearMieGruneisen.hpp
+  \copyright 2012-2015 J. Bakosi,
+             2016-2018 Los Alamos National Security, LLC.,
+             2019-2021 Triad National Security, LLC.
+             All rights reserved. See the LICENSE file for details.
+  \brief     Linear Mie-Gruneisen equation of state for solids
+  \details   This file declares functions for the LinearMieGruneisen equation of
+             state for solids. The elastic contribution follows SmallShearSolid.
+             The hydrodynamic contribution uses a linear Us-Up Hugoniot and a
+             density-dependent Gruneisen coefficient,
+             Gamma = gamma0 + b*(1-rho0/rho).
+*/
+// *****************************************************************************
+#ifndef LinearMieGruneisen_h
+#define LinearMieGruneisen_h
+
+#include "Data.hpp"
+
+namespace inciter {
+
+class LinearMieGruneisen {
+
+  private:
+    tk::real m_gamma0, m_b, m_rho0, m_c0, m_s1, m_cv, m_mu;
+
+    //! \brief Calculate elastic contribution to material energy from the
+    //!   material density, and deformation gradient tensor
+    tk::real elasticEnergy(
+      const std::array< std::array< tk::real, 3 >, 3 >& defgrad,
+      tk::real& eps2 ) const;
+
+    //! Density-dependent Gruneisen coefficient
+    tk::real gruneisen( tk::real rho ) const;
+
+    //! Derivative of density-dependent Gruneisen coefficient wrt density
+    tk::real dGruneisenDrho( tk::real rho ) const;
+
+    //! Compression measure based on reference density
+    tk::real eta( tk::real rho ) const;
+
+    //! Derivative of compression measure wrt density
+    tk::real dEtaDrho( tk::real rho ) const;
+
+    //! Linear Us-Up Hugoniot pressure
+    tk::real hugoniotPressure( tk::real rho ) const;
+
+    //! Derivative of Hugoniot pressure wrt density
+    tk::real dHugoniotPressureDrho( tk::real rho ) const;
+
+    //! Hugoniot internal energy
+    tk::real hugoniotEnergy( tk::real rho ) const;
+
+    //! Derivative of Hugoniot internal energy wrt density
+    tk::real dHugoniotEnergyDrho( tk::real rho ) const;
+
+  public:
+    //! Default constructor
+    LinearMieGruneisen() = default;
+
+    //! Constructor
+    LinearMieGruneisen(
+      tk::real gamma0,
+      tk::real b,
+      tk::real c0,
+      tk::real s1,
+      tk::real cv,
+      tk::real mu );
+
+    //! Set rho0 EOS parameter; i.e. the initial density
+    void setRho0(tk::real rho0);
+
+    //! Calculate density from the material pressure and temperature
+    tk::real density( tk::real pr,
+                      tk::real temp ) const;
+
+    //! Calculate pressure from the material density, momentum and total energy
+    tk::real pressure(
+      tk::real arho,
+      tk::real u,
+      tk::real v,
+      tk::real w,
+      tk::real arhoE,
+      tk::real alpha=1.0,
+      std::size_t imat=0,
+      const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
+
+    //! Calculate cold-compression component of pressure
+    tk::real pressure_coldcompr(
+      tk::real arho,
+      tk::real alpha=1.0 ) const;
+
+    //! \brief Calculate the elastic Cauchy stress tensor from the material
+    //!   inverse deformation gradient tensor using the LinearMieGruneisen EOS
+    std::array< std::array< tk::real, 3 >, 3 >
+    CauchyStress(
+      tk::real alpha,
+      std::size_t /*imat*/,
+      const std::array< std::array< tk::real, 3 >, 3 >& adefgrad ) const;
+
+    //! Calculate speed of sound from the material density and material pressure
+    tk::real soundspeed(
+      tk::real arho,
+      tk::real apr,
+      tk::real alpha=1.0,
+      std::size_t imat=0,
+      const std::array< std::array< tk::real, 3 >, 3 >& adefgrad={{}} ) const;
+
+    //! Calculate speed of shear waves
+    tk::real shearspeed(
+      tk::real arho,
+      tk::real alpha=1.0,
+      std::size_t imat=0 ) const;
+
+    //! \brief Calculate material specific total energy from the material
+    //!   density, momentum and material pressure
+    tk::real totalenergy(
+      tk::real arho,
+      tk::real u,
+      tk::real v,
+      tk::real w,
+      tk::real apr,
+      tk::real alpha=1.0,
+      const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
+
+    //! \brief Calculate material temperature from the material density, and
+    //!   material specific total energy
+    tk::real temperature(
+      tk::real arho,
+      tk::real u,
+      tk::real v,
+      tk::real w,
+      tk::real arhoE,
+      tk::real alpha=1.0,
+      const std::array< std::array< tk::real, 3 >, 3 >& defgrad={{}} ) const;
+
+    //! Compute the minimum allowed pressure
+    tk::real min_eff_pressure(
+      tk::real min,
+      tk::real,
+      tk::real ) const;
+
+    //! Compute the reference density
+    tk::real refDensity() const { return density(refPressure(), 300.0); }
+
+    //! Compute the reference pressure
+    tk::real refPressure() const { return 1.0e5; }
+
+    //! Return initial density
+    tk::real rho0() const { return m_rho0; }
+
+    //! Return gas constant (no-op)
+    tk::real gas_constant() const { return 0.0; }
+
+    //! Return internal energy (no-op)
+    tk::real internalenergy(tk::real temp) const { return m_cv * temp; }
+
+    //! Return specific heat (no-op)
+    tk::real cv( [[maybe_unused]] tk::real temp) const { return m_cv; }
+
+    /** @name Charm++ pack/unpack serializer member functions */
+    ///@{
+    //! \brief Pack/Unpack serialize member function
+    //! \param[in,out] p Charm++'s PUP::er serializer object reference
+    void pup( PUP::er &p ) /*override*/ {
+      p | m_gamma0;
+      p | m_b;
+      p | m_rho0;
+      p | m_c0;
+      p | m_s1;
+      p | m_cv;
+      p | m_mu;
+    }
+    //! \brief Pack/Unpack serialize operator|
+    //! \param[in,out] p Charm++'s PUP::er serializer object reference
+    //! \param[in,out] i LinearMieGruneisen object reference
+    friend void operator|( PUP::er& p, LinearMieGruneisen& i ) { i.pup(p); }
+    //@}
+};
+
+} //inciter::
+
+#endif // LinearMieGruneisen_h

--- a/src/PDE/EoS/LinearMieGruneisen.hpp
+++ b/src/PDE/EoS/LinearMieGruneisen.hpp
@@ -24,7 +24,7 @@ namespace inciter {
 class LinearMieGruneisen {
 
   private:
-    tk::real m_gamma0, m_rho0, m_b, m_c0, m_s1, m_cv, m_mu;
+    tk::real m_gamma0, m_rho0, m_alpha, m_c0, m_s1, m_cv, m_mu;
 
     //! \brief Calculate elastic contribution to material energy from the
     //!   material density, and deformation gradient tensor
@@ -64,7 +64,7 @@ class LinearMieGruneisen {
     LinearMieGruneisen(
       tk::real gamma0,
       tk::real rho0,
-      tk::real b,
+      tk::real alpha,
       tk::real c0,
       tk::real s1,
       tk::real cv,
@@ -168,7 +168,7 @@ class LinearMieGruneisen {
     void pup( PUP::er &p ) /*override*/ {
       p | m_gamma0;
       p | m_rho0;
-      p | m_b;
+      p | m_alpha;
       p | m_c0;
       p | m_s1;
       p | m_cv;

--- a/src/PDE/EoS/LinearMieGruneisen.hpp
+++ b/src/PDE/EoS/LinearMieGruneisen.hpp
@@ -5,12 +5,13 @@
              2016-2018 Los Alamos National Security, LLC.,
              2019-2021 Triad National Security, LLC.
              All rights reserved. See the LICENSE file for details.
-  \brief     Linear Mie-Gruneisen equation of state for solids
+  \brief     Linear Mie-Gruneisen equation of state (a.k.a. shock-wave EOS)
   \details   This file declares functions for the LinearMieGruneisen equation of
              state for solids. The elastic contribution follows SmallShearSolid.
              The hydrodynamic contribution uses a linear Us-Up Hugoniot and a
-             density-dependent Gruneisen coefficient,
-             Gamma = gamma0 + b*(1-rho0/rho).
+             density-dependent Gruneisen coefficient. Ref. Shyue, K. M. (2001).
+             A fluid-mixture type algorithm for compressible multicomponent flow
+             with Mie–Grüneisen equation of state. J Comp Phys, 171(2), 678-707.
 */
 // *****************************************************************************
 #ifndef LinearMieGruneisen_h


### PR DESCRIPTION
Uses the linear Mie-Gruneisen for the hydro part, and Walter's constitutive law for the elastic part.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/708)
<!-- Reviewable:end -->
