### PR TITLE
Isotherm noslip

### DIFF
--- a/src/PDE/MultiSpecies/BCFunctions.hpp
+++ b/src/PDE/MultiSpecies/BCFunctions.hpp
@@ -239,9 +239,7 @@ namespace inciter {
 
   //! \brief Boundary state function providing the left and right state of a
   //!   face at isothermal boundaries, with remaining variables treated as
-  //!   slip wall boundaries. TODO: Once viscosity is implemented for
-  //!   MultiSpecies, the remaining variables should be treated as no-slip
-  //!   boundaries.
+  //!   no slip wall boundaries. 
   //! \param[in] ncomp Number of scalar components in this PDE system
   //! \param[in] ul Left (domain-internal) state
   //! \param[in] fn Unit face normal

--- a/src/PDE/MultiSpecies/BCFunctions.hpp
+++ b/src/PDE/MultiSpecies/BCFunctions.hpp
@@ -242,7 +242,6 @@ namespace inciter {
   //!   no slip wall boundaries. 
   //! \param[in] ncomp Number of scalar components in this PDE system
   //! \param[in] ul Left (domain-internal) state
-  //! \param[in] fn Unit face normal
   //! \return Left and right states for all scalar components in this PDE
   //!   system
   //! \note The function signature must follow tk::StateFn.
@@ -251,7 +250,7 @@ namespace inciter {
                    const std::vector< EOS >& mat_blk,
                    const std::vector< tk::real >& ul,
                    tk::real, tk::real, tk::real, tk::real,
-                   const std::array< tk::real, 3 >& fn )
+                   const std::array< tk::real, 3 >& )
   {
     auto nspec = g_inputdeck.get< tag::multispecies, tag::nspec >();
 

--- a/src/PDE/MultiSpecies/BCFunctions.hpp
+++ b/src/PDE/MultiSpecies/BCFunctions.hpp
@@ -273,12 +273,10 @@ namespace inciter {
     auto v1l = ul[multispecies::momentumIdx(nspec, 0)]/rho;
     auto v2l = ul[multispecies::momentumIdx(nspec, 1)]/rho;
     auto v3l = ul[multispecies::momentumIdx(nspec, 2)]/rho;
-    // Normal component of velocity
-    auto vnl = v1l*fn[0] + v2l*fn[1] + v3l*fn[2];
     // Ghost state velocity components
-    auto v1r = v1l - 2.0*vnl*fn[0];
-    auto v2r = v2l - 2.0*vnl*fn[1];
-    auto v3r = v3l - 2.0*vnl*fn[2];
+    auto v1r = -v1l;
+    auto v2r = -v2l;
+    auto v3r = -v3l;
     // Boundary condition
     ur[multispecies::momentumIdx(nspec, 0)] = rho * v1r;
     ur[multispecies::momentumIdx(nspec, 1)] = rho * v2r;


### PR DESCRIPTION
Changed isothermal wall BC to use a no slip condition instead of symmetry for multispecies.  Hard to gauge effectiveness until viscosity is fully tested, but it runs.

Apparently no regression tests have been made for the isothermal wall because it passed all regression tests, but I was able to confirm that it gave different results than the previous "symmetry" version for a test case.  This is probably for the best at this point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/709)
<!-- Reviewable:end -->
