### PR TITLE
volume integral loops for high-order dg

### DIFF
--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -196,7 +196,7 @@ viscousInternalFaceIntDG(
   Fields& R  )
 // *****************************************************************************
 //  Compute internal surface flux integrals
-//! \param[in] nmat Number of materials in this PDE system
+//! \param[in] viscousRhs PDE-specific viscous residual policy
 //! \param[in] mat_blk EOS material block
 //! \param[in] ndof Maximum number of degrees of freedom
 //! \param[in] inpoel Element-node connectivity

--- a/src/PDE/Integrate/ViscousTerms.cpp
+++ b/src/PDE/Integrate/ViscousTerms.cpp
@@ -366,7 +366,7 @@ MultiSpeciesViscousTermsDGP1::volumeFlux(
   const std::vector< inciter::EOS >& mat_blk,
   std::size_t ncomp,
   const std::vector<tk::real>& state,
-  std::vector<std::array<tk::real, 3>> visc_fl ) const
+  std::vector<std::array<tk::real, 3>>& visc_fl ) const
 // *****************************************************************************
 //! \brief Compute the multispecies viscous flux on a tet volume
 //! \param[in] mat_blk Material EOS block

--- a/src/PDE/Integrate/ViscousTerms.cpp
+++ b/src/PDE/Integrate/ViscousTerms.cpp
@@ -361,4 +361,20 @@ MultiSpeciesViscousTermsDGP1::interiorFlux(
   // no-op
 }
 
+void
+MultiSpeciesViscousTermsDGP1::volumeFlux(
+  const std::vector< inciter::EOS >& mat_blk,
+  std::size_t ncomp,
+  const std::array< std::vector< tk::real >, 2 >& state,
+  const std::vector< std::array< tk::real, 3 > >& visc_fl) const
+// *****************************************************************************
+//! \brief Compute the multispecies viscous flux on a tet volume
+//! \param[in] mat_blk Material EOS block
+//! \param[in] ncomp Number of components in this system
+//! \param[in] state vector of conserved quantities
+//! \param[in,out] visc_fl viscous volume flux
+// *****************************************************************************
+{
+ // no-op
+}
 } // tk::

--- a/src/PDE/Integrate/ViscousTerms.cpp
+++ b/src/PDE/Integrate/ViscousTerms.cpp
@@ -365,8 +365,8 @@ void
 MultiSpeciesViscousTermsDGP1::volumeFlux(
   const std::vector< inciter::EOS >& mat_blk,
   std::size_t ncomp,
-  const std::array< std::vector< tk::real >, 2 >& state,
-  const std::vector< std::array< tk::real, 3 > >& visc_fl) const
+  const std::vector<tk::real>& state,
+  std::vector<std::array<tk::real, 3>> visc_fl ) const
 // *****************************************************************************
 //! \brief Compute the multispecies viscous flux on a tet volume
 //! \param[in] mat_blk Material EOS block

--- a/src/PDE/Integrate/ViscousTerms.hpp
+++ b/src/PDE/Integrate/ViscousTerms.hpp
@@ -131,8 +131,8 @@ class MultiSpeciesViscousTermsDGP1 {
     volumeFlux(
     const std::vector< inciter::EOS >& mat_blk,
     std::size_t ncomp,
-    const std::array< std::vector< tk::real >, 2 >& state,
-    const std::vector< std::array< tk::real, 3 > >& visc_fl) const;
+    const std::vector<tk::real>& state,
+    const std::vector<std::array<tk::real, 3>> visc_fl ) const;
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/Integrate/ViscousTerms.hpp
+++ b/src/PDE/Integrate/ViscousTerms.hpp
@@ -91,7 +91,7 @@ class MultiSpeciesViscousTermsDGP1 {
   public:
     //! Constructor
     MultiSpeciesViscousTermsDGP1( std::size_t nspec, std::size_t rdof );
-    
+
     //! Return local polynomial order
     std::size_t localDof( std::size_t ) const { return m_rdof; }
 
@@ -106,7 +106,7 @@ class MultiSpeciesViscousTermsDGP1 {
       std::size_t e,
       std::size_t ndof,
       const std::vector< tk::real >& B ) const;
- 
+
     //! Compute gradients of quantities for an interior element
     void
     gradientIntElem(
@@ -126,6 +126,13 @@ class MultiSpeciesViscousTermsDGP1 {
       const std::array< std::array< std::array< tk::real, 3 >, 4>, 2 >& grad,
       std::vector< tk::real >& fl ) const;
 
+    //! Compute the viscous volume flux on a tet element
+    void
+    volumeFlux(
+    const std::vector< inciter::EOS >& mat_blk,
+    std::size_t ncomp,
+    const std::array< std::vector< tk::real >, 2 >& state,
+    const std::vector< std::array< tk::real, 3 > >& visc_fl) const;
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/Integrate/ViscousTerms.hpp
+++ b/src/PDE/Integrate/ViscousTerms.hpp
@@ -132,7 +132,7 @@ class MultiSpeciesViscousTermsDGP1 {
     const std::vector< inciter::EOS >& mat_blk,
     std::size_t ncomp,
     const std::vector<tk::real>& state,
-    const std::vector<std::array<tk::real, 3>> visc_fl ) const;
+    std::vector<std::array<tk::real, 3>>& visc_fl ) const;
 
     /** @name Charm++ pack/unpack serializer member functions */
     ///@{

--- a/src/PDE/Integrate/Volume.cpp
+++ b/src/PDE/Integrate/Volume.cpp
@@ -528,7 +528,7 @@ tk::volIntViscousMultiSpecies(
   const std::vector< std::size_t >& ndofel,
   Fields& R )
 // *****************************************************************************
-//  Compute internal surface viscous flux integrals for multispecies flow
+//  Compute volume integrals of viscous fluxes for multispecies flow
 //! \param[in] nspec Number of species in this PDE system
 //! \param[in] mat_blk Material EOS block
 //! \param[in] ndof Maximum number of degrees of freedom

--- a/src/PDE/Integrate/Volume.cpp
+++ b/src/PDE/Integrate/Volume.cpp
@@ -18,11 +18,6 @@
 #include "Quadrature.hpp"
 #include "Reconstruction.hpp"
 #include "ViscousTerms.hpp"
-#include "Vector.hpp"
-#include "Quadrature.hpp"
-#include "Reconstruction.hpp"
-#include "Inciter/InputDeck/InputDeck.hpp"
-#include "UnsMesh.hpp"
 
 template< class ViscousTerms >
 void
@@ -68,8 +63,7 @@ tk::volIntViscous(
   Assert( ndof*ncomp == R.nprop(),
           "Mismatch in viscous RHS polynomial and component sizes" );
 
-  std::vector< std::array< tk::real, 3 > >& visc_fl(0.0);
-
+  std::vector<std::array<tk::real, 3>> visc_fl(ncomp);
   // compute volume integrals
   for (std::size_t e=0; e<nelem; ++e)
   {
@@ -124,12 +118,9 @@ tk::volIntViscous(
       // volume fluxes
       if(dof_el > 1)
       {
-        //evalPolynomialSol(mat_blk, intsharp, ncomp, nprim,
-          //rdof, nmat, e, ndofel[e], inpoel, coord, geoElem,
-          //{{coordgp[0][igp], coordgp[1][igp], coordgp[2][igp]}}, B, U, P, state);
         state = viscousRhs.stateAt(mat_blk, U, P, e, dof_el, B );
         // compute viscous flux
-        viscousRhs.volumeFlux( ncomp, mat_blk, state, visc_fl ); //currently no-op
+        viscousRhs.volumeFlux( mat_blk, ncomp, state, visc_fl ); //currently no-op
 
         update_rhs( ncomp, ndof, dof_el, wt, e, dBdx, visc_fl, R );
       }
@@ -523,7 +514,7 @@ tk::srcIntFV( const std::vector< inciter::EOS >& mat_blk,
 }
 
 void
-volIntViscousMultiSpecies(
+tk::volIntViscousMultiSpecies(
   std::size_t nspec,
   const std::vector< inciter::EOS >& mat_blk,
   const std::size_t ndof,

--- a/src/PDE/Integrate/Volume.cpp
+++ b/src/PDE/Integrate/Volume.cpp
@@ -17,6 +17,125 @@
 #include "Vector.hpp"
 #include "Quadrature.hpp"
 #include "Reconstruction.hpp"
+#include "ViscousTerms.hpp"
+#include "Vector.hpp"
+#include "Quadrature.hpp"
+#include "Reconstruction.hpp"
+#include "Inciter/InputDeck/InputDeck.hpp"
+#include "UnsMesh.hpp"
+
+template< class ViscousTerms >
+void
+tk::volIntViscous(
+            const ViscousTerms& viscousRhs,
+            const std::vector< inciter::EOS >& mat_blk,
+            const std::size_t ndof,
+            const std::size_t rdof,
+            const std::size_t nelem,
+            const std::vector< std::size_t >& inpoel,
+            const UnsMesh::Coords& coord,
+            const Fields& geoElem,
+            const Fields& U,
+            const Fields& P,
+            const std::vector< std::size_t >& ndofel,
+            Fields& R)
+// *****************************************************************************
+//  Compute volume integrals for viscous DG
+//! \tparam ViscousTerms Policy type that computes PDE-specific viscous RHS
+//! \param[in] viscousRhs PDE-specific viscous residual policy
+//! \param[in] mat_blk EOS material block
+//! \param[in] ndof Maximum number of degrees of freedom
+//! \param[in] rdof Total number of degrees of freedom included reconstructed ones
+//! \param[in] nelem Maximum number of elements
+//! \param[in] inpoel Element-node connectivity
+//! \param[in] coord Array of nodal coordinates
+//! \param[in] geoElem Element geometry array
+//! \param[in] U Solution vector at recent time step
+//! \param[in] P Vector of primitives at recent time step
+//! \param[in] ndofel Vector of local number of degrees of freedom
+//! \param[in,out] R Right-hand side vector computed
+// *****************************************************************************
+{
+  const auto& cx = coord[0];
+  const auto& cy = coord[1];
+  const auto& cz = coord[2];
+
+  auto ncomp = U.nprop()/rdof;
+  auto nprim = P.nprop()/rdof;
+
+  std::vector< tk::real > state(ncomp+nprim);
+
+  Assert( ndof*ncomp == R.nprop(),
+          "Mismatch in viscous RHS polynomial and component sizes" );
+
+  std::vector< std::array< tk::real, 3 > >& visc_fl(0.0);
+
+  // compute volume integrals
+  for (std::size_t e=0; e<nelem; ++e)
+  {
+    auto ng = tk::NGvol(ndofel[e]);
+
+    // arrays for quadrature points
+    std::array< std::vector< real >, 3 > coordgp;
+    std::vector< real > wgp;
+
+    coordgp[0].resize( ng );
+    coordgp[1].resize( ng );
+    coordgp[2].resize( ng );
+    wgp.resize( ng );
+
+    GaussQuadratureTet( ng, coordgp, wgp );
+
+    // Extract the element coordinates
+    std::array< std::array< real, 3>, 4 > coordel {{
+      {{ cx[ inpoel[4*e  ] ], cy[ inpoel[4*e  ] ], cz[ inpoel[4*e  ] ] }},
+      {{ cx[ inpoel[4*e+1] ], cy[ inpoel[4*e+1] ], cz[ inpoel[4*e+1] ] }},
+      {{ cx[ inpoel[4*e+2] ], cy[ inpoel[4*e+2] ], cz[ inpoel[4*e+2] ] }},
+      {{ cx[ inpoel[4*e+3] ], cy[ inpoel[4*e+3] ], cz[ inpoel[4*e+3] ] }}
+    }};
+
+    auto jacInv =
+            inverseJacobian( coordel[0], coordel[1], coordel[2], coordel[3] );
+
+    auto dof_el = ndofel[e];
+
+    // Compute the derivatives of basis function for second order terms
+    std::array< std::vector<tk::real>, 3 > dBdx;
+    for (std::size_t i=0; i<3; ++i) dBdx[i].resize( dof_el, 0 );
+    eval_dBdx_p1( dof_el, jacInv, dBdx );
+
+    std::vector< tk::real > B(dof_el);
+
+    // Gaussian quadrature
+    for (std::size_t igp=0; igp<ng; ++igp)
+    {
+      if (dof_el > 4)
+        eval_dBdx_p2( igp, coordgp, jacInv, dBdx );
+
+      // Compute the coordinates of quadrature point at physical domain
+      auto gp = eval_gp( igp, coordel, coordgp );
+
+      // Compute the basis function
+      eval_basis( dof_el, coordgp[0][igp], coordgp[1][igp], coordgp[2][igp],
+        B );
+
+      auto wt = wgp[igp] * geoElem(e, 0);
+
+      // volume fluxes
+      if(dof_el > 1)
+      {
+        //evalPolynomialSol(mat_blk, intsharp, ncomp, nprim,
+          //rdof, nmat, e, ndofel[e], inpoel, coord, geoElem,
+          //{{coordgp[0][igp], coordgp[1][igp], coordgp[2][igp]}}, B, U, P, state);
+        state = viscousRhs.stateAt(mat_blk, U, P, e, dof_el, B );
+        // compute viscous flux
+        viscousRhs.volumeFlux( ncomp, mat_blk, state, visc_fl ); //currently no-op
+
+        update_rhs( ncomp, ndof, dof_el, wt, e, dBdx, visc_fl, R );
+      }
+    }
+  }
+}
 
 void
 tk::volInt( std::size_t nmat,
@@ -401,4 +520,43 @@ tk::srcIntFV( const std::vector< inciter::EOS >& mat_blk,
       R(e, c) += geoElem(e,0) * s[c];
     }
   }
+}
+
+void
+volIntViscousMultiSpecies(
+  std::size_t nspec,
+  const std::vector< inciter::EOS >& mat_blk,
+  const std::size_t ndof,
+  const std::size_t rdof,
+  const std::size_t nelem,
+  const std::vector< std::size_t >& inpoel,
+  const UnsMesh::Coords& coord,
+  const Fields& geoElem,
+  const Fields& U,
+  const Fields& P,
+  const std::vector< std::size_t >& ndofel,
+  Fields& R )
+// *****************************************************************************
+//  Compute internal surface viscous flux integrals for multispecies flow
+//! \param[in] nspec Number of species in this PDE system
+//! \param[in] mat_blk Material EOS block
+//! \param[in] ndof Maximum number of degrees of freedom
+//! \param[in] rdof Maximum number of reconstructed degrees of freedom
+//! \param[in] nelem Maximum number of elements
+//! \param[in] inpoel Element-node connectivity
+//! \param[in] coord Array of nodal coordinates
+//! \param[in] geoElem Element geometry array
+//! \param[in] U Solution vector at recent time step
+//! \param[in] P Vector of primitives at recent time step
+//! \param[in] ndofel Vector of local number of degrees of freedom
+//! \param[in,out] R Right-hand side vector computed
+// *****************************************************************************
+{
+  if (ndof == 4) {
+    MultiSpeciesViscousTermsDGP1 viscousRhs( nspec, rdof );
+    volIntViscous( viscousRhs, mat_blk, ndof, rdof, nelem,
+      inpoel, coord, geoElem, U, P, ndofel, R );
+  }
+  else
+    Throw( "Viscous operators only implemented for scheme = 'dgp1'." );
 }

--- a/src/PDE/Integrate/Volume.hpp
+++ b/src/PDE/Integrate/Volume.hpp
@@ -96,6 +96,22 @@ srcIntFV( const std::vector< inciter::EOS >& mat_blk,
           Fields& R,
           std::size_t nmat );
 
+//  Compute internal surface viscous flux integrals for multispecies flow
+void
+volIntViscousMultiSpecies(
+  std::size_t nspec,
+  const std::vector< inciter::EOS >& mat_blk,
+  const std::size_t ndof,
+  const std::size_t rdof,
+  const std::size_t nelem,
+  const std::vector< std::size_t >& inpoel,
+  const UnsMesh::Coords& coord,
+  const Fields& geoElem,
+  const Fields& U,
+  const Fields& P,
+  const std::vector< std::size_t >& ndofel,
+  Fields& R );
+
 } // tk::
 
 #endif // Volume_h

--- a/src/PDE/Integrate/Volume.hpp
+++ b/src/PDE/Integrate/Volume.hpp
@@ -25,6 +25,22 @@ namespace tk {
 
 using ncomp_t = tk::ncomp_t;
 
+template< class ViscousTerms >
+void
+volIntViscous(
+            const ViscousTerms& viscousRhs,
+            const std::vector< inciter::EOS >& mat_blk,
+            const std::size_t ndof,
+            const std::size_t rdof,
+            const std::size_t nelem,
+            const std::vector< std::size_t >& inpoel,
+            const UnsMesh::Coords& coord,
+            const Fields& geoElem,
+            const Fields& U,
+            const Fields& P,
+            const std::vector< std::size_t >& ndofel,
+            Fields& R);
+
 //! Compute volume integrals for DG
 void
 volInt( std::size_t nmat,

--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -1086,21 +1086,6 @@ class MultiSpecies {
       return fl;
     }
 
-    //! Evaluate conservative part of physical flux function for this PDE system
-    //! \param[in] ncomp Number of scalar components in this PDE system
-    //! \param[in] ugp Numerical solution at the Gauss point at which to
-    //!   evaluate the flux
-    //! \return Flux vectors for all components in this PDE system
-    //! \note The function signature must follow tk::FluxFn
-    static tk::FluxFn::result_type
-    viscflux( [[maybe_unused]] ncomp_t ncomp,
-          const std::vector< EOS >& mat_blk,
-          const std::vector< tk::real >& ugp,
-          const std::vector< std::array< tk::real, 3 > >& )
-    {
-      //no-op
-    }
-
     //! \brief Boundary state function providing the left and right state of a
     //!   face at Dirichlet boundaries
     //! \param[in] ncomp Number of scalar components in this PDE system

--- a/src/PDE/MultiSpecies/DGMultiSpecies.hpp
+++ b/src/PDE/MultiSpecies/DGMultiSpecies.hpp
@@ -738,6 +738,8 @@ class MultiSpecies {
       if (viscous) {
         tk::surfIntViscousMultiSpecies( nspec, m_mat_blk, ndof, rdof, inpoel,
           coord, fd, geoFace, geoElem, U, P, R );
+        tk::volIntViscousMultiSpecies( nspec, m_mat_blk, ndof, rdof, nelem, inpoel,
+          coord, geoElem, U, P, ndofel, R );
         for (const auto& b : m_bc)
           tk::bndSurfIntViscousMultiSpecies( nspec, m_mat_blk, ndof, rdof,
             std::get<0>(b), fd, geoFace, geoElem, inpoel, coord, t,
@@ -1082,6 +1084,21 @@ class MultiSpecies {
       }
 
       return fl;
+    }
+
+    //! Evaluate conservative part of physical flux function for this PDE system
+    //! \param[in] ncomp Number of scalar components in this PDE system
+    //! \param[in] ugp Numerical solution at the Gauss point at which to
+    //!   evaluate the flux
+    //! \return Flux vectors for all components in this PDE system
+    //! \note The function signature must follow tk::FluxFn
+    static tk::FluxFn::result_type
+    viscflux( [[maybe_unused]] ncomp_t ncomp,
+          const std::vector< EOS >& mat_blk,
+          const std::vector< tk::real >& ugp,
+          const std::vector< std::array< tk::real, 3 > >& )
+    {
+      //no-op
     }
 
     //! \brief Boundary state function providing the left and right state of a


### PR DESCRIPTION
This pull request contains quadrature loops for high-order DG viscous volume integrals. Currently the build is failing in Volume.cpp line 41 due to not being declared inside 'tk'. I declared the `volIntViscousMultiSpecies()` function in the .hpp header file, so I am not sure why this is failing. Also failing on line 533 due to `const UnsMesh::Coords&` not naming a type, even though all other functions in the same file using this declaration successfully build. Requesting review of these items specifically as they are blocking progress.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/715)
<!-- Reviewable:end -->
