### PR TITLE
Fixing bug in if statement logic

### DIFF
--- a/src/PDE/Integrate/Boundary.cpp
+++ b/src/PDE/Integrate/Boundary.cpp
@@ -1189,14 +1189,14 @@ bndSurfIntViscousMultiSpecies(
       coord, fd, geoFace, geoElem, U, P, t, state, gradFn, R );
   }
 
-  if (ndof == 4) {
+  else if (ndof == 4) {
     MultiSpeciesViscousTermsDGP1 viscousRhs( nspec, rdof );
     viscousBoundaryFaceIntDG( viscousRhs, mat_blk, ndof, bcconfig, inpoel,
       coord, fd, geoFace, geoElem, U, P, t, state, gradFn, R ); // no-op
   }
 
   else
-    Throw( "Viscous operators only implemented for scheme = 'p0p1'." );
+    Throw( "Viscous operators only implemented for scheme = 'p0p1' and 'dgp1'." );
 }
 
 } // tk::

--- a/src/PDE/Integrate/Surface.cpp
+++ b/src/PDE/Integrate/Surface.cpp
@@ -1270,14 +1270,14 @@ surfIntViscousMultiSpecies(
       geoFace, geoElem, U, P, R );
   }
 
-  if (ndof == 4) {
+  else if (ndof == 4) {
     MultiSpeciesViscousTermsDGP1 viscousRhs( nspec, rdof );
     viscousInternalFaceIntDG( viscousRhs, mat_blk, ndof, inpoel, coord, fd,
       geoFace, geoElem, U, P, R ); // No-op
   }
   
   else
-    Throw( "Viscous operators only implemented for scheme = 'p0p1'." );
+    Throw( "Viscous operators only implemented for scheme = 'p0p1' and 'dgp1'." );
 }
 
 std::vector< real >

--- a/src/PDE/Integrate/Volume.cpp
+++ b/src/PDE/Integrate/Volume.cpp
@@ -576,6 +576,9 @@ tk::volIntViscousMultiSpecies(
     volIntViscous( viscousRhs, mat_blk, ndof, rdof, nelem,
       inpoel, coord, geoElem, U, P, ndofel, R );
   }
+  else if (ndof ==1) {
+     //Do nothing but don't exit as nothing was here in DGMultiSpecies.cpp before adding this call for DGP1
+  }
   else
     Throw( "Viscous operators only implemented for scheme = 'dgp1'." );
 }


### PR DESCRIPTION
Fixed if statements so the else statement does not ignore P0P1 in Boundary/Surface.cpp.  Created a do nothing if statement in Volume.cpp to prevent exiting when running P0P1.

I looked at the history of DGMultiSpecies.cpp, and it looks like before this merge there was no volume integral call for P0P1?  If I don't have that right and Volume.cpp needs to call something, please let me know.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/725)
<!-- Reviewable:end -->
