### PR TITLE
Add operator-split plasticity time integration for DG

### DIFF
--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -318,6 +318,7 @@ using ConfigMembers = brigand::list<
   tag::imex_maxiter,     uint32_t,
   tag::imex_reltol,      tk::real,
   tag::imex_abstol,      tk::real,
+  tag::operator_split_plasticity, uint32_t,
 
   // NASA9 database location for MultiSpecies
   tag::nasa9_filepath, std::string,
@@ -584,6 +585,16 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
         R"(This keywords is used to specify the absolute tolerance that
         the non-linear solver uses to obtain the implicit unknowns within the
         Implicit-Explicit Runge-Kutta scheme.)", "real"});
+
+      keywords.insert({"operator_split_plasticity",
+        "Toggle use of operator-split plasticity around explicit SSP-RK3",
+        R"(This keyword turns on a Godunov (Lie) operator-split treatment of the
+        stiff plasticity source for solid materials in a multimat run, as a
+        non-SSP-free alternative to imex_runge_kutta. The explicit SSP-RK3 scheme
+        advances all equations over the full time step, then the plastic terms
+        are relaxed once per step by a per-element backward-Euler solve. The
+        non-linear solver reuses imex_maxiter/imex_reltol/imex_abstol. Mutually
+        exclusive with imex_runge_kutta and implicit_timestepping.)", "uint 0/1"});
 
       // -----------------------------------------------------------------------
       // MultiSpecies option to provide NASA9 DB filepath

--- a/src/Control/Inciter/InputDeck/InputDeck.hpp
+++ b/src/Control/Inciter/InputDeck/InputDeck.hpp
@@ -588,13 +588,14 @@ class InputDeck : public tk::TaggedTuple< ConfigMembers > {
 
       keywords.insert({"operator_split_plasticity",
         "Toggle use of operator-split plasticity around explicit SSP-RK3",
-        R"(This keyword turns on a Godunov (Lie) operator-split treatment of the
-        stiff plasticity source for solid materials in a multimat run, as a
-        non-SSP-free alternative to imex_runge_kutta. The explicit SSP-RK3 scheme
+        R"(This keyword toggles a Lie operator-split treatment of the
+        stiff plasticity source for solid materials in multimat, as an SSP
+        alternative to imex_runge_kutta. The explicit SSP-RK3 scheme
         advances all equations over the full time step, then the plastic terms
         are relaxed once per step by a per-element backward-Euler solve. The
         non-linear solver reuses imex_maxiter/imex_reltol/imex_abstol. Mutually
-        exclusive with imex_runge_kutta and implicit_timestepping.)", "uint 0/1"});
+        exclusive with imex_runge_kutta and implicit_timestepping.)",
+        "uint 0/1"});
 
       // -----------------------------------------------------------------------
       // MultiSpecies option to provide NASA9 DB filepath

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -155,6 +155,18 @@ LuaParser::storeInputDeck(
     lua_ideck, "imex_reltol", gideck.get< tag::imex_reltol >(), 1.0e-02);
   storeIfSpecd< tk::real >(
     lua_ideck, "imex_abstol", gideck.get< tag::imex_abstol >(), 1.0e-04);
+  storeIfSpecd< uint32_t >(
+    lua_ideck, "operator_split_plasticity",
+    gideck.get< tag::operator_split_plasticity >(), 0);
+
+  // Operator-split plasticity wraps SSP-RK3 and owns the stiff plasticity eqs by
+  // itself; it cannot coexist with the fully-coupled IMEX or the BDF1 solvers.
+  if (gideck.get< tag::operator_split_plasticity >() &&
+      (gideck.get< tag::imex_runge_kutta >() ||
+       gideck.get< tag::implicit_timestepping >()))
+    Throw("operator_split_plasticity is mutually exclusive with "
+      "imex_runge_kutta and implicit_timestepping. Enable only one time "
+      "integration scheme for the stiff plasticity terms.");
 
   if (gideck.get< tag::dt >() < 1e-12 && gideck.get< tag::cfl >() < 1e-12)
     Throw("No time step calculation policy has been selected in the "

--- a/src/Control/Inciter/InputDeck/LuaParser.cpp
+++ b/src/Control/Inciter/InputDeck/LuaParser.cpp
@@ -159,8 +159,7 @@ LuaParser::storeInputDeck(
     lua_ideck, "operator_split_plasticity",
     gideck.get< tag::operator_split_plasticity >(), 0);
 
-  // Operator-split plasticity wraps SSP-RK3 and owns the stiff plasticity eqs by
-  // itself; it cannot coexist with the fully-coupled IMEX or the BDF1 solvers.
+  // Operator-split plasticity cannot coexist with unsplit IMEX or BDF1
   if (gideck.get< tag::operator_split_plasticity >() &&
       (gideck.get< tag::imex_runge_kutta >() ||
        gideck.get< tag::implicit_timestepping >()))

--- a/src/Control/Tags.hpp
+++ b/src/Control/Tags.hpp
@@ -165,6 +165,7 @@ DEFTAG(imex_runge_kutta);
 DEFTAG(imex_maxiter);
 DEFTAG(imex_reltol);
 DEFTAG(imex_abstol);
+DEFTAG(operator_split_plasticity);
 
 DEFTAG(nasa9_filepath);
 

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -336,6 +336,13 @@ DG::setup()
     d->histheader( std::move(histnames) );
   }
 
+  // Select the stiff-equation residual mode for the run. The schemes are
+  // mutually exclusive (enforced by the parser), so this is set once here.
+  if (g_inputdeck.get< tag::operator_split_plasticity >())
+    m_stiffSolverMode = StiffSolverMode::OperatorSplit;
+  else
+    m_stiffSolverMode = StiffSolverMode::IMEX;
+
   // If working with IMEX-RK or operator-split plasticity, store stiff equations
   // into m_stiffEqIdx (both schemes integrate the same stiff plasticity eqs)
   if (g_inputdeck.get< tag::imex_runge_kutta >() ||
@@ -1617,11 +1624,9 @@ DG::solve( tk::real newdt )
       }
     }
 
-  // Operator-split plasticity: after the explicit SSP-RK3 step has fully updated
-  // m_u (including the hyperbolically-advected deformation-gradient equations),
-  // relax the stiff plasticity source once per time step on the final RK stage.
-  // Runs on the post-RK m_u and before updatePrimitives so primitives and the
-  // trace-material cleanup below see the relaxed conserved state.
+  // Operator-split plasticity: after the explicit SSP-RK3 step has updated
+  // m_u using the hyperbolic operator, relax the stiff plasticity source at
+  // the final RK stage.
   if (op_split_plasticity && m_stage == m_nstage-1)
     DG::plasticity_split_integrate();
 
@@ -2493,14 +2498,13 @@ DG::imex_integrate()
 void
 DG::plasticity_split_integrate()
 // *****************************************************************************
-//  Perform the operator-split plasticity relaxation substep
-//! \details Godunov (Lie) operator split: the explicit SSP-RK3 step has already
-//!   advanced every equation over the full time step (including the
-//!   hyperbolically-advected inverse deformation-gradient equations). This
-//!   routine then relaxes the stiff plasticity source once, per element, by a
-//!   backward-Euler solve about the post-RK state, and balances the elastic
-//!   energy change. The plasticity source (DGMultiMat::stiff_rhs) is a purely
-//!   local relaxation ODE, so this substep requires no communication.
+// Perform the operator-split plasticity relaxation substep
+//! \details Lie operator split: the explicit SSP-RK3 step has already
+//!   advanced every equation over the full time step using the hyperbolic
+//!   operators. This routine relaxes the stiff plasticity source, locally per
+//!   element, by a backward-Euler solve about the post-RK state (after RK's
+//!   final stage in this time-step). Then, it balances the elastic energy
+//!   change.
 // *****************************************************************************
 {
   auto d = Disc();
@@ -2510,15 +2514,15 @@ DG::plasticity_split_integrate()
 
   // The split residual carries no tableau history; clear the stiff RHS register.
   m_stiffrhs.fill(0.0);
-  // Switch nonlinear_func() to the backward-Euler split residual.
-  m_stiffMode = StiffMode::OperatorSplit;
 
   for (std::size_t e=0; e<nelem; ++e)
   {
-    // Gather the post-RK stiff DOFs of this element as the relaxation state.
+    // Gather the stiff DOFs of this element as the relaxation state.
+    // m_numEqDof is indexed by global equation index, so the DOF count of a
+    // stiff equation is m_numEqDof[m_stiffEqIdx[ieq]] (not m_numEqDof[ieq]).
     std::vector< tk::real > x(m_nstiffeq*ndof, 0.0);
     for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
-      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      for (std::size_t idof=0; idof<m_numEqDof[m_stiffEqIdx[ieq]]; ++idof)
       {
         auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
         x[ieq*ndof+idof] = m_u(e, stiffrmark);
@@ -2530,7 +2534,7 @@ DG::plasticity_split_integrate()
     auto x_star = x;
 
     // Solve the local nonlinear system, first try Broyden then fall back to
-    // Newton, reusing the IMEX nonlinear solvers (m_stiffMode selects the
+    // Newton, reusing the IMEX nonlinear solvers (m_stiffSolverMode selects the
     // residual assembled in nonlinear_func()).
     bool solver_failed = false;
     x = DG::nonlinear_broyden(e, x, solver_failed);
@@ -2550,15 +2554,12 @@ DG::plasticity_split_integrate()
 
     // Update the state with the converged relaxed stiff DOFs.
     for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
-      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      for (std::size_t idof=0; idof<m_numEqDof[m_stiffEqIdx[ieq]]; ++idof)
       {
         auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
         m_u(e, stiffrmark) = x[ieq*ndof+idof];
       }
   }
-
-  // Restore the default residual mode.
-  m_stiffMode = StiffMode::IMEX;
 }
 
 void
@@ -2604,12 +2605,12 @@ std::vector< tk::real > DG::nonlinear_func(std::size_t e,
   // Operator-split plasticity: pure backward-Euler relaxation of the stiff
   // source about the post-RK state g_afterRK (m_gStar), with no IMEX tableau
   // history. Residual: F_i = x_i - g_afterRK_i - dt*stiff_rhs_i(x)/mm_i.
-  if (m_stiffMode == StiffMode::OperatorSplit) {
+  if (m_stiffSolverMode == StiffSolverMode::OperatorSplit) {
     g_dgpde[d->MeshId()].stiff_rhs( e, myGhosts()->m_geoElem,
       m_u, m_ndof, m_stiffrhs );
     std::vector< tk::real > f(n, 0.0);
     for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
-      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      for (std::size_t idof=0; idof<m_numEqDof[m_stiffEqIdx[ieq]]; ++idof)
       {
         auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
         auto mm_i = vole * mass_dubiner[idof];

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -336,8 +336,10 @@ DG::setup()
     d->histheader( std::move(histnames) );
   }
 
-  // If working with IMEX-RK, Store stiff equations into m_stiffEqIdx
-  if (g_inputdeck.get< tag::imex_runge_kutta >())
+  // If working with IMEX-RK or operator-split plasticity, store stiff equations
+  // into m_stiffEqIdx (both schemes integrate the same stiff plasticity eqs)
+  if (g_inputdeck.get< tag::imex_runge_kutta >() ||
+      g_inputdeck.get< tag::operator_split_plasticity >())
   {
     g_dgpde[Disc()->MeshId()].setStiffEqIdx(m_stiffEqIdx);
     g_dgpde[Disc()->MeshId()].setNonStiffEqIdx(m_nonStiffEqIdx);
@@ -1495,6 +1497,9 @@ DG::solve( tk::real newdt )
   // Explicit or IMEX
   const auto imex_runge_kutta = g_inputdeck.get< tag::imex_runge_kutta >();
   const auto implicit_ts = g_inputdeck.get< tag::implicit_timestepping >();
+  // Operator-split plasticity wraps a relaxation substep around explicit SSP-RK3
+  const auto op_split_plasticity =
+    g_inputdeck.get< tag::operator_split_plasticity >();
 
   // Physical time at time-stage for computing exact source terms.
   // The stage time must match the abscissae of the tableau actually in use:
@@ -1611,6 +1616,14 @@ DG::solve( tk::real newdt )
         }
       }
     }
+
+  // Operator-split plasticity: after the explicit SSP-RK3 step has fully updated
+  // m_u (including the hyperbolically-advected deformation-gradient equations),
+  // relax the stiff plasticity source once per time step on the final RK stage.
+  // Runs on the post-RK m_u and before updatePrimitives so primitives and the
+  // trace-material cleanup below see the relaxed conserved state.
+  if (op_split_plasticity && m_stage == m_nstage-1)
+    DG::plasticity_split_integrate();
 
   // Update primitives based on the evolved solution
   g_dgpde[d->MeshId()].updateInterfaceCells( m_u,
@@ -2478,6 +2491,77 @@ DG::imex_integrate()
 }
 
 void
+DG::plasticity_split_integrate()
+// *****************************************************************************
+//  Perform the operator-split plasticity relaxation substep
+//! \details Godunov (Lie) operator split: the explicit SSP-RK3 step has already
+//!   advanced every equation over the full time step (including the
+//!   hyperbolically-advected inverse deformation-gradient equations). This
+//!   routine then relaxes the stiff plasticity source once, per element, by a
+//!   backward-Euler solve about the post-RK state, and balances the elastic
+//!   energy change. The plasticity source (DGMultiMat::stiff_rhs) is a purely
+//!   local relaxation ODE, so this substep requires no communication.
+// *****************************************************************************
+{
+  auto d = Disc();
+  const auto rdof = g_inputdeck.get< tag::rdof >();
+  const auto ndof = g_inputdeck.get< tag::ndof >();
+  const auto nelem = myGhosts()->m_fd.Esuel().size()/4;
+
+  // The split residual carries no tableau history; clear the stiff RHS register.
+  m_stiffrhs.fill(0.0);
+  // Switch nonlinear_func() to the backward-Euler split residual.
+  m_stiffMode = StiffMode::OperatorSplit;
+
+  for (std::size_t e=0; e<nelem; ++e)
+  {
+    // Gather the post-RK stiff DOFs of this element as the relaxation state.
+    std::vector< tk::real > x(m_nstiffeq*ndof, 0.0);
+    for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
+      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      {
+        auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
+        x[ieq*ndof+idof] = m_u(e, stiffrmark);
+      }
+
+    // g_afterRK (constant term of the backward-Euler residual) and the
+    // pre-relaxation state used to balance the plastic (elastic) energy.
+    m_gStar = x;
+    auto x_star = x;
+
+    // Solve the local nonlinear system, first try Broyden then fall back to
+    // Newton, reusing the IMEX nonlinear solvers (m_stiffMode selects the
+    // residual assembled in nonlinear_func()).
+    bool solver_failed = false;
+    x = DG::nonlinear_broyden(e, x, solver_failed);
+    if (solver_failed) {
+      solver_failed = false;
+      x = DG::nonlinear_newton(e, x, solver_failed);
+    }
+    if (solver_failed)
+      Throw("At element " + std::to_string(e) +
+            " operator-split plasticity nonlinear solver did not converge");
+
+    // Balance the elastic-energy change from the relaxation into total energy.
+    // Unlike IMEX (which defers the stiff combination to the final stage and
+    // deposits into m_un), the split writes the converged solution directly, so
+    // the correction goes into the live m_u.
+    g_dgpde[d->MeshId()].balance_plastic_energy(e, x_star, x, m_u);
+
+    // Update the state with the converged relaxed stiff DOFs.
+    for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
+      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      {
+        auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
+        m_u(e, stiffrmark) = x[ieq*ndof+idof];
+      }
+  }
+
+  // Restore the default residual mode.
+  m_stiffMode = StiffMode::IMEX;
+}
+
+void
 DG::BDF1_integrate()
 // *****************************************************************************
 //  Perform the BDF1 update
@@ -2516,6 +2600,25 @@ std::vector< tk::real > DG::nonlinear_func(std::size_t e,
 
   auto vole = myGhosts()->m_geoElem(e,0);
   auto vole_n = m_geoElemn(e,0);
+
+  // Operator-split plasticity: pure backward-Euler relaxation of the stiff
+  // source about the post-RK state g_afterRK (m_gStar), with no IMEX tableau
+  // history. Residual: F_i = x_i - g_afterRK_i - dt*stiff_rhs_i(x)/mm_i.
+  if (m_stiffMode == StiffMode::OperatorSplit) {
+    g_dgpde[d->MeshId()].stiff_rhs( e, myGhosts()->m_geoElem,
+      m_u, m_ndof, m_stiffrhs );
+    std::vector< tk::real > f(n, 0.0);
+    for (std::size_t ieq=0; ieq<m_nstiffeq; ++ieq)
+      for (std::size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+      {
+        auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
+        auto mm_i = vole * mass_dubiner[idof];
+        f[ieq*ndof+idof] = m_u(e, stiffrmark)
+          - m_gStar[ieq*ndof+idof]
+          - d->Dt() * m_stiffrhs(e,ieq*ndof+idof) / mm_i;
+      }
+    return f;
+  }
 
   // Compute explicit terms (Should be computed once)
   std::vector< tk::real > expl_terms(n, 0.0);

--- a/src/Inciter/DG.cpp
+++ b/src/Inciter/DG.cpp
@@ -2592,8 +2592,10 @@ std::vector< tk::real > DG::nonlinear_func(std::size_t e,
   std::size_t n = x.size();
 
   // m_u <- x
+  // m_numEqDof is indexed by global equation index, so the DOF count of a
+  // stiff equation is m_numEqDof[m_stiffEqIdx[ieq]] (not m_numEqDof[ieq]).
   for (size_t ieq=0; ieq<m_nstiffeq; ++ieq)
-    for (size_t idof=0; idof<m_numEqDof[ieq]; ++idof)
+    for (size_t idof=0; idof<m_numEqDof[m_stiffEqIdx[ieq]]; ++idof)
     {
       auto stiffrmark = m_stiffEqIdx[ieq]*rdof+idof;
       m_u(e, stiffrmark) = x[ieq*ndof+idof];

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -255,7 +255,6 @@ class DG : public CBase_DG {
       p | m_diag;
       p | m_nstage;
       p | m_stage;
-      //PUP::pup_bytes( &p, &m_stiffSolverMode, sizeof(m_stiffSolverMode) );
       p | m_stiffSolverMode;
       p | m_ndof;
       p | m_interface;

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -255,6 +255,7 @@ class DG : public CBase_DG {
       p | m_diag;
       p | m_nstage;
       p | m_stage;
+      PUP::pup_bytes( &p, &m_stiffMode, sizeof(m_stiffMode) );
       p | m_ndof;
       p | m_interface;
       p | m_numEqDof;
@@ -336,6 +337,16 @@ class DG : public CBase_DG {
     tk::Fields m_stiffrhsprev;
     //! Vectors that indicates which equations are stiff and non-stiff
     std::vector< std::size_t > m_stiffEqIdx, m_nonStiffEqIdx;
+    //! \brief Which stiff-equation residual nonlinear_func() should assemble.
+    //!   IMEX: the fully-coupled Cavaglieri-Bewley residual; OperatorSplit: the
+    //!   pure backward-Euler relaxation residual used by the operator-split
+    //!   plasticity substep.
+    enum class StiffMode { IMEX=0, OperatorSplit=1 };
+    StiffMode m_stiffMode = StiffMode::IMEX;
+    //! \brief Post-RK stiff DOFs of the element currently being relaxed, used as
+    //!   the constant term in the operator-split backward-Euler residual. Transient
+    //!   per-element scratch (not PUPed).
+    std::vector< tk::real > m_gStar;
     //! Inverse of Taylor mass-matrix
     std::vector< std::vector< tk::real > > m_mtInv;
     //! Counter for number of nodes on this chare excluding ghosts
@@ -483,6 +494,9 @@ class DG : public CBase_DG {
 
     //! Perform the Implicit-Explicit Runge-Kutta stage update
     void imex_integrate();
+
+    //! Perform the operator-split plasticity relaxation substep (post SSP-RK3)
+    void plasticity_split_integrate();
 
     //! Perform the BDF1 update
     void BDF1_integrate();

--- a/src/Inciter/DG.hpp
+++ b/src/Inciter/DG.hpp
@@ -255,7 +255,8 @@ class DG : public CBase_DG {
       p | m_diag;
       p | m_nstage;
       p | m_stage;
-      PUP::pup_bytes( &p, &m_stiffMode, sizeof(m_stiffMode) );
+      //PUP::pup_bytes( &p, &m_stiffSolverMode, sizeof(m_stiffSolverMode) );
+      p | m_stiffSolverMode;
       p | m_ndof;
       p | m_interface;
       p | m_numEqDof;
@@ -337,12 +338,9 @@ class DG : public CBase_DG {
     tk::Fields m_stiffrhsprev;
     //! Vectors that indicates which equations are stiff and non-stiff
     std::vector< std::size_t > m_stiffEqIdx, m_nonStiffEqIdx;
-    //! \brief Which stiff-equation residual nonlinear_func() should assemble.
-    //!   IMEX: the fully-coupled Cavaglieri-Bewley residual; OperatorSplit: the
-    //!   pure backward-Euler relaxation residual used by the operator-split
-    //!   plasticity substep.
-    enum class StiffMode { IMEX=0, OperatorSplit=1 };
-    StiffMode m_stiffMode = StiffMode::IMEX;
+    //! Which stiff-equation residual nonlinear_func() should assemble.
+    enum class StiffSolverMode { IMEX=0, OperatorSplit=1 };
+    StiffSolverMode m_stiffSolverMode = StiffSolverMode::IMEX;
     //! \brief Post-RK stiff DOFs of the element currently being relaxed, used as
     //!   the constant term in the operator-split backward-Euler residual. Transient
     //!   per-element scratch (not PUPed).
@@ -495,7 +493,7 @@ class DG : public CBase_DG {
     //! Perform the Implicit-Explicit Runge-Kutta stage update
     void imex_integrate();
 
-    //! Perform the operator-split plasticity relaxation substep (post SSP-RK3)
+    //! Perform the operator-split plasticity relaxation substep
     void plasticity_split_integrate();
 
     //! Perform the BDF1 update


### PR DESCRIPTION
Adds a Lie (Godunov) operator-split treatment of the stiff plasticity source (DGMultiMat::stiff_rhs) as an SSP alternative to the IMEX scheme. Explicit SSP-RK3 advances all equations over the full time step, then the plastic terms are relaxed once per step by a per-element backward-Euler solve on the final RK stage.

- New DG::plasticity_split_integrate() runs the per-element relaxation, reusing nonlinear_broyden/nonlinear_newton via a new m_stiffMode flag that switches nonlinear_func()'s residual to backward-Euler (F = x - g_afterRK - dt*stiff_rhs(x)/mm_i).
- Reuses balance_plastic_energy with the pre/post-relaxation states.
- New input-deck flag operator_split_plasticity (uint 0/1), mutually exclusive with imex_runge_kutta and implicit_timestepping; reuses imex_maxiter/reltol/abstol for the substep solver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/quinoacomputing/quinoa/733)
<!-- Reviewable:end -->
